### PR TITLE
adds ResultBase.extract and Visualization.get_indices

### DIFF
--- a/qiime/core/result_base.py
+++ b/qiime/core/result_base.py
@@ -7,8 +7,6 @@
 # ----------------------------------------------------------------------------
 
 import abc
-import zipfile
-import tempfile
 
 import qiime.core.archiver
 
@@ -29,12 +27,8 @@ class ResultBase(metaclass=abc.ABCMeta):
         return result
 
     @classmethod
-    def extract(cls, filepath, output_dir=None):
-        if output_dir is None:
-            output_dir = tempfile.gettempdir()
-        with zipfile.ZipFile(filepath, mode='r') as zf:
-            zf.extractall(output_dir)
-        return output_dir
+    def extract(cls, filepath, output_dir):
+        return qiime.core.archiver.Archiver.extract(filepath, output_dir)
 
     @property
     def type(self):

--- a/qiime/core/result_base.py
+++ b/qiime/core/result_base.py
@@ -7,6 +7,8 @@
 # ----------------------------------------------------------------------------
 
 import abc
+import zipfile
+import tempfile
 
 import qiime.core.archiver
 
@@ -25,6 +27,14 @@ class ResultBase(metaclass=abc.ABCMeta):
         result._archiver = qiime.core.archiver.Archiver.load(filepath)
         result._assert_valid_type(result.type)
         return result
+
+    @classmethod
+    def extract(cls, filepath, output_dir=None):
+        if output_dir is None:
+            output_dir = tempfile.gettempdir()
+        with zipfile.ZipFile(filepath, mode='r') as zf:
+            zf.extractall(output_dir)
+        return output_dir
 
     @property
     def type(self):

--- a/qiime/core/testing/visualizer.py
+++ b/qiime/core/testing/visualizer.py
@@ -27,6 +27,19 @@ def most_common_viz(output_dir: str, ints: collections.Counter) -> None:
         fh.write(df.to_csv(sep='\t', index=False))
 
 
+# Multiple html files (index.1.html, index.2.html)
+def multi_html_viz(output_dir: str, ints: list) -> None:
+    ints = [str(i) for i in ints]
+    with open(os.path.join(output_dir, 'index.1.html'), 'w') as fh:
+        fh.write('<html><body>\n')
+        fh.write(' '.join(ints))
+        fh.write('</body></html>')
+    with open(os.path.join(output_dir, 'index.2.html'), 'w') as fh:
+        fh.write('<html><body>\n')
+        fh.write(' '.join(reversed(ints)))
+        fh.write('</body></html>')
+
+
 # Multiple input artifacts and parameters, and a nested directory with required
 # resources for rendering.
 def mapping_viz(output_dir: str, mapping1: dict, mapping2: dict,

--- a/qiime/sdk/tests/test_artifact.py
+++ b/qiime/sdk/tests/test_artifact.py
@@ -303,29 +303,9 @@ class TestArtifact(unittest.TestCase):
                                        self.provenance)
         artifact.save(fp)
 
-        Artifact.extract(fp)
-
-        contents = [
-            'artifact/VERSION',
-            'artifact/metadata.yaml',
-            'artifact/README.md',
-            'artifact/data/file1.txt',
-            'artifact/data/file2.txt',
-            'artifact/data/nested/file3.txt',
-            'artifact/data/nested/file4.txt']
-        for fp in contents:
-            expected_fp = os.path.join(tempfile.gettempdir(), fp)
-            self.assertTrue(os.path.exists(expected_fp),
-                            'File %s was not extracted.' % fp)
-
-    def test_extract_alt_output_dir(self):
-        fp = os.path.join(self.test_dir.name, 'artifact.qza')
-        artifact = Artifact._from_view([-1, 42, 0, 43], FourInts,
-                                       self.provenance)
-        artifact.save(fp)
-
         output_dir = os.path.join(self.test_dir.name, 'artifact-extract-test')
-        Artifact.extract(fp, output_dir=output_dir)
+        result_dir = Artifact.extract(fp, output_dir=output_dir)
+        self.assertEqual(result_dir, output_dir)
 
         contents = [
             'artifact/VERSION',

--- a/qiime/sdk/tests/test_artifact.py
+++ b/qiime/sdk/tests/test_artifact.py
@@ -297,6 +297,49 @@ class TestArtifact(unittest.TestCase):
             }
             self.assertEqual(fps, expected)
 
+    def test_extract(self):
+        fp = os.path.join(self.test_dir.name, 'artifact.qza')
+        artifact = Artifact._from_view([-1, 42, 0, 43], FourInts,
+                                       self.provenance)
+        artifact.save(fp)
+
+        Artifact.extract(fp)
+
+        contents = [
+            'artifact/VERSION',
+            'artifact/metadata.yaml',
+            'artifact/README.md',
+            'artifact/data/file1.txt',
+            'artifact/data/file2.txt',
+            'artifact/data/nested/file3.txt',
+            'artifact/data/nested/file4.txt']
+        for fp in contents:
+            expected_fp = os.path.join(tempfile.gettempdir(), fp)
+            self.assertTrue(os.path.exists(expected_fp),
+                            'File %s was not extracted.' % fp)
+
+    def test_extract_alt_output_dir(self):
+        fp = os.path.join(self.test_dir.name, 'artifact.qza')
+        artifact = Artifact._from_view([-1, 42, 0, 43], FourInts,
+                                       self.provenance)
+        artifact.save(fp)
+
+        output_dir = os.path.join(self.test_dir.name, 'artifact-extract-test')
+        Artifact.extract(fp, output_dir=output_dir)
+
+        contents = [
+            'artifact/VERSION',
+            'artifact/metadata.yaml',
+            'artifact/README.md',
+            'artifact/data/file1.txt',
+            'artifact/data/file2.txt',
+            'artifact/data/nested/file3.txt',
+            'artifact/data/nested/file4.txt']
+        for fp in contents:
+            expected_fp = os.path.join(output_dir, fp)
+            self.assertTrue(os.path.exists(expected_fp),
+                            'File %s was not extracted.' % fp)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime/sdk/tests/test_visualization.py
+++ b/qiime/sdk/tests/test_visualization.py
@@ -12,11 +12,12 @@ import tempfile
 import unittest
 import uuid
 import zipfile
+import collections
 
 import qiime.core.type
 from qiime.sdk import Visualization, Provenance
 
-from qiime.core.testing.visualizer import mapping_viz
+from qiime.core.testing.visualizer import mapping_viz, most_common_viz
 
 
 class TestVisualization(unittest.TestCase):
@@ -280,6 +281,23 @@ class TestVisualization(unittest.TestCase):
             expected_fp = os.path.join(output_dir, fp)
             self.assertTrue(os.path.exists(expected_fp),
                             'File %s was not extracted.' % fp)
+
+    def test_get_indices_single(self):
+        visualization = Visualization._from_data_dir(self.data_dir,
+                                                     self.provenance)
+        actual = visualization.get_indices()
+        expected = {'data/index.html'}
+        self.assertEqual(actual, expected)
+
+    def test_get_indices_multiple(self):
+        most_common_viz(self.data_dir,
+                        collections.Counter(range(42)))
+        visualization = Visualization._from_data_dir(self.data_dir,
+                                                     self.provenance)
+        actual = visualization.get_indices()
+        expected = {'data/index.html',
+                    'data/index.tsv'}
+        self.assertEqual(actual, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime/sdk/tests/test_visualization.py
+++ b/qiime/sdk/tests/test_visualization.py
@@ -17,7 +17,8 @@ import collections
 import qiime.core.type
 from qiime.sdk import Visualization, Provenance
 
-from qiime.core.testing.visualizer import mapping_viz, most_common_viz
+from qiime.core.testing.visualizer import (
+    mapping_viz, most_common_viz, multi_html_viz)
 
 
 class TestVisualization(unittest.TestCase):
@@ -247,28 +248,9 @@ class TestVisualization(unittest.TestCase):
                                                      self.provenance)
         visualization.save(fp)
 
-        Visualization.extract(fp)
-
-        contents = [
-            'visualization/VERSION',
-            'visualization/metadata.yaml',
-            'visualization/README.md',
-            'visualization/data/index.html',
-            'visualization/data/css/style.css']
-
-        for fp in contents:
-            expected_fp = os.path.join(tempfile.gettempdir(), fp)
-            self.assertTrue(os.path.exists(expected_fp),
-                            'File %s was not extracted.' % fp)
-
-    def test_extract_alt_output_dir(self):
-        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
-        visualization = Visualization._from_data_dir(self.data_dir,
-                                                     self.provenance)
-        visualization.save(fp)
-
         output_dir = os.path.join(self.test_dir.name, 'viz-extract-test')
-        Visualization.extract(fp, output_dir=output_dir)
+        result_dir = Visualization.extract(fp, output_dir=output_dir)
+        self.assertEqual(result_dir, output_dir)
 
         contents = [
             'visualization/VERSION',
@@ -276,28 +258,83 @@ class TestVisualization(unittest.TestCase):
             'visualization/README.md',
             'visualization/data/index.html',
             'visualization/data/css/style.css']
-
         for fp in contents:
             expected_fp = os.path.join(output_dir, fp)
             self.assertTrue(os.path.exists(expected_fp),
                             'File %s was not extracted.' % fp)
 
-    def test_get_indices_single(self):
+    def test_get_index_paths_single_load(self):
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
         visualization = Visualization._from_data_dir(self.data_dir,
                                                      self.provenance)
-        actual = visualization.get_indices()
-        expected = {'data/index.html'}
+        visualization.save(fp)
+        visualization = Visualization.load(fp)
+
+        actual = visualization.get_index_paths()
+        expected = {'html': 'data/index.html'}
         self.assertEqual(actual, expected)
 
-    def test_get_indices_multiple(self):
-        most_common_viz(self.data_dir,
-                        collections.Counter(range(42)))
+    def test_get_index_paths_single_from_data_dir(self):
         visualization = Visualization._from_data_dir(self.data_dir,
                                                      self.provenance)
-        actual = visualization.get_indices()
-        expected = {'data/index.html',
-                    'data/index.tsv'}
+
+        actual = visualization.get_index_paths()
+        expected = {'html': 'data/index.html'}
         self.assertEqual(actual, expected)
+
+    def test_get_index_paths_multiple_load(self):
+        data_dir = os.path.join(self.test_dir.name, 'mc-viz-output1')
+        os.mkdir(data_dir)
+        most_common_viz(data_dir,
+                        collections.Counter(range(42)))
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
+        visualization = Visualization._from_data_dir(data_dir,
+                                                     self.provenance)
+        visualization.save(fp)
+        visualization = Visualization.load(fp)
+
+        actual = visualization.get_index_paths()
+        expected = {'html': 'data/index.html',
+                    'tsv': 'data/index.tsv'}
+        self.assertEqual(actual, expected)
+
+    def test_get_index_paths_multiple_from_data_dir(self):
+        data_dir = os.path.join(self.test_dir.name, 'mc-viz-output2')
+        os.mkdir(data_dir)
+        most_common_viz(data_dir, collections.Counter(range(42)))
+        visualization = Visualization._from_data_dir(data_dir,
+                                                     self.provenance)
+
+        actual = visualization.get_index_paths()
+        expected = {'html': 'data/index.html',
+                    'tsv': 'data/index.tsv'}
+        self.assertEqual(actual, expected)
+
+    def test_get_index_paths_multiple_html_load(self):
+        data_dir = os.path.join(self.test_dir.name, 'multi-html-viz1')
+        os.mkdir(data_dir)
+        multi_html_viz(data_dir, [1, 42])
+
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
+        visualization = Visualization._from_data_dir(data_dir,
+                                                     self.provenance)
+        visualization.save(fp)
+        visualization = Visualization.load(fp)
+
+        with self.assertRaises(ValueError):
+            visualization.get_index_paths()
+
+    def test_get_index_paths_multiple_html_from_data_dir(self):
+        data_dir = os.path.join(self.test_dir.name, 'multi-html-viz2')
+        os.mkdir(data_dir)
+        multi_html_viz(data_dir, [1, 42])
+
+        visualization = Visualization._from_data_dir(data_dir,
+                                                     self.provenance)
+
+        with self.assertRaises(ValueError):
+            visualization.get_index_paths()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime/sdk/tests/test_visualization.py
+++ b/qiime/sdk/tests/test_visualization.py
@@ -240,6 +240,46 @@ class TestVisualization(unittest.TestCase):
             }
             self.assertEqual(fps, expected)
 
+    def test_extract(self):
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
+        visualization = Visualization._from_data_dir(self.data_dir,
+                                                     self.provenance)
+        visualization.save(fp)
+
+        Visualization.extract(fp)
+
+        contents = [
+            'visualization/VERSION',
+            'visualization/metadata.yaml',
+            'visualization/README.md',
+            'visualization/data/index.html',
+            'visualization/data/css/style.css']
+
+        for fp in contents:
+            expected_fp = os.path.join(tempfile.gettempdir(), fp)
+            self.assertTrue(os.path.exists(expected_fp),
+                            'File %s was not extracted.' % fp)
+
+    def test_extract_alt_output_dir(self):
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
+        visualization = Visualization._from_data_dir(self.data_dir,
+                                                     self.provenance)
+        visualization.save(fp)
+
+        output_dir = os.path.join(self.test_dir.name, 'viz-extract-test')
+        Visualization.extract(fp, output_dir=output_dir)
+
+        contents = [
+            'visualization/VERSION',
+            'visualization/metadata.yaml',
+            'visualization/README.md',
+            'visualization/data/index.html',
+            'visualization/data/css/style.css']
+
+        for fp in contents:
+            expected_fp = os.path.join(output_dir, fp)
+            self.assertTrue(os.path.exists(expected_fp),
+                            'File %s was not extracted.' % fp)
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime/sdk/visualization.py
+++ b/qiime/sdk/visualization.py
@@ -8,6 +8,8 @@
 
 import distutils.dir_util
 import uuid
+import glob
+import os.path
 
 import qiime.core.archiver
 import qiime.core.result_base
@@ -33,3 +35,7 @@ class Visualization(qiime.core.result_base.ResultBase):
         # shutil.copytree doesn't allow the destination directory to exist.
         viz._archiver.save_data(data_dir, distutils.dir_util.copy_tree)
         return viz
+
+    def get_indices(self):
+        indices = glob.glob(os.path.join(self._archiver._data_dir, 'index.*'))
+        return {os.path.join('data', os.path.split(fp)[1]) for fp in indices}

--- a/qiime/sdk/visualization.py
+++ b/qiime/sdk/visualization.py
@@ -8,8 +8,6 @@
 
 import distutils.dir_util
 import uuid
-import glob
-import os.path
 
 import qiime.core.archiver
 import qiime.core.result_base
@@ -36,6 +34,5 @@ class Visualization(qiime.core.result_base.ResultBase):
         viz._archiver.save_data(data_dir, distutils.dir_util.copy_tree)
         return viz
 
-    def get_indices(self):
-        indices = glob.glob(os.path.join(self._archiver._data_dir, 'index.*'))
-        return {os.path.join('data', os.path.split(fp)[1]) for fp in indices}
+    def get_index_paths(self):
+        return self._archiver.get_index_paths()


### PR DESCRIPTION
This is ready for review. 

Here's how I envision using this:

```python
In [1]: from qiime.sdk import Visualization

In [2]: Visualization.get_index_paths('pd-compare.qzv')
Out[2]: {'html': 'pd-compare/data/index.html'}

In [3]: Visualization.extract('pd-compare.qzv', '.')
Out[3]: '.'

In [5]: index_paths = Visualization.get_index_paths('pd-compare.qzv')

In [6]: output_dir = Visualization.extract('pd-compare.qzv', '.')

In [9]: import os

In [12]: html_path = os.path.join(output_dir, index_paths['html'])

In [13]: os.path.exists(html_path)
Out[13]: True
```