### PR TITLE
DOC: update to use canonical urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,4 @@
 
 [![Build Status](https://travis-ci.org/qiime2/qiime2.svg?branch=master)](https://travis-ci.org/qiime2/qiime2)
 
-**See the [QIIME 2 wiki](http:/2.qiime.org)** to learn how to use QIIME 2
-(including an installation/usage tutorial), develop QIIME 2 plugins, stay
-up-to-date on QIIME 2, request features and report bugs, and for other
-information.
+Source code repository for the QIIME 2 framework. Visit https://qiime2.org to learn more about the QIIME 2 project.

--- a/qiime/core/testing/plugin.py
+++ b/qiime/core/testing/plugin.py
@@ -31,7 +31,7 @@ dummy_plugin = qiime.plugin.Plugin(
     website='https://github.com/qiime2/qiime2',
     package='qiime.core.testing',
     citation_text='No relevant citation.',
-    user_support_text='For help, see http://2.qiime.org'
+    user_support_text='For help, see https://qiime2.org'
 )
 
 import_module('qiime.core.testing.transformer')

--- a/qiime/plugin/tests/test_plugin.py
+++ b/qiime/plugin/tests/test_plugin.py
@@ -37,7 +37,7 @@ class TestPlugin(unittest.TestCase):
 
     def test_user_support_text(self):
         self.assertEqual(self.plugin.user_support_text,
-                         'For help, see http://2.qiime.org')
+                         'For help, see https://qiime2.org')
 
     def test_citation_text_default(self):
         plugin = qiime.plugin.Plugin(

--- a/qiime/sdk/__init__.py
+++ b/qiime/sdk/__init__.py
@@ -13,8 +13,3 @@ from .util import parse_type, parse_format, UnknownTypeError
 
 __all__ = ['Result', 'Artifact', 'Visualization', 'Action', 'PluginManager',
            'parse_type', 'parse_format', 'UnknownTypeError']
-
-# Various URLs
-CITATION = 'http://www.ncbi.nlm.nih.gov/pubmed/20383131'
-HELP_URL = 'http://2.qiime.org'
-CONDA_CHANNEL = 'https://anaconda.org/qiime2'


### PR DESCRIPTION
Removed `qiime.sdk.HELP_URL`, `CITATION`, and `CONDA_CHANNEL` as these variables were only used a couple of places in q2cli and don't seem to have much value. For example, using `HELP_URL` made it difficult to identify broken links (e.g. there were two broken links in q2cli that weren't searchable).