### PR TITLE
FIX: Support semantic type registration to multiple formats in TestPluginBase harness

### DIFF
--- a/qiime/plugin/testing.py
+++ b/qiime/plugin/testing.py
@@ -72,7 +72,8 @@ class TestPluginBase(unittest.TestCase):
     def assertSemanticTypeRegisteredToFormat(self, semantic_type, exp_format):
         obs_format = None
         for type_format_record in self.plugin.type_formats:
-            if type_format_record.type_expression == semantic_type:
+            if (type_format_record.type_expression == semantic_type and
+                    exp_format == type_format_record.format):
                 obs_format = type_format_record.format
                 break
 


### PR DESCRIPTION
Found while writing tests for `q2_types.feature_table` subpackage.

It has one type registered to two formats, so with `assertSemanticTypeRegisteredToFormat` grabbing the first result it found it led to random occurences of passing and failing based on how they came out of the dict.

```python
plugin.register_semantic_type_to_format(
    FeatureTable[Frequency | RelativeFrequency | PresenceAbsence],
    artifact_format=BIOMV210DirFmt
)

plugin.register_semantic_type_to_format(
    FeatureTable[Frequency | RelativeFrequency | PresenceAbsence],
    artifact_format=BIOMV100DirFmt
)
```