### PR TITLE
ENH/REF: add PluginManager.iter_entry_points(), add qiime.sdk.util

### DIFF
--- a/qiime/core/archiver.py
+++ b/qiime/core/archiver.py
@@ -17,7 +17,6 @@ import yaml
 import zipfile
 
 import qiime.sdk
-import qiime.core.util as util
 
 # Allow OrderedDict to be serialized for YAML representation
 yaml.add_representer(collections.OrderedDict, lambda dumper, data:
@@ -166,7 +165,7 @@ class Archiver:
                 "Archive root directory must match UUID present in archive's "
                 "metadata: %r != %r" % (root_dir, str(uuid_)))
 
-        type_ = util.parse_type(metadata['type'])
+        type_ = qiime.sdk.parse_type(metadata['type'])
         provenance = cls._parse_provenance(metadata['provenance'])
         format = metadata['format']
         return uuid_, type_, format, provenance

--- a/qiime/core/util.py
+++ b/qiime/core/util.py
@@ -6,7 +6,6 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import re
 import contextlib
 import warnings
 
@@ -26,98 +25,6 @@ def overrides(cls):
                                  % (func, cls.__name__))
         return func
     return decorator
-
-
-def parse_type(string, expect=None):
-    """Convert a string into a TypeExpression
-
-    Parameters
-    ----------
-    string : str
-        The string type expression to convert into a TypeExpression
-    expect : {'semantic', 'primitive', 'visualization'}, optional
-        Will raise a TypeError if the resulting TypeExpression is not a member
-        of `expect`.
-
-    Returns
-    -------
-    TypeExpression
-
-    Raises
-    ------
-    ValueError
-        Raised when `expect` has an invalid value
-    TypeError
-        Raised when the expression contains invalid characters
-    TypeError
-        Raised when the expression does not result in a member of `expect`
-    UnknownTypeError
-        Raised when unkown types are present in the expression.
-
-    """
-    # Avoid circular imports
-    import qiime.sdk
-    import qiime.core.type as qtype
-
-    if expect is not None and expect not in {'semantic', 'primitive',
-                                             'visualization'}:
-        raise ValueError("`expect` got %r, must be 'semantic', 'primitive',"
-                         " 'visualization', or None." % (expect,))
-
-    if '\n' in string or '\r' in string or ';' in string:
-        raise TypeError("Found multiple statements in type expression %r. Will"
-                        " not evaluate to avoid arbitrary code execution."
-                        % string)
-
-    pm = qiime.sdk.PluginManager()
-    locals_ = {n: getattr(qtype, n) for n in qtype.__all__ if '_' not in n}
-    locals_.update({k: v.semantic_type for k, v in pm.semantic_types.items()})
-
-    try:
-        type_expr = eval(string, {'__builtins__': {}}, locals_)
-        if expect is None:
-            pass
-        elif expect == 'semantic' and qtype.is_semantic_type(type_expr):
-            pass
-        elif expect == 'primitive' and qtype.is_primitive_type(type_expr):
-            pass
-        elif expect == 'visualization' and type_expr == qtype.Visualization:
-            pass
-        else:
-            raise TypeError("Type expression %r is not a %s type."
-                            % (type_expr, expect))
-        return type_expr
-    except NameError as e:
-        # http://stackoverflow.com/a/2270822/579416
-        name, = re.findall("name '(\w+)' is not defined", str(e))
-        raise UnknownTypeError("Name %r is not a defined QIIME type, a plugin"
-                               " may be needed to define it." % name)
-
-
-# Makes it possible to programmatically detect when a type doesn't exist.
-class UnknownTypeError(TypeError):
-    pass
-
-
-def parse_format(format_str):
-    # Avoid circular imports
-    import qiime.sdk
-    from qiime.plugin.model.base import FormatBase
-
-    pm = qiime.sdk.PluginManager()
-    for type_format_record in pm.type_formats:
-        if type_format_record.format.__name__ == format_str:
-            return type_format_record.format
-
-    for input in pm.transformers:
-        if issubclass(input, FormatBase) and input.__name__ == format_str:
-            return input
-        for output in pm.transformers[input]:
-            if (issubclass(output, FormatBase) and
-                    output.__name__ == format_str):
-                return output
-
-    raise TypeError("No format: %s" % format_str)
 
 
 @contextlib.contextmanager

--- a/qiime/sdk/__init__.py
+++ b/qiime/sdk/__init__.py
@@ -10,10 +10,10 @@ from .action import Action
 from .plugin_manager import PluginManager
 from .provenance import Provenance
 from .result import Result, Artifact, Visualization
-from ..core.util import parse_type
+from .util import parse_type, parse_format, UnknownTypeError
 
 __all__ = ['Result', 'Artifact', 'Visualization', 'Action', 'PluginManager',
-           'Provenance', 'parse_type']
+           'Provenance', 'parse_type', 'parse_format', 'UnknownTypeError']
 
 # Various URLs
 CITATION = 'http://www.ncbi.nlm.nih.gov/pubmed/20383131'

--- a/qiime/sdk/result.py
+++ b/qiime/sdk/result.py
@@ -16,7 +16,6 @@ import pathlib
 import qiime.sdk
 import qiime.core.archiver as archiver
 import qiime.core.type
-import qiime.core.util as util
 import qiime.core.transform as transform
 import qiime.plugin.model as model
 
@@ -111,7 +110,7 @@ class Result:
         # Visualization format (currently a string), otherwise special-casing
         # is needed everywhere.
         if not hasattr(self, '__format'):
-            self.__format = util.parse_format(self._archiver.format)
+            self.__format = qiime.sdk.parse_format(self._archiver.format)
         return self.__format
 
     def __init__(self):
@@ -170,7 +169,7 @@ class Artifact(Result):
             type_ = qiime.sdk.parse_type(type_)
 
         if isinstance(view_type, str):
-            view_type = qiime.core.util.parse_format(view_type)
+            view_type = qiime.sdk.parse_format(view_type)
 
         if view_type is None:
             if type(view) is str or isinstance(view, pathlib.PurePath):

--- a/qiime/sdk/util.py
+++ b/qiime/sdk/util.py
@@ -1,0 +1,100 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import re
+
+import qiime.sdk
+import qiime.core.type as qtype
+from qiime.plugin.model.base import FormatBase
+
+
+# Makes it possible to programmatically detect when a type doesn't exist.
+class UnknownTypeError(TypeError):
+    pass
+
+
+def parse_type(string, expect=None):
+    """Convert a string into a TypeExpression
+
+    Parameters
+    ----------
+    string : str
+        The string type expression to convert into a TypeExpression
+    expect : {'semantic', 'primitive', 'visualization'}, optional
+        Will raise a TypeError if the resulting TypeExpression is not a member
+        of `expect`.
+
+    Returns
+    -------
+    TypeExpression
+
+    Raises
+    ------
+    ValueError
+        Raised when `expect` has an invalid value
+    TypeError
+        Raised when the expression contains invalid characters
+    TypeError
+        Raised when the expression does not result in a member of `expect`
+    UnknownTypeError
+        Raised when unkown types are present in the expression.
+
+    """
+    if expect is not None and expect not in {'semantic', 'primitive',
+                                             'visualization'}:
+        raise ValueError("`expect` got %r, must be 'semantic', 'primitive',"
+                         " 'visualization', or None." % (expect,))
+
+    if '\n' in string or '\r' in string or ';' in string:
+        raise TypeError("Found multiple statements in type expression %r. Will"
+                        " not evaluate to avoid arbitrary code execution."
+                        % string)
+
+    pm = qiime.sdk.PluginManager()
+    locals_ = {n: getattr(qtype, n) for n in qtype.__all__ if '_' not in n}
+    locals_.update({k: v.semantic_type for k, v in pm.semantic_types.items()})
+
+    try:
+        type_expr = eval(string, {'__builtins__': {}}, locals_)
+        if expect is None:
+            pass
+        elif expect == 'semantic' and qtype.is_semantic_type(type_expr):
+            pass
+        # TODO optimize codepath for `expect=primitive` and
+        # `expect=visualization` since `PluginManager` is slow and isn't
+        # necessary for these types.
+        elif expect == 'primitive' and qtype.is_primitive_type(type_expr):
+            pass
+        elif expect == 'visualization' and type_expr == qtype.Visualization:
+            pass
+        else:
+            raise TypeError("Type expression %r is not a %s type."
+                            % (type_expr, expect))
+        return type_expr
+    except NameError as e:
+        # http://stackoverflow.com/a/2270822/579416
+        name, = re.findall("name '(\w+)' is not defined", str(e))
+        raise UnknownTypeError("Name %r is not a defined QIIME type, a plugin"
+                               " may be needed to define it." % name)
+
+
+def parse_format(format_str):
+    pm = qiime.sdk.PluginManager()
+    for type_format_record in pm.type_formats:
+        if type_format_record.format.__name__ == format_str:
+            return type_format_record.format
+
+    for input in pm.transformers:
+        if issubclass(input, FormatBase) and input.__name__ == format_str:
+            return input
+        for output in pm.transformers[input]:
+            if (issubclass(output, FormatBase) and
+                    output.__name__ == format_str):
+                return output
+
+    raise TypeError("No format: %s" % format_str)


### PR DESCRIPTION
Added `PluginManager.iter_entry_points()` classmethod for getting unloaded entry points (needed for CLI optimizations).

Moved `qiime.core.util.parse_type/parse_format/UnknownTypeError` to `qiime.sdk.util` (also accessible from `qiime.sdk`). This move was also necessary for CLI optimizations. It also avoids circular import errors that previously had to be worked around. 👌 