### PR TITLE
ENH: added Bool, addresses #115

### DIFF
--- a/qiime/core/type/__init__.py
+++ b/qiime/core/type/__init__.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from .semantic import SemanticType, is_semantic_type, Properties
-from .primitive import (Str, Int, Float, Color, Dict, Set, Metadata,
+from .primitive import (Str, Int, Float, Color, Dict, Set, Metadata, Bool,
                         MetadataCategory, List, Range, Choices, Arguments,
                         is_primitive_type)
 from .grammar import is_qiime_type
@@ -16,7 +16,7 @@ from .signature import Signature
 
 __all__ = [
     'SemanticType', 'is_qiime_type', 'is_semantic_type', 'is_primitive_type',
-    'Str', 'Int', 'Float', 'Color', 'Dict', 'Set', 'List', 'Metadata',
+    'Str', 'Int', 'Float', 'Bool', 'Color', 'Dict', 'Set', 'List', 'Metadata',
     'MetadataCategory', 'Visualization', 'Signature', 'Properties', 'Range',
     'Choices', 'Arguments'
 ]

--- a/qiime/core/type/primitive.py
+++ b/qiime/core/type/primitive.py
@@ -349,6 +349,27 @@ class _Float(_Primitive):
 Float = _Float('Float')
 
 
+class _Bool(_Primitive):
+    _valid_predicates = {Arguments, }
+
+    def _is_element_(self, value):
+        return isinstance(value, bool)
+
+    def decode(self, string):
+        if string not in ('false', 'true'):
+            raise TypeError("%s is neither 'true' or 'false'" % string)
+
+        return string == 'true'
+
+    def encode(self, value):
+        if value:
+            return 'true'
+        else:
+            return 'false'
+
+Bool = _Bool('Bool')
+
+
 class _Color(type(Str)):
     def _is_element_(self, value):
         # Regex from: http://stackoverflow.com/a/1636354/579416

--- a/qiime/plugin/__init__.py
+++ b/qiime/plugin/__init__.py
@@ -13,9 +13,9 @@ from .template import plugin_init
 
 from qiime.core.type import (SemanticType, Int, Str, Float, Color, Metadata,
                              MetadataCategory, Properties, Range, Choices,
-                             Arguments)
+                             Arguments, Bool)
 
 
 __all__ = ['DataLayout', 'FileFormat', 'Plugin', 'SemanticType', 'Int', 'Str',
            'Float', 'Color', 'Metadata', 'MetadataCategory', 'Properties',
-           'Range', 'Choices', 'Arguments', 'plugin_init']
+           'Range', 'Choices', 'Arguments', 'plugin_init', 'Bool']


### PR DESCRIPTION
I'm still green with the codebase, so apologize if this is off-base. I believe it's to the expectation. Have support for `int`, where `0 is False` and any other number (positive or negative) is `True`:

```python
In [1]: from primitive import Bool

In [2]: Bool.decode("10")
Out[2]: True

In [3]: Bool.decode("0")
Out[3]: False

In [4]: Bool.decode("True")
Out[4]: True

In [5]: Bool.decode("False")
Out[5]: False
```

Note: Python's `bool` casting is unexpected hence the direct checks against `"0"` and `"False"`. See below, where the expectation is that `bool` would operate like `int` but it actually just appears to test for a non-empty string:

```python
In [1]: bool("True")
Out[1]: True

In [2]: bool("False")
Out[2]: True

In [3]: bool("")
Out[3]: False
```