### PR TITLE
BUG: Normalize matplotlib backend check

### DIFF
--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -197,7 +197,7 @@ class Action(metaclass=abc.ABCMeta):
             # caused by MacOSX async runs for now.
             try:
                 import matplotlib as plt
-                if plt.rcParams['backend'] == 'MacOSX':
+                if plt.rcParams['backend'].lower() == 'macosx':
                     raise EnvironmentError(backend_error_template %
                                            plt.matplotlib_fname())
             except ImportError:


### PR DESCRIPTION
Stumbled upon this issue while working on something else. Matplotlib backend `MacOSX` also works as `macosx`, but this check is checking case-sensitive parameters. 

Modify and compare it against a lowercase string instead.