### PR TITLE
ENH: Artifact/Visualization.save() appends file extension automatically

### DIFF
--- a/qiime/sdk/result.py
+++ b/qiime/sdk/result.py
@@ -42,6 +42,10 @@ class Result:
     API shared by Artifact and Visualization.
 
     """
+
+    # Subclasses must override to provide a file extension.
+    extension = None
+
     @classmethod
     def _is_valid_type(cls, type_):
         """Subclasses should override this method."""
@@ -144,7 +148,10 @@ class Result:
         self._archiver.orphan(pid)
 
     def save(self, filepath):
+        if not filepath.endswith(self.extension):
+            filepath += self.extension
         self._archiver.save(filepath)
+        return filepath
 
 
 class Artifact(Result):
@@ -221,13 +228,6 @@ class Artifact(Result):
         to_type.set_user_owned(result, True)
         return result
 
-    def save(self, filepath):
-        if not filepath.endswith(self.extension):
-            with qiime.core.util.warning() as warn:
-                warn(_result_extension_warning_template.format(
-                     'Artifact', self.extension))
-        super().save(filepath)
-
 
 class Visualization(Result):
     extension = '.qzv'
@@ -265,16 +265,3 @@ class Visualization(Result):
                 else:
                     result[ext] = relpath if relative else abspath
         return result
-
-    def save(self, filepath):
-        if not filepath.endswith(self.extension):
-            with qiime.core.util.warning() as warn:
-                warn(_result_extension_warning_template.format(
-                     'Visualization', self.extension))
-        super().save(filepath)
-
-
-_result_extension_warning_template = "The most widely supported " \
-    "and recommended file extension for a QIIME 2 {0} is '{1}'. The {0} "\
-    "will still be created, but the provided file extension can not be " \
-    "guaranteed to work with all QIIME 2 interfaces."

--- a/qiime/sdk/tests/test_result.py
+++ b/qiime/sdk/tests/test_result.py
@@ -10,7 +10,6 @@ import os
 import tempfile
 import unittest
 import uuid
-import warnings
 
 import qiime.core.type
 from qiime.sdk import Result, Artifact, Visualization, Provenance
@@ -220,29 +219,55 @@ class TestResult(unittest.TestCase):
         self.assertEqual(metadata.provenance, self.provenance)
         self.assertEqual(metadata.uuid, visualization.uuid)
 
-    def test_save_artifact_warning(self):
+    def test_save_artifact_auto_extension(self):
         artifact = Artifact._from_view(FourInts, [0, 0, 42, 1000],
                                        list, self.provenance)
+
+        # No extension.
+        fp = os.path.join(self.test_dir.name, 'artifact')
+        obs_fp = artifact.save(fp)
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.qza')
+
+        # Wrong extension.
         fp = os.path.join(self.test_dir.name, 'artifact.zip')
+        obs_fp = artifact.save(fp)
+        obs_filename = os.path.basename(obs_fp)
 
-        with warnings.catch_warnings(record=True) as w:
-            artifact.save(fp)
+        self.assertEqual(obs_filename, 'artifact.zip.qza')
 
-            self.assertEqual(len(w), 1)
-            self.assertIsInstance(w[0].message, UserWarning)
-            self.assertIn(Artifact.extension, str(w[0].message))
+        # Correct extension.
+        fp = os.path.join(self.test_dir.name, 'artifact.qza')
+        obs_fp = artifact.save(fp)
+        obs_filename = os.path.basename(obs_fp)
 
-    def test_save_visualization_warning(self):
+        self.assertEqual(obs_filename, 'artifact.qza')
+
+    def test_save_visualization_auto_extension(self):
         visualization = Visualization._from_data_dir(self.data_dir,
                                                      self.provenance)
+
+        # No extension.
+        fp = os.path.join(self.test_dir.name, 'visualization')
+        obs_fp = visualization.save(fp)
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.qzv')
+
+        # Wrong extension.
         fp = os.path.join(self.test_dir.name, 'visualization.zip')
+        obs_fp = visualization.save(fp)
+        obs_filename = os.path.basename(obs_fp)
 
-        with warnings.catch_warnings(record=True) as w:
-            visualization.save(fp)
+        self.assertEqual(obs_filename, 'visualization.zip.qzv')
 
-            self.assertEqual(len(w), 1)
-            self.assertIsInstance(w[0].message, UserWarning)
-            self.assertIn(Visualization.extension, str(w[0].message))
+        # Correct extension.
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
+        obs_fp = visualization.save(fp)
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.qzv')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`Artifact/Visualization.save()` now automatically appends the correct file extension (.qza/.qzv) if not present in the filepath that is saved to. A warning is no longer issued if the filepath doesn't have the correct extension. `.save()` returns the filepath that is saved to.