### PR TITLE
TST: Check Archiver file encoding and decoding uses UTF-8.

### DIFF
--- a/qiime/core/archiver.py
+++ b/qiime/core/archiver.py
@@ -19,7 +19,6 @@ import qiime.sdk
 from .util import parse_type
 
 
-# TODO use utf-8 encoding when reading/writing files
 class Archiver:
     # This class will likely defer to one of many ArchiveFormats in the future.
     # There's only one supported archive format currently.
@@ -74,7 +73,7 @@ class Archiver:
         version_path = os.path.join(root_dir, cls._VERSION_FILENAME)
         with zf.open(version_path) as bytes_fh:
             with io.TextIOWrapper(bytes_fh, newline=None,
-                                  encoding='utf-8') as fh:
+                                  encoding='utf-8', errors='strict') as fh:
                 return fh.read().rstrip('\n')
 
     @classmethod
@@ -82,7 +81,7 @@ class Archiver:
         metadata_path = os.path.join(root_dir, cls._METADATA_FILENAME)
         with zf.open(metadata_path) as bytes_fh:
             with io.TextIOWrapper(bytes_fh, newline=None,
-                                  encoding='utf-8') as fh:
+                                  encoding='utf-8', errors='strict') as fh:
                 metadata = yaml.safe_load(fh)
 
         uuid_ = cls._parse_uuid(metadata['uuid'])
@@ -211,12 +210,13 @@ class Archiver:
                     zf.write(abspath, arcname=archive_path)
 
     def _save_version(self, zf, root_dir):
+        version = '%s\n' % self._VERSION
         zf.writestr(os.path.join(root_dir, self._VERSION_FILENAME),
-                    '%s\n' % self._VERSION)
+                    version.encode('utf-8'))
 
     def _save_readme(self, zf, root_dir):
         zf.writestr(os.path.join(root_dir, self._README_FILENAME),
-                    _README_TEXT)
+                    _README_TEXT.encode('utf-8'))
 
     # TODO clean up metadata yaml formatting. It currently dumps Python
     # objects, `yaml.safe_dump` call needs to be updated to format lists and
@@ -228,7 +228,7 @@ class Archiver:
             'provenance': self._formatted_provenance()
         })
         zf.writestr(os.path.join(root_dir, self._METADATA_FILENAME),
-                    metadata_bytes)
+                    metadata_bytes.encode('utf-8'))
 
     def _formatted_uuid(self):
         return str(self.uuid)

--- a/qiime/core/tests/__init__.py
+++ b/qiime/core/tests/__init__.py
@@ -1,0 +1,7 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------

--- a/qiime/core/tests/test_archiver.py
+++ b/qiime/core/tests/test_archiver.py
@@ -1,0 +1,127 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import io
+import os
+import tempfile
+import unittest
+import zipfile
+
+from qiime.core.archiver import Archiver
+
+
+class TestArchiver(unittest.TestCase):
+    def setUp(self):
+        prefix = "qiime2-test-temp-"
+        self.temp_dir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.root_dir = self.temp_dir.name
+
+        # FakeArchiver is for testing some of the private methods on Archiver
+        # that don't require the full class.
+        class FakeArchiver(Archiver):
+            # Specifically not calling super() because we don't need to
+            # drag any of Archiver's baggage into this.
+            def __init__(self, *args, **kwargs):
+                self._temp_dir = tempfile.mkdtemp(prefix)
+                self._data_dir = os.path.join(self._temp_dir,
+                                              self.DATA_DIRNAME)
+                self._pid = os.getpid()
+                self._uuid = 'foo'
+                self._type = 'bar'
+                self._provenance = 'baz'
+        self.FakeArchiver = FakeArchiver
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_load_version_file_decoding(self):
+        fp = os.path.join(self.root_dir, "bad_data.qza")
+
+        # Bypass Archiver.save to build a faux-qza file with a
+        # non-UTF-8 encoded version file.
+        with zipfile.ZipFile(fp, mode="w",
+                             compression=zipfile.ZIP_DEFLATED,
+                             allowZip64=True) as zf:
+            zf.writestr(os.path.join(self.root_dir,
+                                     Archiver._VERSION_FILENAME),
+                        "version info".encode("utf-16"))
+
+            with self.assertRaises(UnicodeDecodeError):
+                Archiver._load_version(zf, self.root_dir)
+
+    def test_load_metadata_file_decoding(self):
+        fp = os.path.join(self.root_dir, "bad_data.qza")
+
+        # Bypass Archiver.save to build a faux-qza file with a
+        # non-UTF-8 encoded metadata file.
+        with zipfile.ZipFile(fp, mode="w",
+                             compression=zipfile.ZIP_DEFLATED,
+                             allowZip64=True) as zf:
+            zf.writestr(os.path.join(self.root_dir,
+                                     Archiver._METADATA_FILENAME),
+                        "metadata info".encode("utf-16"))
+
+            with self.assertRaises(UnicodeDecodeError):
+                Archiver._load_metadata(zf, self.root_dir)
+
+    def test_save_version_file_encoding(self):
+        archive = self.FakeArchiver()
+        fp = os.path.join(self.root_dir, "archive.qza")
+
+        with zipfile.ZipFile(fp, mode="w",
+                             compression=zipfile.ZIP_DEFLATED,
+                             allowZip64=True) as zf:
+            archive._save_version(zf, self.root_dir)
+
+            # Manually load the saved file with strict errors on (this will
+            # raise a UnicodeDecodeError if there is a mismatch
+            # during decoding).
+            version_path = os.path.join(self.root_dir,
+                                        Archiver._VERSION_FILENAME)
+            with zf.open(version_path) as bytes_fh:
+                with io.TextIOWrapper(bytes_fh, newline=None,
+                                      encoding='utf-8', errors='strict') as fh:
+                    self.assertEqual(fh.read().rstrip('\n'), Archiver._VERSION)
+
+    def test_save_readme_file_encoding(self):
+        archive = self.FakeArchiver()
+        fp = os.path.join(self.root_dir, "archive.qza")
+
+        with zipfile.ZipFile(fp, mode="w",
+                             compression=zipfile.ZIP_DEFLATED,
+                             allowZip64=True) as zf:
+            archive._save_readme(zf, self.root_dir)
+
+            # Manually load the saved file with strict errors on (this will
+            # raise a UnicodeDecodeError if there is a mismatch during
+            # decoding).
+            readme_path = os.path.join(self.root_dir,
+                                       Archiver._README_FILENAME)
+            with zf.open(readme_path) as bytes_fh:
+                with io.TextIOWrapper(bytes_fh, newline=None,
+                                      encoding='utf-8', errors='strict') as fh:
+                    self.assertTrue(fh.read().rstrip('\n'))
+
+    def test_save_metadata_file_encoding(self):
+        archive = self.FakeArchiver()
+        fp = os.path.join(self.root_dir, "archive.qza")
+
+        with zipfile.ZipFile(fp, mode="w",
+                             compression=zipfile.ZIP_DEFLATED,
+                             allowZip64=True) as zf:
+            archive._save_metadata(zf, self.root_dir)
+
+            # Manually load the saved file with strict errors on (this will
+            # raise a UnicodeDecodeError if there is a mismatch during
+            # decoding).
+            metadata_path = os.path.join(self.root_dir,
+                                         Archiver._METADATA_FILENAME)
+            with zf.open(metadata_path) as bytes_fh:
+                with io.TextIOWrapper(bytes_fh, newline=None,
+                                      encoding='utf-8', errors='strict') as fh:
+                    self.assertTrue(fh.read().rstrip('\n'))


### PR DESCRIPTION
This is a quick rough-cut of some tests that check for UTF-8 during encoding and decoding.

- Set `errors='strict'` in existing readers (`_load_version`, `_load_metadata`). This will ensure that a `TypeError` is raised if there is an encoding mismatch. Not sure if we need to raise our own exception at this point, but feel free to comment.
- Manually encode the payloads for the existing writers (`_save_version`, `_save_readme`, `_save_metadata`)

Questions:
- I used a dummy class for testing the relevant Archiver methods discussed above: thoughts on that? Maybe it makes more sense to set up a real Archiver instance for these tests. Let me know.
- Do we want to set a package constant (or class, etc.) that specifies the encoding to use? Right now `'utf-8'` is sprinkled throughout as arguments.
- I didn't touch anything outside of the artifact metadata/info/version domain, let me know if there is something I missed.

Thanks!