### PR TITLE
ENH: more informative error message

### DIFF
--- a/qiime/core/type/signature.py
+++ b/qiime/core/type/signature.py
@@ -315,8 +315,8 @@ def function_to_signature(cls, function, inputs, parameters, outputs):
     output_types = collections.OrderedDict()
     for output_name, semantic_type in outputs.items():
         view_type = output_view_types.get(output_name)
-
-        if view_type is None:
+        
+        if output_name != "visualization" and view_type is None:
             raise TypeError("Function %r does not describe %r in its return "
                             "annotation." % (function.__name__, output_name))
 

--- a/qiime/core/type/signature.py
+++ b/qiime/core/type/signature.py
@@ -314,7 +314,12 @@ def function_to_signature(cls, function, inputs, parameters, outputs):
 
     output_types = collections.OrderedDict()
     for output_name, semantic_type in outputs.items():
-        view_type = output_view_types[output_name]
+        view_type = output_view_types.get(output_name)
+        
+        if view_type is None:
+            raise TypeError("Function %r does not describe %r in its return "
+                            "annotation." % (function.__name__, output_name))
+
         output_types[output_name] = (semantic_type, view_type)
 
     return cls(input_types, param_types, defaults, output_types)

--- a/qiime/core/type/signature.py
+++ b/qiime/core/type/signature.py
@@ -315,7 +315,7 @@ def function_to_signature(cls, function, inputs, parameters, outputs):
     output_types = collections.OrderedDict()
     for output_name, semantic_type in outputs.items():
         view_type = output_view_types.get(output_name)
-        
+
         if view_type is None:
             raise TypeError("Function %r does not describe %r in its return "
                             "annotation." % (function.__name__, output_name))


### PR DESCRIPTION
Provides additional context, whereas the existing behavior was the default `KeyError` which did not specify the function being evaluated. 