### PR TITLE
ENH/BUG: add Artifact/Visualization.peek for quick inspection of archives

### DIFF
--- a/qiime/core/result_base.py
+++ b/qiime/core/result_base.py
@@ -20,6 +20,10 @@ class ResultBase(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @classmethod
+    def peek(cls, filepath):
+        return qiime.core.archiver.Archiver.peek(filepath)
+
+    @classmethod
     def load(cls, filepath):
         result = cls.__new__(cls)
         result._archiver = qiime.core.archiver.Archiver.load(filepath)
@@ -43,10 +47,10 @@ class ResultBase(metaclass=abc.ABCMeta):
         return self._archiver.uuid
 
     def __init__(self):
-        class_name = self.__class__.__name__
         raise NotImplementedError(
-            "%s constructor is private, use `%s.load`." %
-            (class_name, class_name))
+            "%(classname)s constructor is private, use `%(classname)s.load` "
+            "or `%(classname)s.peek`."
+            % {'classname': self.__class__.__name__})
 
     def __new__(cls):
         result = object.__new__(cls)

--- a/qiime/sdk/artifact.py
+++ b/qiime/sdk/artifact.py
@@ -6,6 +6,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import functools
 import uuid
 
 import qiime.core.archiver
@@ -20,7 +21,7 @@ class Artifact(qiime.core.result_base.ResultBase):
         if not (qiime.core.type.is_semantic_type(type_) and
                 type_.is_concrete()):
             error_suffix = ""
-            if type_ is qiime.core.type.Visualization:
+            if type_ == qiime.core.type.Visualization:
                 error_suffix = " Use qiime.sdk.Visualization with this type."
             raise TypeError(
                 "An artifact requires a concrete semantic type, not type %r.%s"
@@ -34,45 +35,44 @@ class Artifact(qiime.core.result_base.ResultBase):
         ----------
         view : Python object
             View to serialize.
-        type_ : qiime.plugin.Type or str
+        type_ : qiime.plugin.Type
             Concrete semantic type of the artifact.
         provenance : qiime.sdk.Provenance
             Artifact provenance.
 
         """
+        cls._assert_valid_type(type_)
+        data_layout = cls._get_data_layout(type_)
+        view_type = type(view)
+        # TODO better error handling for when `view` cannot be written to
+        # `type_` data layout.
+        writer = data_layout.writers[view_type]
+        writer = functools.partial(writer, view)
+
         artifact = cls.__new__(cls)
-        artifact._archiver = qiime.core.archiver.Archiver(uuid.uuid4(), type_,
-                                                          provenance)
-        artifact._assert_valid_type(artifact.type)
-        # TODO do some validation, such as making sure `view` can be
-        # written to `type_` data layout.
-        artifact._save_view(view)
+        artifact._archiver = qiime.core.archiver.Archiver(
+            uuid.uuid4(), type_, provenance, data_initializer=writer)
         return artifact
 
-    def _save_view(self, view):
-        data_layout = self._get_data_layout()
-        view_type = type(view)
-        writer = data_layout.writers[view_type]
-        self._archiver.save_data(view, writer)
-
-    def _get_data_layout(self):
+    @classmethod
+    def _get_data_layout(cls, type_):
         pm = qiime.sdk.PluginManager()
 
         data_layout = None
         for semantic_type, datalayout in \
                 pm.semantic_type_to_data_layouts.items():
-            if self.type <= semantic_type:
+            if type_ <= semantic_type:
                 data_layout = datalayout
                 break
 
         if data_layout is None:
             raise TypeError(
                 "Artifact semantic type %r does not have a compatible data "
-                "layout." % self.type)
+                "layout." % type_)
 
         return data_layout
 
     def view(self, view_type):
-        data_layout = self._get_data_layout()
+        data_layout = self._get_data_layout(self.type)
         reader = data_layout.readers[view_type]
         return self._archiver.load_data(reader)


### PR DESCRIPTION
Solves bug in Artifact/Visualization.load where previously the archive filepath was extracted on demand, resulting in buggy behavior if the filepath was deleted or modified after loading but prior to extraction. This problem is not easily solvable in a cross-platform compatible way so a new `.peek()` classmethod is provided to quickly retrieve an archive's metadata (e.g. UUID, type, and provenance) without extracting. `.load()` now extracts immediately.

Fixes #24.