### PR TITLE
DOC: Fix LICENSE holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, biocore
+Copyright (c) 2016, QIIME 2 Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
LICENSE incorrectly stated it was under biocore.