### PR TITLE
ENH: Add explicit format registration to Plugin objects

### DIFF
--- a/qiime/core/testing/plugin.py
+++ b/qiime/core/testing/plugin.py
@@ -12,9 +12,12 @@ import qiime
 import qiime.plugin
 
 from .format import (
+    IntSequenceFormat,
+    MappingFormat,
+    SingleIntFormat,
     IntSequenceDirectoryFormat,
     MappingDirectoryFormat,
-    FourIntsDirectoryFormat,
+    FourIntsDirectoryFormat
 )
 
 from .type import IntSequence1, IntSequence2, Mapping, FourInts
@@ -37,6 +40,14 @@ dummy_plugin.register_semantic_type(IntSequence1)
 dummy_plugin.register_semantic_type(IntSequence2)
 dummy_plugin.register_semantic_type(Mapping)
 dummy_plugin.register_semantic_type(FourInts)
+
+# Register formats
+dummy_plugin.register_format(IntSequenceFormat)
+dummy_plugin.register_format(MappingFormat)
+dummy_plugin.register_format(SingleIntFormat)
+dummy_plugin.register_format(IntSequenceDirectoryFormat)
+dummy_plugin.register_format(MappingDirectoryFormat)
+dummy_plugin.register_format(FourIntsDirectoryFormat)
 
 
 dummy_plugin.register_semantic_type_to_format(

--- a/qiime/core/testing/plugin.py
+++ b/qiime/core/testing/plugin.py
@@ -36,18 +36,15 @@ dummy_plugin = qiime.plugin.Plugin(
 import_module('qiime.core.testing.transformer')
 
 # Register semantic types
-dummy_plugin.register_semantic_type(IntSequence1)
-dummy_plugin.register_semantic_type(IntSequence2)
-dummy_plugin.register_semantic_type(Mapping)
-dummy_plugin.register_semantic_type(FourInts)
+dummy_plugin.register_semantic_types(IntSequence1, IntSequence2, Mapping,
+                                     FourInts)
 
 # Register formats
-dummy_plugin.register_format(IntSequenceFormat)
-dummy_plugin.register_format(MappingFormat)
-dummy_plugin.register_format(SingleIntFormat)
-dummy_plugin.register_format(IntSequenceDirectoryFormat)
-dummy_plugin.register_format(MappingDirectoryFormat)
-dummy_plugin.register_format(FourIntsDirectoryFormat)
+dummy_plugin.register_formats(
+    IntSequenceFormat, MappingFormat, SingleIntFormat,
+    IntSequenceDirectoryFormat, MappingDirectoryFormat,
+    FourIntsDirectoryFormat
+)
 
 
 dummy_plugin.register_semantic_type_to_format(

--- a/qiime/plugin/plugin.py
+++ b/qiime/plugin/plugin.py
@@ -68,14 +68,15 @@ class Plugin:
         actions.update(self.visualizers)
         return types.MappingProxyType(actions)
 
-    def register_format(self, format):
-        if not issubclass(format, FormatBase):
-            raise TypeError("%r is not a valid format." % format)
-        if format.__name__ in self.formats.keys():
-            raise NameError("%r is already a registered format." % format)
+    def register_formats(self, *formats):
+        for format in formats:
+            if not issubclass(format, FormatBase):
+                raise TypeError("%r is not a valid format." % format)
+            if format.__name__ in self.formats:
+                raise NameError("%r is already a registered format." % format)
 
-        self.formats[format.__name__] = FormatRecord(format=format,
-                                                     plugin=self)
+            self.formats[format.__name__] = FormatRecord(format=format,
+                                                         plugin=self)
 
     def register_transformer(self, _fn=None, *, restrict=None):
         """
@@ -128,21 +129,23 @@ class Plugin:
             # Apply the decorator as we were applied with a single function
             return decorator(_fn)
 
-    def register_semantic_type(self, semantic_type):
-        if not is_semantic_type(semantic_type):
-            raise TypeError("%r is not a semantic type." % semantic_type)
+    def register_semantic_types(self, *semantic_types):
+        for semantic_type in semantic_types:
+            if not is_semantic_type(semantic_type):
+                raise TypeError("%r is not a semantic type." % semantic_type)
 
-        if not (isinstance(semantic_type, grammar.CompositeType) or
-                (semantic_type.is_concrete() and not semantic_type.fields)):
-            raise ValueError("%r is not a semantic type symbol."
-                             % semantic_type)
+            if not (isinstance(semantic_type, grammar.CompositeType) or
+                    (semantic_type.is_concrete() and
+                    not semantic_type.fields)):
+                raise ValueError("%r is not a semantic type symbol."
+                                 % semantic_type)
 
-        if semantic_type.name in self.types:
-            raise ValueError("Duplicate semantic type symbol %r."
-                             % semantic_type)
+            if semantic_type.name in self.types:
+                raise ValueError("Duplicate semantic type symbol %r."
+                                 % semantic_type)
 
-        self.types[semantic_type.name] = SemanticTypeRecord(
-            semantic_type=semantic_type, plugin=self)
+            self.types[semantic_type.name] = SemanticTypeRecord(
+                semantic_type=semantic_type, plugin=self)
 
     def register_semantic_type_to_format(self, semantic_type, artifact_format):
         if not issubclass(artifact_format, DirectoryFormat):

--- a/qiime/plugin/plugin.py
+++ b/qiime/plugin/plugin.py
@@ -17,6 +17,7 @@ import qiime.sdk
 import qiime.core.type.grammar as grammar
 from qiime.core.callable import MethodCallable, VisualizerCallable
 from qiime.plugin.model import DirectoryFormat
+from qiime.plugin.model.base import FormatBase
 from qiime.core.type import is_semantic_type
 
 
@@ -24,6 +25,7 @@ TransformerRecord = collections.namedtuple(
     'TransformerRecord', ['transformer', 'restrict', 'plugin'])
 SemanticTypeRecord = collections.namedtuple(
     'SemanticTypeRecord', ['semantic_type', 'plugin'])
+FormatRecord = collections.namedtuple('FormatRecord', ['format', 'plugin'])
 TypeFormatRecord = collections.namedtuple(
     'TypeFormatRecord', ['type_expression', 'format', 'plugin'])
 
@@ -50,6 +52,7 @@ class Plugin:
         self.methods = PluginMethods(self)
         self.visualizers = PluginVisualizers(self)
 
+        self.formats = {}
         self.types = {}
         self.transformers = {}
         self.type_formats = []
@@ -64,6 +67,15 @@ class Plugin:
         actions.update(self.methods)
         actions.update(self.visualizers)
         return types.MappingProxyType(actions)
+
+    def register_format(self, format):
+        if not issubclass(format, FormatBase):
+            raise TypeError("%r is not a valid format." % format)
+        if format.__name__ in self.formats.keys():
+            raise NameError("%r is already a registered format." % format)
+
+        self.formats[format.__name__] = FormatRecord(format=format,
+                                                     plugin=self)
 
     def register_transformer(self, _fn=None, *, restrict=None):
         """

--- a/qiime/sdk/plugin_manager.py
+++ b/qiime/sdk/plugin_manager.py
@@ -37,6 +37,7 @@ class PluginManager:
         self.plugins = {}
         self.semantic_types = {}
         self.transformers = collections.defaultdict(dict)
+        self.formats = {}
         self.type_formats = []
 
         # These are all dependent loops, each requires the loop above it to
@@ -65,6 +66,7 @@ class PluginManager:
                                  % transformer_record)
             self.transformers[input][output] = transformer_record
 
+        self.formats.update(plugin.formats)
         self.type_formats.extend(plugin.type_formats)
 
     # TODO: Should plugin loading be transactional? i.e. if there's

--- a/qiime/sdk/plugin_manager.py
+++ b/qiime/sdk/plugin_manager.py
@@ -66,7 +66,14 @@ class PluginManager:
                                  % transformer_record)
             self.transformers[input][output] = transformer_record
 
-        self.formats.update(plugin.formats)
+        for name, record in plugin.formats.items():
+            if name in self.formats:
+                raise NameError(
+                    "Duplicate format registration (%r) defined in plugins: %r"
+                    " and %r" %
+                    (name, record.plugin.name, self.formats[name].plugin.name)
+                )
+            self.formats[name] = record
         self.type_formats.extend(plugin.type_formats)
 
     # TODO: Should plugin loading be transactional? i.e. if there's

--- a/qiime/sdk/util.py
+++ b/qiime/sdk/util.py
@@ -10,7 +10,6 @@ import re
 
 import qiime.sdk
 import qiime.core.type as qtype
-from qiime.plugin.model.base import FormatBase
 
 
 # Makes it possible to programmatically detect when a type doesn't exist.
@@ -85,16 +84,8 @@ def parse_type(string, expect=None):
 
 def parse_format(format_str):
     pm = qiime.sdk.PluginManager()
-    for type_format_record in pm.type_formats:
-        if type_format_record.format.__name__ == format_str:
-            return type_format_record.format
-
-    for input in pm.transformers:
-        if issubclass(input, FormatBase) and input.__name__ == format_str:
-            return input
-        for output in pm.transformers[input]:
-            if (issubclass(output, FormatBase) and
-                    output.__name__ == format_str):
-                return output
-
-    raise TypeError("No format: %s" % format_str)
+    try:
+        format_record = pm.formats[format_str]
+    except KeyError:
+        raise TypeError("No format: %s" % format_str)
+    return format_record.format


### PR DESCRIPTION
A "bug" was discovered while removing the duplicate BIOMv1 directory type registration from `q2-types`. The framework loses the ability to know this format still exists, as it was previously scraping transformer annotations, and semantic type to format registrations.

This PR adds explicit format registration to plugin objects, and makes them accessible through the `PluginManager`, a nice side effect is that this greatly reduces the runtime of `qiime.sdk.util.parse_format`.