### PR TITLE
FIX: Directory Formats fail to validate from globbed hidden files

### DIFF
--- a/qiime/plugin/model/directory_format.py
+++ b/qiime/plugin/model/directory_format.py
@@ -162,7 +162,8 @@ class DirectoryFormat(FormatBase, metaclass=_DirectoryMeta):
         if not self.path.is_dir():
             raise ValueError("%r is not a directory." % self.path)
         collected_paths = {p: None for p in self.path.glob('**/*')
-                           if p.is_file()}
+                           if not p.name.startswith('.') and
+                           p.is_file()}
         for field in self._fields:
             getattr(self, field)._validate_members(collected_paths)
 


### PR DESCRIPTION
Trying to import using a `source_format` as a Directory Format is failing due to the glob grabbing hidden `.DS_Store` files and failing to validate.

``` bash
ValueError: Unrecognized file (InPath('/var/folders/t1/qdtgl9t964s0s_8yfsfx9d_c0
000gq/T/qiime2-archive-_4ak2iap/f00c26ac-4cea-4620-9f35-249024bd241c/data/.DS_St
ore')) for 'BIOMV100DirFmt'.
```
