### PR TITLE
ENH: annotations removed on Methods and Visualizers

### DIFF
--- a/qiime/sdk/method.py
+++ b/qiime/sdk/method.py
@@ -213,11 +213,10 @@ class Method:
     def _bind_executors(self):
         callable_wrapper = self._get_callable_wrapper()
 
-        # TODO drop function annotations as they only make sense for the
-        # "view API". Necessary for `async` too. Simply setting __annotations__
-        # to {} or None doesn't work for some reason.
         __call__ = decorator.decorator(callable_wrapper, self._callable)
         __call__.__name__ = '__call__'
+        del __call__.__annotations__
+        del __call__.__wrapped__
         self._dynamic_call = __call__
 
         # TODO `async` execution has some problems with garbage-collection in
@@ -231,6 +230,8 @@ class Method:
 
         async = decorator.decorator(async_wrapper, self._callable)
         async.__name__ = 'async'
+        del async.__annotations__
+        del async.__wrapped__
         self._dynamic_async = async
 
     def _get_callable_wrapper(self):


### PR DESCRIPTION
Turns out it was a simple case of `__wrapped__` getting set and being the fallback for inspect when `__annotations__` doesn't exist. You must delete both in order to get rid of the annotations.

Formerly:
```json
In [1]: from qiime.plugin.diversity import ancom, beta_diversity

In [2]: ancom?
Type:           Visualizer
String form:    <qiime.sdk.visualizer.Visualizer object at 0x7f8d22bb45c0>
File:           ~/qiime2/qiime2/qiime/sdk/visualizer.py
Docstring:      <no docstring>
Call signature: ancom(output_dir:str, table:biom.table.Table, metadata:qiime.metadata.MetadataCategory) -> None

In [3]: beta_diversity?
Type:           Method
String form:    <qiime.sdk.method.Method object at 0x7f8d22b9b1d0>
File:           ~/qiime2/qiime2/qiime/sdk/method.py
Docstring:      <no docstring>
Call signature: beta_diversity(metric:str, feature_table:biom.table.Table, phylogeny:skbio.tree._tree.TreeNode=None) -> skbio.stats.distance._base.DistanceMatrix
```

Now:

```json
In [1]: from qiime.plugin.diversity import ancom, beta_diversity

In [2]: ancom?
Type:           Visualizer
String form:    <qiime.sdk.visualizer.Visualizer object at 0x7fcf5e2d9400>
File:           ~/qiime2/qiime2/qiime/sdk/visualizer.py
Docstring:      <no docstring>
Call signature: ancom(table, metadata)

In [3]: beta_diversity?
Type:           Method
String form:    <qiime.sdk.method.Method object at 0x7fcf5e2b4f28>
File:           ~/qiime2/qiime2/qiime/sdk/method.py
Docstring:      <no docstring>
Call signature: beta_diversity(metric, feature_table, phylogeny=None)
```

This also means `output_dir` stops showing up in the Visualizer API.