### PR TITLE
ENH: Add format switch ctx mgr

### DIFF
--- a/qiime/core/archive/format/tests/test_util.py
+++ b/qiime/core/archive/format/tests/test_util.py
@@ -1,0 +1,79 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+import unittest
+import tempfile
+import os
+import zipfile
+
+from qiime.core.testing.type import FourInts
+from qiime.core.testing.util import ArchiveTestingMixin
+import qiime.core.archive as archive
+from qiime.core.archive.format.util import artifact_version
+from qiime.sdk import Artifact
+
+
+class TestArtifactVersion(unittest.TestCase, ArchiveTestingMixin):
+    def setUp(self):
+        prefix = "qiime2-test-temp-"
+        self.temp_dir = tempfile.TemporaryDirectory(prefix=prefix)
+        self.provenance_capture = archive.ImportProvenanceCapture()
+
+    def test_nonexistent_archive_format(self):
+        with self.assertRaisesRegex(ValueError, 'Version foo not supported'):
+            with artifact_version('foo'):
+                pass
+
+    def test_write_v0_archive(self):
+        fp = os.path.join(self.temp_dir.name, 'artifact_v0.qza')
+
+        with artifact_version(0):
+            artifact = Artifact._from_view(FourInts, [-1, 42, 0, 43], list,
+                                           self.provenance_capture)
+            artifact.save(fp)
+
+        root_dir = str(artifact.uuid)
+        # There should be no provenance
+        expected = {
+            'VERSION',
+            'metadata.yaml',
+            'data/file1.txt',
+            'data/file2.txt',
+            'data/nested/file3.txt',
+            'data/nested/file4.txt',
+        }
+        self.assertArchiveMembers(fp, root_dir, expected)
+
+        with zipfile.ZipFile(fp, mode='r') as zf:
+            version = zf.read(os.path.join(root_dir, 'VERSION'))
+        self.assertRegex(str(version), '^.*archive: 0.*$')
+
+    def test_write_v1_archive(self):
+        fp = os.path.join(self.temp_dir.name, 'artifact_v1.qza')
+
+        with artifact_version(1):
+            artifact = Artifact._from_view(FourInts, [-1, 42, 0, 43], list,
+                                           self.provenance_capture)
+            artifact.save(fp)
+
+        root_dir = str(artifact.uuid)
+        expected = {
+            'VERSION',
+            'metadata.yaml',
+            'data/file1.txt',
+            'data/file2.txt',
+            'data/nested/file3.txt',
+            'data/nested/file4.txt',
+            'provenance/metadata.yaml',
+            'provenance/VERSION',
+            'provenance/action/action.yaml',
+        }
+        self.assertArchiveMembers(fp, root_dir, expected)
+
+        with zipfile.ZipFile(fp, mode='r') as zf:
+            version = zf.read(os.path.join(root_dir, 'VERSION'))
+        self.assertRegex(str(version), '^.*archive: 1.*$')

--- a/qiime/core/archive/format/tests/test_v0.py
+++ b/qiime/core/archive/format/tests/test_v0.py
@@ -52,7 +52,7 @@ class TestArchiveFormat(unittest.TestCase):
                              r.version, r.framework_version)
 
         ArchiveFormat.write(fake, IntSequence1, IntSequenceDirectoryFormat,
-                            lambda x: None)
+                            lambda x: None, None)
         with self.assertRaisesRegex(
                 ValueError, 'root directory must match UUID.*metadata'):
             ArchiveFormat(r)

--- a/qiime/core/archive/format/util.py
+++ b/qiime/core/archive/format/util.py
@@ -1,0 +1,24 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from contextlib import contextmanager
+
+from qiime.core.archive import Archiver
+
+
+@contextmanager
+def artifact_version(version):
+    version = str(version)
+    if version not in Archiver._FORMAT_REGISTRY:
+        raise ValueError("Version %s not supported" % version)
+    original_version = Archiver.CURRENT_FORMAT_VERSION
+    try:
+        Archiver.CURRENT_FORMAT_VERSION = version
+        yield
+    finally:
+        Archiver.CURRENT_FORMAT_VERSION = original_version

--- a/qiime/core/archive/format/v0.py
+++ b/qiime/core/archive/format/v0.py
@@ -49,7 +49,7 @@ class ArchiveFormat:
             return self._parse_metadata(fh, expected_uuid=archive.uuid)
 
     @classmethod
-    def write(cls, archive_record, type, format, data_initializer):
+    def write(cls, archive_record, type, format, data_initializer, _):
         root = archive_record.root
         metadata_fp = root / cls.METADATA_FILE
 

--- a/qiime/core/archive/format/v1.py
+++ b/qiime/core/archive/format/v1.py
@@ -15,7 +15,8 @@ class ArchiveFormat(v0.ArchiveFormat):
     @classmethod
     def write(cls, archive_record, type, format, data_initializer,
               provenance_capture):
-        super().write(archive_record, type, format, data_initializer)
+        super().write(archive_record, type, format, data_initializer,
+                      provenance_capture)
         root = archive_record.root
 
         prov_dir = root / cls.PROVENANCE_DIR


### PR DESCRIPTION
`artifact_version` allows for contextual monkey-patching of the Archive
version used by the framework. This is useful for testing previous
archive versions for backwards-compatibility, etc.

This also makes several changes to the `v0` format for compatibility with the `v1` API.