### PR TITLE
ENH: support user-configured temporary directory

### DIFF
--- a/qiime/sdk/config/__init__.py
+++ b/qiime/sdk/config/__init__.py
@@ -1,0 +1,12 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from .tempfile import gettempdir, mkdtemp, TemporaryDirectory
+from .util import reset_config
+
+__all__ = ['gettempdir', 'mkdtemp', 'TemporaryDirectory', 'reset_config']

--- a/qiime/sdk/config/_config.py
+++ b/qiime/sdk/config/_config.py
@@ -1,0 +1,17 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+import click
+import configparser
+import os
+
+CONFIG_DIR = click.get_app_dir('QIIME 2', roaming=False, force_posix=False)
+VERSION_DIR = os.path.join(CONFIG_DIR, '2.0.x')
+CONFIG_FILE = os.path.join(VERSION_DIR, 'config.ini')
+
+CONFIG = configparser.ConfigParser()
+CONFIG.read(CONFIG_FILE)

--- a/qiime/sdk/config/boilerplate/config.ini
+++ b/qiime/sdk/config/boilerplate/config.ini
@@ -1,0 +1,10 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+[Paths]
+# temp_dir: /path/to/temporary/directory

--- a/qiime/sdk/config/tempfile.py
+++ b/qiime/sdk/config/tempfile.py
@@ -1,0 +1,25 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+import tempfile
+
+from ._config import CONFIG
+
+
+def gettempdir():
+    paths = CONFIG['Paths'] if 'Paths' in CONFIG else {}
+    return paths.get('temp_dir', tempfile.gettempdir())
+
+
+def mkdtemp(suffix=None):
+    return tempfile.mkdtemp(suffix, prefix='q2-', dir=gettempdir())
+
+
+class TemporaryDirectory(tempfile.TemporaryDirectory):
+
+    def __init__(self, suffix=None):
+        super().__init__(suffix=suffix, prefix='q2-', dir=gettempdir())

--- a/qiime/sdk/config/util.py
+++ b/qiime/sdk/config/util.py
@@ -1,0 +1,25 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+import os
+import shutil
+
+from ._config import VERSION_DIR
+
+__BOILERPLATE_DIR = os.path.join(os.path.dirname(__file__), 'boilerplate')
+
+
+def reset_config():
+    try:
+        shutil.rmtree(VERSION_DIR)
+    except FileNotFoundError:
+        pass
+    shutil.copytree(__BOILERPLATE_DIR, VERSION_DIR)
+
+
+def config_location():
+    print(os.path.join(VERSION_DIR, 'config.ini'))


### PR DESCRIPTION
- [x] Add `qiime.sdk.config`
  - [x] `gettempdir()`
  - [x] `mkdtemp()`
  - [x] `TemporaryDirectory()`

Resolves #12 

RFCs meeting additions:
- [x] Click's get_app_dir (roaming=False, posix=False)
- [ ] QIIME2_CONFIG_DIR env override
- [ ] Reset config used in setuptools hook
- [ ] SDK api get config location
- [x] Train releases have version-specific config
- [ ] Config validation for custom configs
- [ ] Backwards compatible: attempt to migrate, fallback on custom config validation
- [ ] API to get current dir 

**_This is on hold pending RFC**_: qiime2/rfcs/pull/5
