### PR TITLE
ENH: Archiver.save() filepath validation

### DIFF
--- a/qiime/core/archiver.py
+++ b/qiime/core/archiver.py
@@ -206,6 +206,15 @@ class Archiver:
         return loader(self._data_dir)
 
     def save(self, filepath):
+        if filepath == '':
+            raise ValueError("Cannot save to an empty filepath.")
+        if os.path.isdir(filepath):
+            raise ValueError("Cannot save to a directory (%s)." % filepath)
+        if filepath.endswith(os.sep):
+            raise ValueError(
+                "Cannot save to a filepath ending in a path separator (%s)." %
+                filepath)
+
         root_dir = self._get_root_dir(filepath)
 
         with zipfile.ZipFile(filepath, mode='w',


### PR DESCRIPTION
Archiver.save() now validates filepaths to provide useful error messages for common mistakes. Added corresponding unit tests.

Also removed FakeArchiver from unit tests in favor of a real Archiver instance.