### PR TITLE
ENH: add `qiime2.__release__` API

### DIFF
--- a/qiime2/__init__.py
+++ b/qiime2/__init__.py
@@ -16,6 +16,11 @@ __all__ = ['Metadata', 'MetadataCategory', 'Visualization', 'Artifact']
 
 __version__ = pkg_resources.get_distribution('qiime2').version
 
+# "Train release" version includes <year>.<month> and excludes patch numbers
+# and pre/post-release tags. All versions within a train release are expected
+# to be compatible.
+__release__ = '.'.join(__version__.split('.')[:2])
+
 # `from qiime2 import Artifact` fails if `from qiime2.sdk` is used above so
 # import and alias instead
 Visualization = _sdk.Visualization


### PR DESCRIPTION
`qiime2.__release__` is a string containing the "train release" in `<year>.<month>` format. It is `__version__` with patch and pre/post-release tags stripped.

For example:

```
__version__ = '2017.2.0.dev0'
__release__ = '2017.2'
```