### PR TITLE
ENH: Add Transformer Test Helper to TestPluginBase

### DIFF
--- a/qiime/plugin/testing.py
+++ b/qiime/plugin/testing.py
@@ -9,6 +9,8 @@
 import pkg_resources
 import tempfile
 import unittest
+import shutil
+
 import qiime
 
 
@@ -84,3 +86,17 @@ class TestPluginBase(unittest.TestCase):
             obs_format, exp_format,
             "Expected semantic type %r to be registered to format %r, not %r."
             % (semantic_type, exp_format, obs_format))
+
+    def transformer_helper(self, source, target, filenames):
+        transformer = self.get_transformer(source, target)
+
+        for filename in filenames:
+            filepath = self.get_data_path(filename)
+            shutil.copy(filepath, self.temp_dir.name)
+        input = source(self.temp_dir.name, mode='r')
+
+        obs = transformer(input)
+
+        self.assertIsInstance(obs, target)
+
+        return input, obs

--- a/qiime/plugin/testing.py
+++ b/qiime/plugin/testing.py
@@ -93,7 +93,9 @@ class TestPluginBase(unittest.TestCase):
     def transform_format(self, source_format, target, filename=None,
                          filenames=None):
         # Guard any non-QIIME2 Format sources from being tested
-        self.assertTrue(issubclass(source_format, FormatBase))
+        if not issubclass(source_format, FormatBase):
+            raise ValueError("`source_format` must be a subclass of "
+                             "FormatBase.")
 
         # Guard against invalid filename(s) usage
         if filename is not None and filenames is not None:


### PR DESCRIPTION
Discovered a pattern while making `q2_types` tests, and this helper cut over 40 lines of transformer test boilerplate from a single subpackage.