### PR TITLE
FIX: Notify users of invalid matplotlib backend

### DIFF
--- a/qiime/sdk/visualizer.py
+++ b/qiime/sdk/visualizer.py
@@ -158,6 +158,15 @@ class Visualizer:
         # TODO `async` execution has some problems with garbage-collection in
         # the subprocess given certain inputs. Needs further investigation.
         def async_wrapper(*args, **kwargs):
+            # TODO handle this better in the future, but stop the massive error
+            # caused by MacOSX async runs for now.
+            try:
+                import matplotlib as plt
+                if plt.rcParams['backend'] == 'MacOSX':
+                    raise EnvironmentError(backend_error_template %
+                                           plt.matplotlib_fname())
+            except ImportError:
+                pass
             args = args[1:]
             pool = concurrent.futures.ProcessPoolExecutor(max_workers=1)
             future = pool.submit(self, *args, **kwargs)
@@ -262,4 +271,10 @@ markdown_source_template = """
 ```python
 %(source)s
 ```
+"""
+
+backend_error_template = """
+Your current matplotlib backend (MacOSX) does not work with async calls.
+A recommended backend is Agg, and can be changed by modifying your
+matplotlibrc "backend" parameter, which can be found at: \n\n %s
 """


### PR DESCRIPTION
Temporary solution for #73


```bash
In [2]: from qiime.plugin.feature_table.visualizers import summarize

In [3]: from qiime.sdk import Artifact

In [4]: summarize.async(table=Artifact.load('feature-table-frequency.qza')).result()
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-4-a9c7a68dedce> in <module>()
----> 1 summarize.async(table=Artifact.load('feature-table-frequency.qza')).result()

<decorator-gen-140> in summarize(table)

/Users/Develop/Developer/work/qiime2/qiime/sdk/visualizer.py in async_wrapper(*args, **kwargs)
    164             if plt.rcParams['backend'] == 'MacOSX':
    165                 raise EnvironmentError(backend_error_template %
--> 166                                        plt.matplotlib_fname())
    167             args = args[1:]
    168             pool = concurrent.futures.ProcessPoolExecutor(max_workers=1)

OSError: 
Your current matplotlib backend (MacOSX) does not work with async calls.
A recommended backend is Agg, and can be changed by modifying your
matplotlibrc "backend" parameter, which can be found at: 

 /Users/Develop/anaconda/envs/qiime_studio/lib/python3.5/site-packages/matplotlib/mpl-data/matplotlibrc
```