### PR TITLE
ENH: Method, validate markdown

### DIFF
--- a/qiime/sdk/method.py
+++ b/qiime/sdk/method.py
@@ -117,19 +117,28 @@ class Method:
 
         input_types = collections.OrderedDict()
         for input_ in metadata['inputs']:
-            # TODO validate each nested dict has exactly two items
             name, type_tuple = list(input_.items())[0]
+            if len(type_tuple) != 2:
+                raise TypeError(
+                    "Bad input section formatting, need two items per key"
+                )
             input_types[name] = self._split_type_tuple(type_tuple, 'semantic')
 
         param_types = collections.OrderedDict()
         for parameter in metadata['parameters']:
-            # TODO validate each nested dict has exactly two items
             name, type_tuple = list(parameter.items())[0]
+            if len(type_tuple) != 2:
+                raise TypeError(
+                    "Bad parameters section formatting, need two items per key"
+                )
             param_types[name] = self._split_type_tuple(type_tuple, 'primitive')
         output_types = collections.OrderedDict()
         for output in metadata['outputs']:
-            # TODO validate each nested dict has exactly two items
             name, type_tuple = list(output.items())[0]
+            if len(type_tuple) != 2:
+                raise TypeError(
+                    "Bad outputs section formatting, need two items per key"
+                )
             output_types[name] = self._split_type_tuple(type_tuple, 'semantic')
 
         signature = qtype.Signature(input_types, param_types, output_types)

--- a/qiime/sdk/tests/data/method_bad_input_section.md
+++ b/qiime/sdk/tests/data/method_bad_input_section.md
@@ -1,0 +1,17 @@
+---
+name: Bad markdown
+description: "incorrectly formatted inputs"
+inputs:
+    - ints1:
+        - IntSequence1 | IntSequence2
+        - list
+        - Oops
+parameters:
+    - int1:
+        - Int
+        - int
+outputs:
+    - concatenated_ints:
+        - IntSequence1
+        - list
+---

--- a/qiime/sdk/tests/data/method_bad_outputs_section.md
+++ b/qiime/sdk/tests/data/method_bad_outputs_section.md
@@ -1,0 +1,17 @@
+---
+name: Bad markdown
+description: "incorrectly formatted outputs"
+inputs:
+    - ints1:
+        - IntSequence1 | IntSequence2
+        - list
+parameters:
+    - int1:
+        - Int
+        - int
+outputs:
+    - concatenated_ints:
+        - IntSequence1
+        - list
+        - Oops
+---

--- a/qiime/sdk/tests/data/method_bad_parameters_section.md
+++ b/qiime/sdk/tests/data/method_bad_parameters_section.md
@@ -1,0 +1,17 @@
+---
+name: Bad markdown
+description: "incorrectly formatted parameters"
+inputs:
+    - ints1:
+        - IntSequence1 | IntSequence2
+        - list
+parameters:
+    - int1:
+        - Int
+        - int
+        - Oops
+outputs:
+    - concatenated_ints:
+        - IntSequence1
+        - list
+---

--- a/qiime/sdk/tests/test_method.py
+++ b/qiime/sdk/tests/test_method.py
@@ -9,6 +9,7 @@
 import collections
 import concurrent.futures
 import inspect
+import pkg_resources
 import unittest
 import uuid
 
@@ -373,6 +374,27 @@ class TestMethod(unittest.TestCase):
             self.assertEqual(result.type, IntSequence1)
             self.assertEqual(result.view(list),
                              [10, 20, 0, 42, 43, 99, -22, 55, 1])
+
+    def test_markdown_input_section_validation(self):
+        fp = pkg_resources.resource_filename(
+            'qiime.sdk.tests', 'data/method_bad_input_section.md')
+
+        with self.assertRaisesRegex(TypeError, 'input section'):
+            Method.from_markdown(fp)
+
+    def test_markdown_parameters_section_validation(self):
+        fp = pkg_resources.resource_filename(
+            'qiime.sdk.tests', 'data/method_bad_parameters_section.md')
+
+        with self.assertRaisesRegex(TypeError, 'parameters section'):
+            Method.from_markdown(fp)
+
+    def test_markdown_outputs_section_validation(self):
+        fp = pkg_resources.resource_filename(
+            'qiime.sdk.tests', 'data/method_bad_outputs_section.md')
+
+        with self.assertRaisesRegex(TypeError, 'outputs section'):
+            Method.from_markdown(fp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds basic checks for length of `type_tuple`, raises an exception if value is not two items long.

Questions:
- Do we need to raise separate errors for each metadata section? Or, could this be collapsed down into exception handling in `_split_type_tuple()`?
- If we are keeping the handling as-is, I imagine the error text could use a tune-up. Thoughts?
- Instead of saving temp MD files in the tests, should I be building this up as a permanent bad example in `qiime.core.testing`?

Thanks!