### PR TITLE
ENH: initial visualization support

### DIFF
--- a/qiime/core/archiver.py
+++ b/qiime/core/archiver.py
@@ -1,0 +1,259 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import datetime
+import io
+import os
+import tempfile
+import time
+import uuid
+import yaml
+import zipfile
+
+import qiime.sdk
+
+
+# TODO use utf-8 encoding when reading/writing files
+class Archiver:
+    # This class will likely defer to one of many ArchiveFormats in the future.
+    # There's only one supported archive format currently.
+    _version = '0.1.0'
+    _version_path = 'VERSION'
+    _readme_path = 'README.md'
+    _metadata_path = 'metadata.yaml'
+    _data_dir = 'data'
+
+    @classmethod
+    def load(cls, filepath):
+        if not zipfile.is_zipfile(filepath):
+            raise zipfile.BadZipFile(
+                "%r is not a readable ZIP file, or the file does not exist" %
+                filepath)
+
+        root_dir = cls._get_root_dir(filepath)
+        with zipfile.ZipFile(filepath, mode='r') as zf:
+            version = cls._load_version(zf, root_dir)
+            if version != cls._version:
+                raise ValueError(
+                    "Unsupported archive format version %r. "
+                    "Supported version(s): %r" % (version, cls._version))
+
+            uuid_, type_, provenance = cls._load_metadata(zf, root_dir)
+
+        return cls(uuid_, type_, provenance, archive_filepath=filepath)
+
+    @classmethod
+    def _get_root_dir(cls, filepath):
+        return os.path.splitext(os.path.basename(filepath))[0]
+
+    @classmethod
+    def _create_temp_dir(cls):
+        return tempfile.TemporaryDirectory(prefix='qiime2-archive-temp-data-')
+
+    @classmethod
+    def _load_version(cls, zf, root_dir):
+        with zf.open(os.path.join(root_dir, cls._version_path)) as bytes_fh:
+            with io.TextIOWrapper(bytes_fh, newline=None,
+                                  encoding='utf-8') as fh:
+                return fh.read().rstrip('\n')
+
+    @classmethod
+    def _load_metadata(cls, zf, root_dir):
+        with zf.open(os.path.join(root_dir, cls._metadata_path)) as bytes_fh:
+            with io.TextIOWrapper(bytes_fh, newline=None,
+                                  encoding='utf-8') as fh:
+                metadata = yaml.safe_load(fh)
+
+        uuid_ = cls._parse_uuid(metadata['UUID'])
+        type_ = cls._parse_type(metadata['type'])
+        provenance = cls._parse_provenance(metadata['provenance'])
+        return uuid_, type_, provenance
+
+    @classmethod
+    def _parse_uuid(cls, string):
+        return uuid.UUID(hex=string)
+
+    @classmethod
+    def _parse_type(cls, type_exp):
+        # TODO this is mostly duplicated from Workflow._parse_semantic_type.
+        type_exp = type_exp.split('\n')
+        if len(type_exp) != 1:
+            raise TypeError(
+                "Found multiple lines in archive type expression. Will not "
+                "evaluate to avoid arbitrary code execution.")
+        type_exp, = type_exp
+
+        if ';' in type_exp:
+            raise TypeError(
+                "Invalid archive type expression. Will not evaluate to avoid "
+                "arbitrary code execution.")
+
+        pm = qiime.sdk.PluginManager()
+        locals_ = {k: v[1] for k, v in pm.semantic_types.items()}
+        locals_[qiime.core.type.Visualization.name] = \
+            qiime.core.type.Visualization
+
+        # TODO better error handling for un-eval-able type expressions
+        return eval(type_exp, {'__builtins__': {}}, locals_)
+
+    # TODO implement provenance parsing for real
+    @classmethod
+    def _parse_provenance(cls, provenance):
+        if isinstance(provenance, str):
+            return None
+        else:
+            return qiime.sdk.Provenance(
+                job_uuid=provenance['job-UUID'],
+                artifact_uuids=provenance['artifact-uuids'],
+                parameters=provenance['parameters'],
+                workflow_reference=provenance['workflow-reference']
+            )
+
+    def __init__(self, uuid_, type_, provenance, archive_filepath=None):
+        self._uuid = uuid_
+
+        if isinstance(type_, str):
+            type_ = self._parse_type(type_)
+        self._type = type_
+
+        self._provenance = provenance
+        self._archive_filepath = archive_filepath
+        self._temp_dir = None
+
+    def __del__(self):
+        if self._temp_dir is not None:
+            self._temp_dir.cleanup()
+
+    @property
+    def uuid(self):
+        return self._uuid
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def provenance(self):
+        return self._provenance
+
+    def load_data(self, loader):
+        if self._temp_dir is None:
+            self._extract_data()
+
+        return loader(self._temp_dir.name)
+
+    def _extract_data(self):
+        assert self._temp_dir is None and self._archive_filepath is not None
+
+        self._temp_dir = self._create_temp_dir()
+        temp_dir = self._temp_dir.name
+
+        # TODO is there a better way to extract the files in an archive
+        # subdirectory into a directory without keeping the nested archive
+        # directory structure?
+        with zipfile.ZipFile(self._archive_filepath, mode='r') as zf:
+            root_dir = self._get_root_dir(self._archive_filepath)
+            prefix = os.path.join(root_dir, self._data_dir, '')
+
+            for file_ in zf.namelist():
+                if file_.startswith(prefix):
+                    extract_path = zf.extract(file_, path=temp_dir)
+                    os.rename(extract_path,
+                              os.path.join(temp_dir, os.path.basename(file_)))
+            os.rmdir(os.path.join(temp_dir, prefix))
+
+    def save_data(self, data, saver):
+        assert self._temp_dir is None and self._archive_filepath is None
+
+        self._temp_dir = self._create_temp_dir()
+        saver(data, self._temp_dir.name)
+
+    def save(self, filepath):
+        root_dir = self._get_root_dir(filepath)
+
+        if self._temp_dir is None:
+            self._extract_data()
+
+        with zipfile.ZipFile(filepath, mode='w',
+                             compression=zipfile.ZIP_DEFLATED,
+                             allowZip64=True) as zf:
+            self._save_version(zf, root_dir)
+            self._save_readme(zf, root_dir)
+            self._save_metadata(zf, root_dir)
+
+            for root, dirs, files in os.walk(self._temp_dir.name):
+                for file_ in files:
+                    temp_path = os.path.join(root, file_)
+                    archive_path = os.path.join(
+                        root_dir,
+                        self._data_dir,
+                        root.replace(self._temp_dir.name, '', 1),
+                        file_
+                    )
+                    zf.write(temp_path, arcname=archive_path)
+
+    def _save_version(self, zf, root_dir):
+        zf.writestr(os.path.join(root_dir, self._version_path),
+                    '%s\n' % self._version)
+
+    def _save_readme(self, zf, root_dir):
+        zf.writestr(os.path.join(root_dir, self._readme_path),
+                    _README_TEXT)
+
+    # TODO clean up metadata yaml formatting. It currently dumps Python
+    # objects, `yaml.safe_dump` call needs to be updated to format lists and
+    # dicts as typical yaml.
+    def _save_metadata(self, zf, root_dir):
+        metadata_bytes = yaml.safe_dump({
+            'UUID': self._formatted_uuid(),
+            'type': repr(self.type),
+            'provenance': self._formatted_provenance()
+        })
+        zf.writestr(os.path.join(root_dir, self._metadata_path),
+                    metadata_bytes)
+
+    def _formatted_uuid(self):
+        return str(self.uuid)
+
+    def _formatted_provenance(self):
+        if self.provenance is None:
+            return ('No provenance available because this archive was '
+                    'generated independently of QIIME.')
+        else:
+            return {
+                'job-UUID': str(self.provenance.job_uuid),
+                'artifact-uuids': self.provenance.artifact_uuids,
+                # TODO: need to store parameter types (or is it enough
+                # that the workflow template reference could get us that?)
+                'parameters': self.provenance.parameters,
+                'runtime': self._formatted_runtime(),
+                'workflow-reference': self.provenance.workflow_reference
+            }
+
+    def _formatted_runtime(self):
+        stop_time = time.time()
+        run_time = stop_time - self.provenance.start_time
+        datetime_start = datetime.datetime.fromtimestamp(
+            self.provenance.start_time)
+        datetime_stop = datetime.datetime.fromtimestamp(stop_time)
+        return {
+            'run-time-seconds': run_time,
+            'execution-start-time': datetime_start.isoformat(),
+            'execution-stop-time': datetime_stop.isoformat()
+        }
+
+
+_README_TEXT = """# QIIME 2 archive
+
+This archive stores the data and associated metadata of a serialized QIIME 2
+artifact or visualization.
+
+**WARNING:** This is a temporary file format used for prototyping QIIME 2. Do
+not rely on this format for any reason as it will not be supported past the
+prototyping stage in its current form.
+"""

--- a/qiime/core/result_base.py
+++ b/qiime/core/result_base.py
@@ -1,0 +1,53 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import abc
+
+import qiime.core.archiver
+
+
+class ResultBase(metaclass=abc.ABCMeta):
+    """ABC for QIIME 2 result/output classes."""
+
+    @classmethod
+    @abc.abstractmethod
+    def _assert_valid_type(cls, type_):
+        raise NotImplementedError
+
+    @classmethod
+    def load(cls, filepath):
+        result = cls.__new__(cls)
+        result._archiver = qiime.core.archiver.Archiver.load(filepath)
+        result._assert_valid_type(result.type)
+        return result
+
+    @property
+    def type(self):
+        return self._archiver.type
+
+    @property
+    def provenance(self):
+        return self._archiver.provenance
+
+    @property
+    def uuid(self):
+        return self._archiver.uuid
+
+    def __init__(self):
+        class_name = self.__class__.__name__
+        raise NotImplementedError(
+            "%s constructor is private, use `%s.load`." %
+            (class_name, class_name))
+
+    def __new__(cls):
+        result = object.__new__(cls)
+        result._archiver = None
+        return result
+
+    def save(self, filepath):
+        self._archiver.save(filepath)

--- a/qiime/core/testing.py
+++ b/qiime/core/testing.py
@@ -26,10 +26,10 @@ def validator(data_dir):
     raise NotImplementedError()
 
 
-plugin.register_archive_format('example-archive-format', 1, validator)
+plugin.register_data_layout('example-data-layout', 1, validator)
 
 
-def example_archive_format_to_list(data_dir):
+def example_data_layout_to_list(data_dir):
     with open(os.path.join(data_dir, 'data.txt'), 'r') as fh:
         model = []
         for line in fh:
@@ -37,24 +37,24 @@ def example_archive_format_to_list(data_dir):
         return model
 
 
-plugin.register_archive_format_reader('example-archive-format', 1, list,
-                                      example_archive_format_to_list)
+plugin.register_data_layout_reader('example-data-layout', 1, list,
+                                   example_data_layout_to_list)
 
 
-def list_to_example_archive_format(view, data_dir):
+def list_to_example_data_layout(view, data_dir):
     with open(os.path.join(data_dir, 'data.txt'), 'w') as fh:
         for num in view:
             fh.write('%d\n' % num)
 
 
-plugin.register_archive_format_writer('example-archive-format', 1, list,
-                                      list_to_example_archive_format)
+plugin.register_data_layout_writer('example-data-layout', 1, list,
+                                   list_to_example_data_layout)
 
 TestType = qiime.plugin.SemanticType('TestType')
 
 plugin.register_semantic_type(TestType)
 
-plugin.register_type_to_archive_format(TestType, 'example-archive-format', 1)
+plugin.register_type_to_data_layout(TestType, 'example-data-layout', 1)
 
 
 def visualizer1(ints: list, output_dir: str) -> None:

--- a/qiime/core/testing.py
+++ b/qiime/core/testing.py
@@ -10,6 +10,7 @@ import os.path
 
 import qiime
 import qiime.plugin
+import qiime.core.type
 
 # TODO centralize "dummy" functions and workflows that are currently duplicated
 # across unit tests.
@@ -54,3 +55,19 @@ TestType = qiime.plugin.SemanticType('TestType')
 plugin.register_semantic_type(TestType)
 
 plugin.register_type_to_archive_format(TestType, 'example-archive-format', 1)
+
+
+def visualizer1(ints: list, output_dir: str) -> None:
+    with open(os.path.join(output_dir, 'index.html'), 'w') as fh:
+        fh.write('<html><body>\n')
+        for i in ints:
+            fh.write('%d<br>\n' % i)
+        fh.write('</body></html>')
+
+plugin.register_visualization(
+    function=visualizer1,
+    inputs={'ints': TestType},
+    parameters={'output_dir': qiime.core.type.Str},
+    name='Visualizer #1',
+    doc="Let's write some integers to an html file!"
+)

--- a/qiime/core/testing.py
+++ b/qiime/core/testing.py
@@ -57,7 +57,7 @@ plugin.register_semantic_type(TestType)
 plugin.register_type_to_data_layout(TestType, 'example-data-layout', 1)
 
 
-def visualizer1(ints: list, output_dir: str) -> None:
+def visualizer1(output_dir: str, ints: list) -> None:
     with open(os.path.join(output_dir, 'index.html'), 'w') as fh:
         fh.write('<html><body>\n')
         for i in ints:
@@ -67,7 +67,7 @@ def visualizer1(ints: list, output_dir: str) -> None:
 plugin.register_visualization(
     function=visualizer1,
     inputs={'ints': TestType},
-    parameters={'output_dir': qiime.core.type.Str},
+    parameters={},
     name='Visualizer #1',
     doc="Let's write some integers to an html file!"
 )

--- a/qiime/plugin.py
+++ b/qiime/plugin.py
@@ -11,7 +11,8 @@ import pkg_resources
 
 import qiime.sdk
 import qiime.core.type.grammar as grammar
-from qiime.core.type import SemanticType, is_semantic_type, Int, Str, Float
+from qiime.core.type import (SemanticType, is_semantic_type, Int, Str, Float,
+                             Visualization)
 
 __all__ = ['load', 'Plugin', 'Int', 'Str', 'Float', 'SemanticType']
 
@@ -58,6 +59,7 @@ class Plugin:
         self.version = version
         self.website = website
         self.workflows = {}
+        self.visualizations = {}
         self.archive_formats = {}
         self.types = {}
         self.type_to_archive_formats = {}
@@ -77,6 +79,13 @@ class Plugin:
         w = qiime.sdk.Workflow.from_function(function, inputs, parameters,
                                              outputs, name, doc)
         self.workflows[w.id] = w
+
+    def register_visualization(self, name, function, inputs, parameters,
+                               doc=""):
+        outputs = collections.OrderedDict([('visualization', Visualization)])
+        v = qiime.sdk.Workflow.from_function(function, inputs, parameters,
+                                             outputs, name, doc)
+        self.visualizations[v.id] = v
 
     def register_archive_format_reader(self, name, version, view_type,
                                        reader):

--- a/qiime/sdk/__init__.py
+++ b/qiime/sdk/__init__.py
@@ -7,10 +7,11 @@
 # ----------------------------------------------------------------------------
 
 from .artifact import Artifact
+from .visualization import Visualization
 from .plugin_manager import PluginManager
 from .provenance import Provenance
 from .workflow import Workflow, Signature
 from .execution import SubprocessExecutor
 
-__all__ = ['Artifact', 'PluginManager', 'Provenance', 'Workflow', 'Signature',
-           'SubprocessExecutor']
+__all__ = ['Artifact', 'Visualization', 'PluginManager', 'Provenance',
+           'Workflow', 'Signature', 'SubprocessExecutor']

--- a/qiime/sdk/artifact.py
+++ b/qiime/sdk/artifact.py
@@ -6,131 +6,25 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import io
-import os
 import uuid
-import tempfile
-import yaml
-import time
-import datetime
-import zipfile
 
-import qiime.plugin
+import qiime.core.archiver
+import qiime.core.result_base
+import qiime.core.type
 import qiime.sdk
 
 
-# TODO use utf-8 encoding when reading/writing files
-class Artifact:
-    _version = '0.1.0'  # artifact archive format version
-    _version_path = 'VERSION'
-    _readme_path = 'README.md'
-    _metadata_path = 'metadata.yaml'
-    _archive_dir = 'data'
-
-    @property
-    def type(self):
-        return self._type
-
-    @property
-    def provenance(self):
-        return self._provenance
-
-    @property
-    def uuid(self):
-        return self._uuid
-
+class Artifact(qiime.core.result_base.ResultBase):
     @classmethod
-    def _get_root_dir(cls, filepath):
-        return os.path.splitext(os.path.basename(filepath))[0]
-
-    @classmethod
-    def _create_temp_dir(cls):
-        return tempfile.TemporaryDirectory(prefix='qiime2-temp-artifact-data-')
-
-    @classmethod
-    def load(cls, filepath):
-        if not zipfile.is_zipfile(filepath):
-            raise zipfile.BadZipFile(
-                "%r is not a readable ZIP file, or the file does not exist" %
-                filepath)
-
-        root_dir = cls._get_root_dir(filepath)
-        with zipfile.ZipFile(filepath, mode='r') as zf:
-            version = cls._load_version(zf, root_dir)
-            if version != cls._version:
-                raise ValueError(
-                    "Unsupported artifact archive format version %r. "
-                    "Supported version(s): %r" % (version, cls._version))
-
-            type_, uuid_, provenance = cls._load_metadata(zf, root_dir)
-
-        artifact = cls.__new__(cls)
-
-        artifact._type = type_
-        artifact._provenance = provenance
-        artifact._uuid = uuid_
-        artifact._zip_filepath = filepath
-
-        return artifact
-
-    @classmethod
-    def _load_version(cls, zf, root_dir):
-        with zf.open(os.path.join(root_dir, cls._version_path)) as bytes_fh:
-            with io.TextIOWrapper(bytes_fh, newline=None,
-                                  encoding='utf-8') as fh:
-                return fh.read().rstrip('\n')
-
-    @classmethod
-    def _load_metadata(cls, zf, root_dir):
-        with zf.open(os.path.join(root_dir, cls._metadata_path)) as bytes_fh:
-            with io.TextIOWrapper(bytes_fh, newline=None,
-                                  encoding='utf-8') as fh:
-                metadata = yaml.safe_load(fh)
-
-        uuid_ = cls._parse_uuid(metadata['UUID'])
-        provenance = cls._parse_provenance(metadata['provenance'])
-        type_ = cls._parse_semantic_type(metadata['type'])
-        return type_, uuid_, provenance
-
-    # TODO this is mostly duplicated from Workflow._parse_semantic_type.
-    @classmethod
-    def _parse_semantic_type(cls, type_exp):
-        type_exp = type_exp.split('\n')
-        if len(type_exp) != 1:
-            raise TypeError("Multiple lines in type expression of"
-                            " artifact. Will not load to avoid arbitrary"
-                            " code execution.")
-        type_exp, = type_exp
-
-        if ';' in type_exp:
-            raise TypeError("Invalid type expression in artifact. Will not"
-                            " load to avoid arbitrary code execution.")
-
-        pm = qiime.sdk.PluginManager()
-        locals_ = {k: v[1] for k, v in pm.semantic_types.items()}
-
-        type_ = eval(type_exp, {'__builtins__': {}}, locals_)
-        if not type_.is_concrete():
-            raise TypeError("%r is not a concrete type. Only concrete types "
-                            "can be loaded." % type_)
-        return type_
-
-    @classmethod
-    def _parse_uuid(cls, string):
-        return uuid.UUID(hex=string)
-
-    # TODO implement provenance parsing
-    @classmethod
-    def _parse_provenance(cls, provenance):
-        if isinstance(provenance, str):
-            return None
-        else:
-            return qiime.sdk.Provenance(
-                job_uuid=provenance['job-UUID'],
-                artifact_uuids=provenance['artifact-uuids'],
-                parameters=provenance['parameters'],
-                workflow_reference=provenance['workflow-reference']
-            )
+    def _assert_valid_type(cls, type_):
+        if not (qiime.core.type.is_semantic_type(type_) and
+                type_.is_concrete()):
+            error_suffix = ""
+            if type_ is qiime.core.type.Visualization:
+                error_suffix = " Use qiime.sdk.Visualization with this type."
+            raise TypeError(
+                "An artifact requires a concrete semantic type, not type %r.%s"
+                % (type_, error_suffix))
 
     @classmethod
     def _from_view(cls, view, type_, provenance):
@@ -141,196 +35,44 @@ class Artifact:
         view : Python object
             View to serialize.
         type_ : qiime.plugin.Type or str
-            Semantic type of the artifact.
+            Concrete semantic type of the artifact.
         provenance : qiime.sdk.Provenance
             Artifact provenance.
 
         """
-        # TODO do some validation here, such as making sure `view` can be
-        # written to `type_` archive format.
-        if isinstance(type_, str):
-            type_ = cls._parse_semantic_type(type_)
-        if not type_.is_concrete():
-            raise TypeError(
-                "%r is not a concrete type. Artifacts can only contain "
-                "concrete types." % type_)
-
         artifact = cls.__new__(cls)
-
-        artifact._type = type_
-        artifact._provenance = provenance
-        artifact._uuid = uuid.uuid4()
-        artifact._temp_dir = cls._create_temp_dir()
+        artifact._archiver = qiime.core.archiver.Archiver(uuid.uuid4(), type_,
+                                                          provenance)
+        artifact._assert_valid_type(artifact.type)
+        # TODO do some validation, such as making sure `view` can be
+        # written to `type_` data layout.
         artifact._save_view(view)
-
         return artifact
 
     def _save_view(self, view):
+        data_layout = self._get_data_layout()
+        view_type = type(view)
+        writer = data_layout.writers[view_type]
+        self._archiver.save_data(view, writer)
+
+    def _get_data_layout(self):
         pm = qiime.sdk.PluginManager()
-        archive_format = None
-        for semantic_type, archive_fmt in \
-                pm.semantic_type_to_archive_formats.items():
+
+        data_layout = None
+        for semantic_type, datalayout in \
+                pm.semantic_type_to_data_layouts.items():
             if self.type <= semantic_type:
-                archive_format = archive_fmt
+                data_layout = datalayout
                 break
 
-        if archive_format is None:
+        if data_layout is None:
             raise TypeError(
-                "Artifact type %r does not have an archive format to "
-                "serialize to." % self.type)
+                "Artifact semantic type %r does not have a compatible data "
+                "layout." % self.type)
 
-        view_type = type(view)
-        writer = archive_format.writers[view_type]
-        writer(view, self._temp_dir.name)
-
-    def __init__(self):
-        """
-
-        This constructor is private.
-
-        """
-        raise NotImplementedError(
-            "Artifact constructor is private. Use `Artifact.load` to "
-            "construct an Artifact.")
-
-    def __new__(cls):
-        artifact = object.__new__(cls)
-
-        artifact._type = None
-        artifact._provenance = None
-        artifact._uuid = None
-        artifact._temp_dir = None
-        artifact._zip_filepath = None
-
-        return artifact
-
-    def __del__(self):
-        if self._temp_dir is not None:
-            self._temp_dir.cleanup()
+        return data_layout
 
     def view(self, view_type):
-        pm = qiime.sdk.PluginManager()
-
-        archive_format = None
-        for semantic_type, archive_fmt in \
-                pm.semantic_type_to_archive_formats.items():
-            if self.type <= semantic_type:
-                archive_format = archive_fmt
-                break
-
-        if archive_format is None:
-            raise TypeError(
-                "Artifact type %r does not have an archive format to "
-                "deserialize from." % self.type)
-
-        reader = archive_format.readers[view_type]
-
-        if self._temp_dir is None:
-            self._extract_artifact_data()
-
-        return reader(self._temp_dir.name)
-
-    def _extract_artifact_data(self):
-        assert self._temp_dir is None and self._zip_filepath is not None
-
-        self._temp_dir = self._create_temp_dir()
-        temp_dir = self._temp_dir.name
-
-        # TODO is there a better way to extract the files in an archive
-        # subdirectory into a directory without keeping the nested archive
-        # directory structure?
-        with zipfile.ZipFile(self._zip_filepath, mode='r') as zf:
-            root_dir = self._get_root_dir(self._zip_filepath)
-            prefix = os.path.join(root_dir, self._archive_dir, '')
-
-            for file_ in zf.namelist():
-                if file_.startswith(prefix):
-                    extract_path = zf.extract(file_, path=temp_dir)
-                    os.rename(extract_path,
-                              os.path.join(temp_dir, os.path.basename(file_)))
-            os.rmdir(os.path.join(temp_dir, prefix))
-
-    def save(self, filepath):
-        root_dir = self._get_root_dir(filepath)
-
-        if self._temp_dir is None:
-            self._extract_artifact_data()
-
-        with zipfile.ZipFile(filepath, mode='w',
-                             compression=zipfile.ZIP_DEFLATED,
-                             allowZip64=True) as zf:
-            self._save_version(zf, root_dir)
-            self._save_readme(zf, root_dir)
-            self._save_metadata(zf, root_dir)
-
-            for root, dirs, files in os.walk(self._temp_dir.name):
-                for file_ in files:
-                    temp_path = os.path.join(root, file_)
-                    archive_path = os.path.join(
-                        root_dir,
-                        self._archive_dir,
-                        root.replace(self._temp_dir.name, '', 1),
-                        file_
-                    )
-                    zf.write(temp_path, arcname=archive_path)
-
-    def _save_version(self, zf, root_dir):
-        zf.writestr(os.path.join(root_dir, self._version_path),
-                    '%s\n' % self._version)
-
-    def _save_readme(self, zf, root_dir):
-        zf.writestr(os.path.join(root_dir, self._readme_path),
-                    _README_TEXT)
-
-    # TODO clean up metadata yaml formatting. It currently dumps Python
-    # objects, `yaml.safe_dump` call needs to be updated to format lists and
-    # dicts as typical yaml.
-    def _save_metadata(self, zf, root_dir):
-        metadata_bytes = yaml.safe_dump({
-            'UUID': self._formatted_uuid(),
-            'provenance': self._formatted_provenance(),
-            'type': repr(self.type)
-        })
-        zf.writestr(os.path.join(root_dir, self._metadata_path),
-                    metadata_bytes)
-
-    def _formatted_uuid(self):
-        return str(self.uuid)
-
-    def _formatted_provenance(self):
-        if self.provenance is None:
-            return ('No provenance available because this artifact was '
-                    'generated independently of QIIME.')
-        else:
-            return {
-                'job-UUID': str(self.provenance.job_uuid),
-                'artifact-uuids': self.provenance.artifact_uuids,
-                # TODO: need to store parameter types (or is it enough
-                # that the workflow template reference could get us that?)
-                'parameters': self.provenance.parameters,
-                'runtime': self._formatted_runtime(),
-                'workflow-reference': self.provenance.workflow_reference
-            }
-
-    def _formatted_runtime(self):
-        stop_time = time.time()
-        run_time = stop_time - self.provenance.start_time
-        datetime_start = datetime.datetime.fromtimestamp(
-            self.provenance.start_time)
-        datetime_stop = datetime.datetime.fromtimestamp(stop_time)
-        return {
-            'run-time-seconds': run_time,
-            'execution-start-time': datetime_start.isoformat(),
-            'execution-stop-time': datetime_stop.isoformat()
-        }
-
-
-_README_TEXT = """# QIIME 2 artifact
-
-This archive stores the data and associated metadata of a serialized QIIME 2
-artifact.
-
-**WARNING:** This is a temporary file format used for prototyping QIIME 2. Do
-not rely on this format for any reason as it will not be supported past the
-prototyping stage in its current form.
-"""
+        data_layout = self._get_data_layout()
+        reader = data_layout.readers[view_type]
+        return self._archiver.load_data(reader)

--- a/qiime/sdk/tests/test_artifact.py
+++ b/qiime/sdk/tests/test_artifact.py
@@ -47,7 +47,7 @@ class TestArtifact(unittest.TestCase):
         self.test_dir.cleanup()
 
     def test_save(self):
-        fp = os.path.join(self.test_dir.name, 'artifact.qzf')
+        fp = os.path.join(self.test_dir.name, 'artifact.qza')
 
         self.artifact_with_provenance.save(fp)
 
@@ -58,7 +58,7 @@ class TestArtifact(unittest.TestCase):
             self.assertEqual(fps, expected)
 
     def test_load_with_provenance(self):
-        fp = os.path.join(self.test_dir.name, 'artifact.qzf')
+        fp = os.path.join(self.test_dir.name, 'artifact.qza')
         self.artifact_with_provenance.save(fp)
 
         artifact = Artifact.load(fp)
@@ -69,7 +69,7 @@ class TestArtifact(unittest.TestCase):
         self.assertEqual(artifact.view(list), [-1, 42, 0, 43, 43])
 
     def test_load_without_provenance(self):
-        fp = os.path.join(self.test_dir.name, 'artifact.qzf')
+        fp = os.path.join(self.test_dir.name, 'artifact.qza')
         self.artifact_without_provenance.save(fp)
 
         artifact = Artifact.load(fp)

--- a/qiime/sdk/tests/test_execution.py
+++ b/qiime/sdk/tests/test_execution.py
@@ -45,9 +45,9 @@ class TestSubprocessExecutor(unittest.TestCase):
             doc="Let's concatenate some things!"
         )
 
-        self.artifact_fp1 = os.path.join(self.test_dir.name, 'artifact1.qzf')
-        self.artifact_fp2 = os.path.join(self.test_dir.name, 'artifact2.qzf')
-        self.artifact_fp3 = os.path.join(self.test_dir.name, 'artifact3.qzf')
+        self.artifact_fp1 = os.path.join(self.test_dir.name, 'artifact1.qza')
+        self.artifact_fp2 = os.path.join(self.test_dir.name, 'artifact2.qza')
+        self.artifact_fp3 = os.path.join(self.test_dir.name, 'artifact3.qza')
 
         artifact = Artifact._from_view(
             [-1, 42, 0, 43, 43], qiime.core.testing.TestType, None)

--- a/qiime/sdk/tests/test_job.py
+++ b/qiime/sdk/tests/test_job.py
@@ -17,18 +17,18 @@ class TestJob(unittest.TestCase):
     def test_constructor(self):
         job = Job(code="import this",
                   uuid=uuid.UUID('7e909a23-21e2-44c2-be17-0723fae91dc8'),
-                  input_artifact_filepaths={'input1': 'input1.qzf'},
+                  input_artifact_filepaths={'input1': 'input1.qza'},
                   parameter_references={'param1': 42},
-                  output_artifact_filepaths={'output1': 'output1.qzf'})
+                  output_artifact_filepaths={'output1': 'output1.qza'})
 
         self.assertEqual(job.code, "import this")
         self.assertEqual(job.uuid,
                          uuid.UUID('7e909a23-21e2-44c2-be17-0723fae91dc8'))
         self.assertEqual(job.input_artifact_filepaths,
-                         {'input1': 'input1.qzf'})
+                         {'input1': 'input1.qza'})
         self.assertEqual(job.parameter_references, {'param1': 42})
         self.assertEqual(job.output_artifact_filepaths,
-                         {'output1': 'output1.qzf'})
+                         {'output1': 'output1.qza'})
 
 
 if __name__ == "__main__":

--- a/qiime/sdk/tests/test_plugin_manager.py
+++ b/qiime/sdk/tests/test_plugin_manager.py
@@ -49,12 +49,12 @@ class TestPluginManager(unittest.TestCase):
             {'dummy-plugin': plugin1, 'other-dummy-plugin': plugin2,
              'test-plugin': qiime.core.testing.plugin})
 
-        expected_archive_format = qiime.plugin.ArchiveFormat(
-            'example-archive-format', 1, lambda e: e)
+        expected_data_layout = qiime.plugin.DataLayout(
+            'example-data-layout', 1, lambda e: e)
         self.assertEqual(
-            plugin_manager.archive_formats,
-            {('example-archive-format', 1):
-             ('test-plugin', expected_archive_format)})
+            plugin_manager.data_layouts,
+            {('example-data-layout', 1):
+             ('test-plugin', expected_data_layout)})
 
 
 if __name__ == '__main__':

--- a/qiime/sdk/tests/test_workflow.py
+++ b/qiime/sdk/tests/test_workflow.py
@@ -165,17 +165,17 @@ class TestWorkflow(unittest.TestCase):
         # that can test either one instead of duplicating a bunch of code.
         workflow = Workflow.from_markdown(self.markdown_fp)
 
-        artifact_fp1 = os.path.join(self.test_dir.name, 'artifact1.qzf')
+        artifact_fp1 = os.path.join(self.test_dir.name, 'artifact1.qza')
         artifact = Artifact._from_view(
             [-1, 42, 0, 43, 43], qiime.core.testing.TestType, None)
         artifact.save(artifact_fp1)
 
-        artifact_fp2 = os.path.join(self.test_dir.name, 'artifact2.qzf')
+        artifact_fp2 = os.path.join(self.test_dir.name, 'artifact2.qza')
         artifact = Artifact._from_view(
             [1, 2, 100], qiime.core.testing.TestType, None)
         artifact.save(artifact_fp2)
 
-        artifact_fp3 = os.path.join(self.test_dir.name, 'artifact3.qzf')
+        artifact_fp3 = os.path.join(self.test_dir.name, 'artifact3.qza')
 
         job = to_method(
             workflow,

--- a/qiime/sdk/visualization.py
+++ b/qiime/sdk/visualization.py
@@ -1,0 +1,35 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import distutils.dir_util
+import uuid
+
+import qiime.core.archiver
+import qiime.core.result_base
+import qiime.core.type
+
+
+class Visualization(qiime.core.result_base.ResultBase):
+    @classmethod
+    def _assert_valid_type(cls, type_):
+        if type_ is not qiime.core.type.Visualization:
+            error_suffix = ""
+            if qiime.core.type.is_semantic_type(type_) and type_.is_concrete():
+                error_suffix = " Use qiime.sdk.Artifact with this type."
+            raise TypeError(
+                "A visualization requires type %r, not type %r.%s" %
+                (qiime.core.type.Visualization, type_, error_suffix))
+
+    @classmethod
+    def _from_data_dir(cls, data_dir, provenance):
+        viz = cls.__new__(cls)
+        viz._archiver = qiime.core.archiver.Archiver(
+            uuid.uuid4(), qiime.core.type.Visualization, provenance)
+        # shutil.copytree doesn't allow the destination directory to exist.
+        viz._archiver.save_data(data_dir, distutils.dir_util.copy_tree)
+        return viz

--- a/qiime/sdk/workflow.py
+++ b/qiime/sdk/workflow.py
@@ -305,8 +305,7 @@ class Workflow:
                 # parameter, so that is hard-coded here.
                 teardown_lines.append(
                     'visualization = Visualization._from_data_dir('
-                    '%s, %r, provenance)' %
-                    ('output_dir', str(qiime.core.type.Visualization))
+                    'output_dir, provenance)'
                 )
                 teardown_lines.append(
                     'visualization.save(%r)' % output_filepath

--- a/qiime/sdk/workflow.py
+++ b/qiime/sdk/workflow.py
@@ -193,7 +193,7 @@ class Workflow:
         import_path = inspect.getmodule(function).__name__
         function_name = function.__name__
         # TODO sorting by parameter name for reproducible output necessary for
-        # testing. Should devs be able to define an ordering to parameters?
+        # testing. This should match `function` signature
         md_params = ', '.join([
             '%s=%s' % (k, k) for k in sorted(inputs) + sorted(parameters)])
 

--- a/qiime/tests/test_archive_format.py
+++ b/qiime/tests/test_archive_format.py
@@ -17,7 +17,7 @@ class TestFormat(unittest.TestCase):
         def is_valid(data_dir):
             return True
 
-        f = qiime.plugin.ArchiveFormat('my-format', '1.0.0', is_valid)
+        f = qiime.plugin.DataLayout('my-format', '1.0.0', is_valid)
         self.assertEqual(f.name, 'my-format')
         self.assertEqual(f.version, '1.0.0')
         with tempfile.TemporaryDirectory() as data_dir:
@@ -30,10 +30,10 @@ class TestFormat(unittest.TestCase):
         def is_valid(data_dir):
             return True
 
-        f1 = qiime.plugin.ArchiveFormat('my-format', '1.0.0', is_valid)
-        f2 = qiime.plugin.ArchiveFormat('my-format', '1.0.0', is_valid)
-        f3 = qiime.plugin.ArchiveFormat('your-format', '1.0.0', is_valid)
-        f4 = qiime.plugin.ArchiveFormat('my-format', '1.0.1', is_valid)
+        f1 = qiime.plugin.DataLayout('my-format', '1.0.0', is_valid)
+        f2 = qiime.plugin.DataLayout('my-format', '1.0.0', is_valid)
+        f3 = qiime.plugin.DataLayout('your-format', '1.0.0', is_valid)
+        f4 = qiime.plugin.DataLayout('my-format', '1.0.1', is_valid)
         self.assertEqual(f1, f1)
         self.assertEqual(f1, f2)
         self.assertNotEqual(f1, f3)
@@ -44,7 +44,7 @@ class TestFormat(unittest.TestCase):
         def is_valid(data_dir):
             return True
 
-        f = qiime.plugin.ArchiveFormat('my-format', '1.0.0', is_valid)
+        f = qiime.plugin.DataLayout('my-format', '1.0.0', is_valid)
 
         @f.reader(float)
         def my_reader(data_dir):
@@ -59,7 +59,7 @@ class TestFormat(unittest.TestCase):
         def is_valid(data_dir):
             return True
 
-        f = qiime.plugin.ArchiveFormat('my-format', '1.0.0', is_valid)
+        f = qiime.plugin.DataLayout('my-format', '1.0.0', is_valid)
 
         @f.writer(float)
         def my_writer(data_dir):

--- a/qiime/tests/test_plugin.py
+++ b/qiime/tests/test_plugin.py
@@ -16,7 +16,7 @@ import unittest.mock
 import frontmatter
 
 from qiime.core.testing import TestType
-from qiime.plugin import Plugin, Int, ArchiveFormat
+from qiime.plugin import Plugin, Int, DataLayout
 from qiime.sdk import Workflow, Signature
 
 
@@ -55,18 +55,18 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(self.plugin.website, 'www.dummy-plugin-hub.com')
         self.assertEqual(self.plugin.package, 'dummy_plugin')
         self.assertEqual(self.plugin.workflows, {})
-        self.assertEqual(self.plugin.archive_formats, {})
+        self.assertEqual(self.plugin.data_layouts, {})
 
-    def test_register_archive_format(self):
-        self.assertEqual(self.plugin.archive_formats, {})
+    def test_register_data_layout(self):
+        self.assertEqual(self.plugin.data_layouts, {})
 
         def is_valid(data_dir):
             return True
-        self.plugin.register_archive_format('my-format', '1.0.0', is_valid)
-        exp_format = ArchiveFormat('my-format', '1.0.0', is_valid)
-        self.assertEqual(self.plugin.archive_formats,
+        self.plugin.register_data_layout('my-format', '1.0.0', is_valid)
+        exp_format = DataLayout('my-format', '1.0.0', is_valid)
+        self.assertEqual(self.plugin.data_layouts,
                          {('my-format', '1.0.0'): exp_format})
-        # TODO: test execution of archive format reader and writer
+        # TODO: test execution of data layout reader and writer
 
     def test_register_function(self):
         self.assertEqual(self.plugin.workflows, {})


### PR DESCRIPTION
Parts of this were pair-programmed with @gregcaporaso.

Adds `Plugin.register_visualization` and `qiime.sdk.Visualization` class.

Refactored Artifact archive format logic into an Archiver class. Artifact and Visualization now have an archiver. Factored shared code into ResultBase ABC that Artifact and Visualization extend.

Renamed "archive format" to "data layout" to prevent confusion with actual Artifact/Visualization archive format (.qzf/.vzf).