### PR TITLE
ENH: Signature now matches order of function sig.

### DIFF
--- a/qiime/core/type/signature.py
+++ b/qiime/core/type/signature.py
@@ -288,15 +288,20 @@ class VisualizerSignature(PipelineSignature):
 # duplicate code between MethodSignature.from_function and
 # VisualizerSignature.from_function.
 def function_to_signature(cls, function, inputs, parameters, outputs):
-    # TODO respect function signature parameter order by using `inspect` and
-    # `OrderedDict`.
-    # TODO prevent function signature from mixing artifacts and primitives.
-    # Artifacts come first followed by primitives.
-
     sig_params = inspect.signature(function).parameters
     annotations = {n: p.annotation for n, p in sig_params.items()}
-    input_types = {n: (t, annotations[n]) for n, t in inputs.items()}
-    param_types = {n: (t, annotations[n]) for n, t in parameters.items()}
+
+    input_types = collections.OrderedDict()
+    param_types = collections.OrderedDict()
+
+    # TODO prevent function signature from mixing artifacts and primitives.
+    # Artifacts come first followed by primitives.
+    for name in sig_params:
+        if name in inputs:
+            input_types[name] = (inputs[name], annotations[name])
+        if name in parameters:
+            param_types[name] = (parameters[name], annotations[name])
+
     defaults = {n: p.default for n, p in sig_params.items()
                 if p.default is not p.empty and n in parameters}
 

--- a/qiime/core/type/tests/test_signature.py
+++ b/qiime/core/type/tests/test_signature.py
@@ -9,7 +9,9 @@
 import unittest
 import collections
 
-from qiime.core.type.signature import PipelineSignature
+from qiime.core.type import Visualization
+from qiime.core.type.signature import (
+    PipelineSignature, MethodSignature, VisualizerSignature)
 from qiime.plugin import Int
 from qiime.core.testing.type import IntSequence1
 
@@ -56,6 +58,107 @@ class TestPipelineSignature(unittest.TestCase):
             collections.OrderedDict([
                 ('output1', (IntSequence1, list)),
                 ('output2', (IntSequence1, list))]))
+
+
+class TestMethodSignature(unittest.TestCase):
+    def test_from_function(self):
+        def method(input3: list, input2: dict, in1: set, param1: str,
+                   p2: int=2) -> tuple:
+            pass
+
+        inputs = {
+            'in1': IntSequence1,
+            'input2': IntSequence1,
+            'input3': IntSequence1
+        }
+        exp_inputs = collections.OrderedDict([
+            ('input3', (IntSequence1, list)),
+            ('input2', (IntSequence1, dict)),
+            ('in1', (IntSequence1, set))
+        ])
+
+        parameters = {
+            'param1': Int,
+            'p2': Int
+        }
+        exp_parameters = collections.OrderedDict([
+            ('param1', (Int, str)),
+            ('p2', (Int, int))
+        ])
+
+        outputs = [
+            ('out', IntSequence1)
+        ]
+        exp_outputs = collections.OrderedDict([
+            ('out', (IntSequence1, tuple))
+        ])
+
+        exp_defaults = {
+            'p2': 2
+        }
+
+        sig = MethodSignature.from_function(
+            method, inputs, parameters, outputs)
+
+        self.assertIsInstance(sig.inputs, collections.OrderedDict)
+        self.assertEqual(sig.inputs, exp_inputs)
+
+        self.assertIsInstance(sig.parameters, collections.OrderedDict)
+        self.assertEqual(sig.parameters, exp_parameters)
+
+        self.assertIsInstance(sig.outputs, collections.OrderedDict)
+        self.assertEqual(sig.outputs, exp_outputs)
+
+        self.assertEqual(sig.defaults, exp_defaults)
+
+
+class TestVisualizerSignature(unittest.TestCase):
+    def test_from_function(self):
+        def visualizer(output_dir, input3: list, input2: dict, in1: set,
+                       param1: str, p2: int=2) -> None:
+            pass
+
+        inputs = {
+            'in1': IntSequence1,
+            'input2': IntSequence1,
+            'input3': IntSequence1
+        }
+        exp_inputs = collections.OrderedDict([
+            ('input3', (IntSequence1, list)),
+            ('input2', (IntSequence1, dict)),
+            ('in1', (IntSequence1, set))
+        ])
+
+        parameters = {
+            'param1': Int,
+            'p2': Int
+        }
+        exp_parameters = collections.OrderedDict([
+            ('param1', (Int, str)),
+            ('p2', (Int, int))
+        ])
+
+        exp_outputs = collections.OrderedDict([
+            ('visualization', (Visualization, None))
+        ])
+
+        exp_defaults = {
+            'p2': 2
+        }
+
+        sig = VisualizerSignature.from_function(
+            visualizer, inputs, parameters)
+
+        self.assertIsInstance(sig.inputs, collections.OrderedDict)
+        self.assertEqual(sig.inputs, exp_inputs)
+
+        self.assertIsInstance(sig.parameters, collections.OrderedDict)
+        self.assertEqual(sig.parameters, exp_parameters)
+
+        self.assertIsInstance(sig.outputs, collections.OrderedDict)
+        self.assertEqual(sig.outputs, exp_outputs)
+
+        self.assertEqual(sig.defaults, exp_defaults)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously the `inputs` and `parameters` property of `Signature` objects
created by the `.from_function` alternate constructor did not respect the order
of the original function signature. Now these properties are always
`collections.OrderedDict` instances.