### PR TITLE
ENH: Visualizers should not return anything

### DIFF
--- a/qiime/sdk/tests/test_visualizer.py
+++ b/qiime/sdk/tests/test_visualizer.py
@@ -281,6 +281,20 @@ class TestVisualizer(unittest.TestCase):
             }
             self.assertEqual(fps, expected)
 
+    def test_visualizer_callable_output(self):
+        # Callable returns a value from `return_vals`
+        return_vals = (True, False, [], {}, '', 0, 0.0)
+        for return_val in return_vals:
+            visualizer = Visualizer.from_function(
+                lambda output_dir: return_val, {}, {}, '', ''
+            )
+            with self.assertRaisesRegex(TypeError, "should not return"):
+                visualizer()
+
+        # Callable returns None (default function return)
+        visualizer = Visualizer.from_function(lambda output_dir: None,
+                                              {}, {}, '', '')
+        visualizer()  # Should not raise an exception
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime/sdk/visualizer.py
+++ b/qiime/sdk/visualizer.py
@@ -220,8 +220,11 @@ class Visualizer:
 
             # TODO use user-configured temp dir
             with tempfile.TemporaryDirectory('qiime2-temp-') as temp_dir:
-                # TODO make sure _callable doesn't return anything
-                self._callable(output_dir=temp_dir, **view_args)
+                ret_val = self._callable(output_dir=temp_dir, **view_args)
+                if ret_val is not None:
+                    raise TypeError(
+                        "Visualizer %r should not return anything. "
+                        "Received %r as a return value." % (self, ret_val))
                 visualization = qiime.sdk.Visualization._from_data_dir(
                     temp_dir, provenance)
                 visualization._orphan(self._pid)


### PR DESCRIPTION
Visualizers should only return `None` (Python implicit return value when not otherwise specified). This adds a quick check when calling the visualizer function, and if a value other than `None` is returned it raises a `ValueError` exception.

Questions:
- Thoughts on the verbiage for the exception?

Thanks!