### PR TITLE
ENH: Add class-level extensions to Artifact, Visualization

### DIFF
--- a/qiime/core/util.py
+++ b/qiime/core/util.py
@@ -7,6 +7,8 @@
 # ----------------------------------------------------------------------------
 
 import re
+import contextlib
+import warnings
 
 
 def tuplize(x):
@@ -93,3 +95,16 @@ def parse_type(string, expect=None):
 # Makes it possible to programmatically detect when a type doesn't exist.
 class UnknownTypeError(TypeError):
     pass
+
+
+@contextlib.contextmanager
+def warning():
+    def _warnformat(msg, category, filename, lineno, file=None, line=None):
+        return '%s:%s: %s: %s\n' % (filename, lineno, category.__name__, msg)
+
+    default_warn_format = warnings.formatwarning
+    try:
+        warnings.formatwarning = _warnformat
+        yield warnings.warn
+    finally:
+        warnings.formatwarning = default_warn_format

--- a/qiime/sdk/result.py
+++ b/qiime/sdk/result.py
@@ -17,6 +17,7 @@ import uuid
 import qiime.sdk
 import qiime.core.archiver
 import qiime.core.type
+import qiime.core.util
 
 # Note: Result, Artifact, and Visualization classes are in this file to avoid
 # circular dependencies between Result and its subclasses. Result is tightly
@@ -118,6 +119,8 @@ class Result:
 
 
 class Artifact(Result):
+    extension = '.qza'
+
     @classmethod
     def _is_valid_type(cls, type_):
         if qiime.core.type.is_semantic_type(type_) and type_.is_concrete():
@@ -223,8 +226,17 @@ class Artifact(Result):
         reader = data_layout.readers[view_type]
         return self._archiver.load_data(reader)
 
+    def save(self, filepath):
+        if not filepath.endswith(self.extension):
+            with qiime.core.util.warning() as warn:
+                warn(_result_extension_warning_template.format(
+                     'Artifact', self.extension))
+        super().save(filepath)
+
 
 class Visualization(Result):
+    extension = '.qzv'
+
     @classmethod
     def _is_valid_type(cls, type_):
         if type_ == qiime.core.type.Visualization:
@@ -258,3 +270,16 @@ class Visualization(Result):
                 else:
                     result[ext] = relpath if relative else abspath
         return result
+
+    def save(self, filepath):
+        if not filepath.endswith(self.extension):
+            with qiime.core.util.warning() as warn:
+                warn(_result_extension_warning_template.format(
+                     'Visualization', self.extension))
+        super().save(filepath)
+
+
+_result_extension_warning_template = "The most widely supported " \
+    "and recommended file extension for a QIIME 2 {0} is '{1}'. The {0} "\
+    "will still be created, but the provided file extension can not be " \
+    "guaranteed to work with all QIIME 2 interfaces."

--- a/qiime/sdk/tests/test_visualization.py
+++ b/qiime/sdk/tests/test_visualization.py
@@ -245,7 +245,7 @@ class TestVisualization(unittest.TestCase):
 
     def test_load_with_archive_filepath_modified(self):
         # Save a visualization for use in the following test case.
-        fp = os.path.join(self.test_dir.name, 'visualization.qza')
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
         Visualization._from_data_dir(self.data_dir, None).save(fp)
 
         # Load the visualization from a filepath then save a different
@@ -385,7 +385,7 @@ class TestVisualization(unittest.TestCase):
 
     def test_peek(self):
         visualization = Visualization._from_data_dir(self.data_dir, None)
-        fp = os.path.join(self.test_dir.name, 'visualization.qza')
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
         visualization.save(fp)
 
         metadata = Visualization.peek(fp)
@@ -398,7 +398,7 @@ class TestVisualization(unittest.TestCase):
     def test_peek_with_provenance(self):
         visualization = Visualization._from_data_dir(self.data_dir,
                                                      self.provenance)
-        fp = os.path.join(self.test_dir.name, 'visualization.qza')
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
         visualization.save(fp)
 
         metadata = Visualization.peek(fp)


### PR DESCRIPTION
Allows interfaces to use `Artifact.extension` or `Visualization.extension` to access the currently supported/recommended file extensions. 

Fix a few tests that were found to be using `visualization.qza` instead of `.qzv` through the warnings.

Example Output:

```shell
>>> Artifact.load('/Users/Develop/Developer/work/q2-types/q2_types/tests/data/feature-table-frequency.qza').save('test')
/Users/Develop/Developer/work/qiime2/qiime/sdk/result.py:236: UserWarning: The most widely supported and recommended file extension for a QIIME 2 Artifact is '.qza'. The Artifact will still be created, but the provided file extension can not be guaranteed to work with all QIIME 2 interfaces.
```

Resolves #7
Resolves #59