### PR TITLE
ENH: Result.extract returns path to extracted directory

### DIFF
--- a/qiime/core/archiver.py
+++ b/qiime/core/archiver.py
@@ -37,8 +37,9 @@ class Archiver:
     @classmethod
     def extract(cls, filepath, output_dir):
         with zipfile.ZipFile(filepath, mode='r') as zf:
+            root_dir = cls._get_root_dir(zf)
             zf.extractall(output_dir)
-        return output_dir
+        return os.path.join(output_dir, root_dir)
 
     @classmethod
     def peek(cls, filepath):

--- a/qiime/sdk/tests/test_artifact.py
+++ b/qiime/sdk/tests/test_artifact.py
@@ -272,11 +272,11 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
                                        list, self.provenance)
         artifact.save(fp)
 
+        root_dir = str(artifact.uuid)
         output_dir = os.path.join(self.test_dir.name, 'artifact-extract-test')
         result_dir = Artifact.extract(fp, output_dir=output_dir)
-        self.assertEqual(result_dir, output_dir)
+        self.assertEqual(result_dir, os.path.join(output_dir, root_dir))
 
-        root_dir = str(artifact.uuid)
         expected = {
             'VERSION',
             'metadata.yaml',

--- a/qiime/sdk/tests/test_result.py
+++ b/qiime/sdk/tests/test_result.py
@@ -155,11 +155,11 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
                                        list, self.provenance)
         artifact.save(fp)
 
+        root_dir = str(artifact.uuid)
         output_dir = os.path.join(self.test_dir.name, 'artifact-extract-test')
         result_dir = Result.extract(fp, output_dir=output_dir)
-        self.assertEqual(result_dir, output_dir)
+        self.assertEqual(result_dir, os.path.join(output_dir, root_dir))
 
-        root_dir = str(artifact.uuid)
         expected = {
             'VERSION',
             'metadata.yaml',
@@ -178,11 +178,11 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
                                                      self.provenance)
         visualization.save(fp)
 
+        root_dir = str(visualization.uuid)
         output_dir = os.path.join(self.test_dir.name, 'viz-extract-test')
         result_dir = Result.extract(fp, output_dir=output_dir)
-        self.assertEqual(result_dir, output_dir)
+        self.assertEqual(result_dir, os.path.join(output_dir, root_dir))
 
-        root_dir = str(visualization.uuid)
         expected = {
             'VERSION',
             'metadata.yaml',

--- a/qiime/sdk/tests/test_visualization.py
+++ b/qiime/sdk/tests/test_visualization.py
@@ -218,11 +218,11 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
                                                      self.provenance)
         visualization.save(fp)
 
+        root_dir = str(visualization.uuid)
         output_dir = os.path.join(self.test_dir.name, 'viz-extract-test')
         result_dir = Visualization.extract(fp, output_dir=output_dir)
-        self.assertEqual(result_dir, output_dir)
+        self.assertEqual(result_dir, os.path.join(output_dir, root_dir))
 
-        root_dir = str(visualization.uuid)
         expected = {
             'VERSION',
             'metadata.yaml',


### PR DESCRIPTION
Previously returned the output directory the Result was extracted in. Now
returns the absolute path to the directory that was extracted (i.e. the
Result's UUID root directory).

This change is necessary to support https://github.com/qiime2/q2cli/issues/72