### PR TITLE
ENH: Add help_text support to action signatures

### DIFF
--- a/qiime/core/type/signature.py
+++ b/qiime/core/type/signature.py
@@ -148,9 +148,7 @@ class PipelineSignature:
             default = ParameterSpec.NOVALUE
             if parameter.default is not parameter.empty:
                 default = parameter.default
-            help_text = help_texts.get(name, ParameterSpec.NOVALUE)
-            if help_text is not ParameterSpec.NOVALUE:
-                help_texts.pop(name)
+            help_text = help_texts.pop(name, ParameterSpec.NOVALUE)
 
             if name in inputs:
                 if in_parameter_section:
@@ -184,24 +182,20 @@ class PipelineSignature:
                                 (len(outputs), len(output_views)))
 
             for (name, qiime_type), view_type in zip(outputs, output_views):
-                help_text = help_texts.get(name, ParameterSpec.NOVALUE)
-                if help_text is not ParameterSpec.NOVALUE:
-                    help_texts.pop(name)
+                help_text = help_texts.pop(name, ParameterSpec.NOVALUE)
                 annotated_outputs[name] = ParameterSpec(qiime_type=qiime_type,
                                                         view_type=view_type,
                                                         help_text=help_text)
         else:
             for name, qiime_type in outputs:
-                help_text = help_texts.get(name, ParameterSpec.NOVALUE)
-                if help_text is not ParameterSpec.NOVALUE:
-                    help_texts.pop(name)
+                help_text = help_texts.pop(name, ParameterSpec.NOVALUE)
                 annotated_outputs[name] = ParameterSpec(qiime_type=qiime_type,
                                                         help_text=help_text)
 
         # we should have popped the help_texts empty by this point
         if help_texts:
-            raise TypeError("Callable does not have parameter(s) found in "
-                            "help_texts: %r" % list(help_texts))
+            raise TypeError("Callable does not have parameter(s)/output(s) "
+                            "found in help_texts: %r" % list(help_texts))
 
         return annotated_inputs, annotated_parameters, annotated_outputs
 

--- a/qiime/core/type/signature.py
+++ b/qiime/core/type/signature.py
@@ -213,9 +213,9 @@ class PipelineSignature:
         if input_descriptions or parameter_descriptions or output_descriptions:
             raise TypeError(
                 "Callable does not have parameter(s)/output(s) found in "
-                " descriptions: %r" % list({**input_descriptions,
-                                            **parameter_descriptions,
-                                            **output_descriptions}))
+                "descriptions: %r" % [*input_descriptions,
+                                      *parameter_descriptions,
+                                      *output_descriptions])
 
         return annotated_inputs, annotated_parameters, annotated_outputs
 

--- a/qiime/core/type/signature.py
+++ b/qiime/core/type/signature.py
@@ -110,13 +110,6 @@ class PipelineSignature:
             (name, spec.default) for name, spec in self.parameters.items()
             if spec.has_default()])
 
-    @property
-    def descriptions(self):
-        params = {**self.inputs, **self.parameters, **self.outputs}
-        return collections.OrderedDict([
-            (name, spec.description) for name, spec in params.items()
-            if spec.has_description()])
-
     def _parse_signature(self, callable, inputs, parameters, outputs,
                          input_descriptions=None, parameter_descriptions=None,
                          output_descriptions=None):

--- a/qiime/plugin/plugin.py
+++ b/qiime/plugin/plugin.py
@@ -188,10 +188,14 @@ class PluginMethods(PluginActions):
     # TODO is `register` a better name now that functions are the only accepted
     # source (i.e. markdown support is gone)?
     def register_function(self, function, inputs, parameters, outputs, name,
-                          description, help_texts=None):
+                          description, input_descriptions=None,
+                          parameter_descriptions=None,
+                          output_descriptions=None):
         method = qiime.sdk.Method._init(function, inputs, parameters, outputs,
                                         self._package, name, description,
-                                        help_texts)
+                                        input_descriptions,
+                                        parameter_descriptions,
+                                        output_descriptions)
         self[method.id] = method
 
 
@@ -199,8 +203,11 @@ class PluginVisualizers(PluginActions):
     _subpackage = 'visualizers'
 
     def register_function(self, function, inputs, parameters, name,
-                          description, help_texts=None):
+                          description, input_descriptions=None,
+                          parameter_descriptions=None):
         visualizer = qiime.sdk.Visualizer._init(function, inputs, parameters,
                                                 self._package, name,
-                                                description, help_texts)
+                                                description,
+                                                input_descriptions,
+                                                parameter_descriptions)
         self[visualizer.id] = visualizer

--- a/qiime/plugin/plugin.py
+++ b/qiime/plugin/plugin.py
@@ -188,9 +188,10 @@ class PluginMethods(PluginActions):
     # TODO is `register` a better name now that functions are the only accepted
     # source (i.e. markdown support is gone)?
     def register_function(self, function, inputs, parameters, outputs, name,
-                          description):
+                          description, help_text=None):
         method = qiime.sdk.Method._init(function, inputs, parameters, outputs,
-                                        self._package, name, description)
+                                        self._package, name, description,
+                                        help_text)
         self[method.id] = method
 
 
@@ -198,8 +199,8 @@ class PluginVisualizers(PluginActions):
     _subpackage = 'visualizers'
 
     def register_function(self, function, inputs, parameters, name,
-                          description):
+                          description, help_text=None):
         visualizer = qiime.sdk.Visualizer._init(function, inputs, parameters,
                                                 self._package, name,
-                                                description)
+                                                description, help_text)
         self[visualizer.id] = visualizer

--- a/qiime/plugin/plugin.py
+++ b/qiime/plugin/plugin.py
@@ -188,10 +188,10 @@ class PluginMethods(PluginActions):
     # TODO is `register` a better name now that functions are the only accepted
     # source (i.e. markdown support is gone)?
     def register_function(self, function, inputs, parameters, outputs, name,
-                          description, help_text=None):
+                          description, help_texts=None):
         method = qiime.sdk.Method._init(function, inputs, parameters, outputs,
                                         self._package, name, description,
-                                        help_text)
+                                        help_texts)
         self[method.id] = method
 
 
@@ -199,8 +199,8 @@ class PluginVisualizers(PluginActions):
     _subpackage = 'visualizers'
 
     def register_function(self, function, inputs, parameters, name,
-                          description, help_text=None):
+                          description, help_texts=None):
         visualizer = qiime.sdk.Visualizer._init(function, inputs, parameters,
                                                 self._package, name,
-                                                description, help_text)
+                                                description, help_texts)
         self[visualizer.id] = visualizer

--- a/qiime/sdk/action.py
+++ b/qiime/sdk/action.py
@@ -279,9 +279,9 @@ class Method(Action):
 
     @classmethod
     def _init(cls, callable, inputs, parameters, outputs, package, name,
-              description):
+              description, help_text=None):
         signature = qtype.MethodSignature(callable, inputs, parameters,
-                                          outputs)
+                                          outputs, help_text)
         return super()._init(callable, signature, package, name, description)
 
 
@@ -307,8 +307,10 @@ class Visualizer(Action):
             return qiime.sdk.Visualization._from_data_dir(temp_dir, provenance)
 
     @classmethod
-    def _init(cls, callable, inputs, parameters, package, name, description):
-        signature = qtype.VisualizerSignature(callable, inputs, parameters)
+    def _init(cls, callable, inputs, parameters, package, name, description,
+              help_text=None):
+        signature = qtype.VisualizerSignature(callable, inputs, parameters,
+                                              help_text)
         return super()._init(callable, signature, package, name, description)
 
 

--- a/qiime/sdk/action.py
+++ b/qiime/sdk/action.py
@@ -279,9 +279,9 @@ class Method(Action):
 
     @classmethod
     def _init(cls, callable, inputs, parameters, outputs, package, name,
-              description, help_text=None):
+              description, help_texts=None):
         signature = qtype.MethodSignature(callable, inputs, parameters,
-                                          outputs, help_text)
+                                          outputs, help_texts)
         return super()._init(callable, signature, package, name, description)
 
 
@@ -308,9 +308,9 @@ class Visualizer(Action):
 
     @classmethod
     def _init(cls, callable, inputs, parameters, package, name, description,
-              help_text=None):
+              help_texts=None):
         signature = qtype.VisualizerSignature(callable, inputs, parameters,
-                                              help_text)
+                                              help_texts)
         return super()._init(callable, signature, package, name, description)
 
 

--- a/qiime/sdk/action.py
+++ b/qiime/sdk/action.py
@@ -279,9 +279,12 @@ class Method(Action):
 
     @classmethod
     def _init(cls, callable, inputs, parameters, outputs, package, name,
-              description, help_texts=None):
+              description, input_descriptions, parameter_descriptions,
+              output_descriptions):
         signature = qtype.MethodSignature(callable, inputs, parameters,
-                                          outputs, help_texts)
+                                          outputs, input_descriptions,
+                                          parameter_descriptions,
+                                          output_descriptions)
         return super()._init(callable, signature, package, name, description)
 
 
@@ -308,9 +311,10 @@ class Visualizer(Action):
 
     @classmethod
     def _init(cls, callable, inputs, parameters, package, name, description,
-              help_texts=None):
+              input_descriptions, parameter_descriptions):
         signature = qtype.VisualizerSignature(callable, inputs, parameters,
-                                              help_texts)
+                                              input_descriptions,
+                                              parameter_descriptions)
         return super()._init(callable, signature, package, name, description)
 
 


### PR DESCRIPTION
Allow optional help text strings to be associated with action parameters.

```python
In [1]: from qiime.plugins.test_plugin.methods import blocking_test

In [2]: blocking_test.signature
Out[2]: 
inputs:
    table: ParameterSpec(qiime_type=FeatureTable[Frequency], view_type=<class 'biom.table.Table'>, default=NOVALUE, help_text=NOVALUE)
parameters:
    timeout: ParameterSpec(qiime_type=Int, view_type=<class 'int'>, default=NOVALUE, help_text='The amount of time to wait before continuing execution of the method.')
outputs:
    rarefied_table: ParameterSpec(qiime_type=FeatureTable[Frequency], view_type=<class 'biom.table.Table'>, default=NOVALUE, help_text=NOVALUE)


```