### PR TITLE
ENH: add PluginManager.get_data_layout()

### DIFF
--- a/qiime/sdk/result.py
+++ b/qiime/sdk/result.py
@@ -140,7 +140,8 @@ class Artifact(Result):
                 "An artifact requires a concrete semantic type, not type %r."
                 % type)
 
-        data_layout = cls._get_data_layout(type)
+        pm = qiime.sdk.PluginManager()
+        data_layout = pm.get_data_layout(type)
         data_layout.validate(path)
 
         if os.path.isfile(path):
@@ -188,7 +189,8 @@ class Artifact(Result):
                 "`provenance` must be None or an instance of "
                 "qiime.sdk.Provenance.")
 
-        data_layout = cls._get_data_layout(type_)
+        pm = qiime.sdk.PluginManager()
+        data_layout = pm.get_data_layout(type_)
         view_type = type(view)
         # TODO better error handling for when `view` cannot be written to
         # `type_` data layout.
@@ -200,26 +202,9 @@ class Artifact(Result):
             uuid.uuid4(), type_, provenance, data_initializer=writer)
         return artifact
 
-    @classmethod
-    def _get_data_layout(cls, type_):
-        pm = qiime.sdk.PluginManager()
-
-        data_layout = None
-        for semantic_type, datalayout in \
-                pm.semantic_type_to_data_layouts.items():
-            if type_ <= semantic_type:
-                data_layout = datalayout
-                break
-
-        if data_layout is None:
-            raise TypeError(
-                "Artifact semantic type %r does not have a compatible data "
-                "layout." % type_)
-
-        return data_layout
-
     def view(self, view_type):
-        data_layout = self._get_data_layout(self.type)
+        pm = qiime.sdk.PluginManager()
+        data_layout = pm.get_data_layout(self.type)
         reader = data_layout.readers[view_type]
         return self._archiver.load_data(reader)
 

--- a/qiime/sdk/tests/test_plugin_manager.py
+++ b/qiime/sdk/tests/test_plugin_manager.py
@@ -67,15 +67,17 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(types['Mapping'], ('dummy-plugin', Mapping))
         self.assertEqual(types['FourInts'], ('dummy-plugin', FourInts))
 
-    def test_semantic_type_to_data_layouts(self):
-        type_to_layouts = self.pm.semantic_type_to_data_layouts
+    def test_get_data_layout(self):
+        self.assertIsInstance(
+            self.pm.get_data_layout(IntSequence1), DataLayout)
+        self.assertIsInstance(
+            self.pm.get_data_layout(IntSequence2), DataLayout)
+        self.assertIsInstance(
+            self.pm.get_data_layout(Mapping), DataLayout)
+        self.assertIsInstance(
+            self.pm.get_data_layout(FourInts), DataLayout)
 
-        self.assertIsInstance(type_to_layouts[IntSequence1], DataLayout)
-        self.assertIsInstance(type_to_layouts[IntSequence2], DataLayout)
-        self.assertIsInstance(type_to_layouts[Mapping], DataLayout)
-        self.assertIsInstance(type_to_layouts[FourInts], DataLayout)
-
-        data_layout = type_to_layouts[Mapping]
+        data_layout = self.pm.get_data_layout(Mapping)
 
         self.assertEqual(data_layout.name, 'mapping')
         self.assertEqual(data_layout.version, 1)


### PR DESCRIPTION
Moved private Artifact._get_data_layout to PluginManager as this functionality is generally useful (e.g. q2-types unit tests need access to it).