### PR TITLE
ENH: Actions return Results object regardless of number of outputs

### DIFF
--- a/qiime/core/callable.py
+++ b/qiime/core/callable.py
@@ -249,15 +249,9 @@ class Callable(metaclass=abc.ABCMeta):
                     "defined in signature: %d != %d" %
                     (len(outputs_tuple), len(self.signature.outputs)))
 
-            # If there is a single output, don't wrap in a Results object to
-            # match how Python handles single return values. Otherwise, wrap in
-            # a Results object mapping output name to value so users have
-            # access to outputs by name or position.
-            if len(outputs_tuple) == 1:
-                return outputs_tuple[0]
-            else:
-                return Results(self.signature.outputs.keys(),
-                               outputs_tuple)
+            # Wrap in a Results object mapping output name to value so users
+            # have access to outputs by name or position.
+            return Results(self.signature.outputs.keys(), outputs_tuple)
 
         callable_wrapper = self._rewrite_wrapper_signature(callable_wrapper)
         self._set_wrapper_properties(callable_wrapper, '__call__')

--- a/qiime/sdk/tests/test_method.py
+++ b/qiime/sdk/tests/test_method.py
@@ -223,6 +223,15 @@ class TestMethod(unittest.TestCase):
         for method in concatenate_ints, concatenate_ints_markdown:
             result = method(artifact1, artifact1, artifact2, 55, 1)
 
+            # Test properties of the `Results` object.
+            self.assertIsInstance(result, tuple)
+            self.assertIsInstance(result, Results)
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result.concatenated_ints.view(list),
+                             [0, 42, 43, 0, 42, 43, 99, -22, 55, 1])
+
+            result = result[0]
+
             self.assertIsInstance(result, Artifact)
             self.assertEqual(result.type, IntSequence1)
 
@@ -258,7 +267,7 @@ class TestMethod(unittest.TestCase):
             # Accepts IntSequence1 | IntSequence2
             artifact3 = Artifact._from_view(IntSequence2, [10, 20],
                                             list, None)
-            result = method(artifact3, artifact1, artifact2, 55, 1)
+            result, = method(artifact3, artifact1, artifact2, 55, 1)
 
             self.assertEqual(result.type, IntSequence1)
             self.assertEqual(result.view(list),
@@ -318,6 +327,15 @@ class TestMethod(unittest.TestCase):
 
         result = merge_mappings(artifact1, artifact2)
 
+        # Test properties of the `Results` object.
+        self.assertIsInstance(result, tuple)
+        self.assertIsInstance(result, Results)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result.merged_mapping.view(dict),
+                         {'foo': 'abc', 'bar': 'def', 'bazz': 'abc'})
+
+        result = result[0]
+
         self.assertIsInstance(result, Artifact)
         self.assertEqual(result.type, Mapping)
 
@@ -352,6 +370,15 @@ class TestMethod(unittest.TestCase):
 
             self.assertIsInstance(future, concurrent.futures.Future)
             result = future.result()
+
+            # Test properties of the `Results` object.
+            self.assertIsInstance(result, tuple)
+            self.assertIsInstance(result, Results)
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result.concatenated_ints.view(list),
+                             [0, 42, 43, 0, 42, 43, 99, -22, 55, 1])
+
+            result = result[0]
 
             self.assertIsInstance(result, Artifact)
             self.assertEqual(result.type, IntSequence1)
@@ -388,7 +415,7 @@ class TestMethod(unittest.TestCase):
             # Accepts IntSequence1 | IntSequence2
             artifact3 = Artifact._from_view(IntSequence2, [10, 20], list, None)
             future = method.async(artifact3, artifact1, artifact2, 55, 1)
-            result = future.result()
+            result, = future.result()
 
             self.assertEqual(result.type, IntSequence1)
             self.assertEqual(result.view(list),

--- a/qiime/sdk/tests/test_visualizer.py
+++ b/qiime/sdk/tests/test_visualizer.py
@@ -17,6 +17,7 @@ import zipfile
 
 import qiime.plugin
 import qiime.core.type
+from qiime.core.callable import Results
 from qiime.core.type import VisualizerSignature
 from qiime.sdk import Artifact, Visualization, Provenance, Action
 
@@ -159,6 +160,14 @@ class TestVisualizer(unittest.TestCase):
 
         result = mapping_viz(artifact1, artifact2, 'Key', 'Value')
 
+        # Test properties of the `Results` object.
+        self.assertIsInstance(result, tuple)
+        self.assertIsInstance(result, Results)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result.visualization, result[0])
+
+        result = result[0]
+
         self.assertIsInstance(result, Visualization)
         self.assertEqual(result.type, qiime.core.type.Visualization)
 
@@ -201,6 +210,14 @@ class TestVisualizer(unittest.TestCase):
                                        list, None)
 
         result = most_common_viz(artifact)
+
+        # Test properties of the `Results` object.
+        self.assertIsInstance(result, tuple)
+        self.assertIsInstance(result, Results)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result.visualization, result[0])
+
+        result = result[0]
 
         self.assertIsInstance(result, Visualization)
         self.assertEqual(result.type, qiime.core.type.Visualization)
@@ -245,6 +262,14 @@ class TestVisualizer(unittest.TestCase):
 
         self.assertIsInstance(future, concurrent.futures.Future)
         result = future.result()
+
+        # Test properties of the `Results` object.
+        self.assertIsInstance(result, tuple)
+        self.assertIsInstance(result, Results)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result.visualization, result[0])
+
+        result = result[0]
 
         self.assertIsInstance(result, Visualization)
         self.assertEqual(result.type, qiime.core.type.Visualization)
@@ -310,7 +335,8 @@ class TestVisualizer(unittest.TestCase):
 
         # Should not raise an exception
         output = visualizer(foo=artifact)
-        self.assertIsInstance(output, Visualization)
+        self.assertIsInstance(output, Results)
+        self.assertIsInstance(output.visualization, Visualization)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now that we have a Results class it is more consistent and easier to reason about if a Results object is always returned from an Action, regardless of the number of outputs. This will also simplify logic in interfaces (e.g. q2cli and qiime-studio).