### PR TITLE
ENH: qiime2.sdk.PluginManager.importable_types; sandboxed tests

### DIFF
--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -20,7 +20,8 @@ from .format import (
     FourIntsDirectoryFormat
 )
 
-from .type import IntSequence1, IntSequence2, Mapping, FourInts
+from .type import (IntSequence1, IntSequence2, Mapping, FourInts,
+                   Kennel, Dog, Cat)
 from .method import (concatenate_ints, split_ints, merge_mappings,
                      identity_with_metadata, identity_with_metadata_category)
 from .visualizer import most_common_viz, mapping_viz
@@ -40,7 +41,7 @@ import_module('qiime2.core.testing.transformer')
 
 # Register semantic types
 dummy_plugin.register_semantic_types(IntSequence1, IntSequence2, Mapping,
-                                     FourInts)
+                                     FourInts, Kennel, Dog, Cat)
 
 # Register formats
 dummy_plugin.register_formats(
@@ -48,7 +49,6 @@ dummy_plugin.register_formats(
     IntSequenceDirectoryFormat, MappingDirectoryFormat,
     FourIntsDirectoryFormat
 )
-
 
 dummy_plugin.register_semantic_type_to_format(
     IntSequence1,
@@ -65,6 +65,10 @@ dummy_plugin.register_semantic_type_to_format(
 dummy_plugin.register_semantic_type_to_format(
     FourInts,
     artifact_format=FourIntsDirectoryFormat
+)
+dummy_plugin.register_semantic_type_to_format(
+    Kennel[Dog | Cat],
+    artifact_format=MappingDirectoryFormat
 )
 
 # TODO add an optional parameter to this method when they are supported

--- a/qiime2/core/testing/type.py
+++ b/qiime2/core/testing/type.py
@@ -13,3 +13,7 @@ IntSequence1 = qiime2.plugin.SemanticType('IntSequence1')
 IntSequence2 = qiime2.plugin.SemanticType('IntSequence2')
 Mapping = qiime2.plugin.SemanticType('Mapping')
 FourInts = qiime2.plugin.SemanticType('FourInts')
+
+Kennel = qiime2.plugin.SemanticType('Kennel', field_names='pet')
+Dog = qiime2.plugin.SemanticType('Dog', variant_of=Kennel.field['pet'])
+Cat = qiime2.plugin.SemanticType('Cat', variant_of=Kennel.field['pet'])

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -110,7 +110,8 @@ class TestPlugin(unittest.TestCase):
 
         self.assertEqual(
             set(types),
-            set(['IntSequence1', 'IntSequence2', 'Mapping', 'FourInts']))
+            set(['IntSequence1', 'IntSequence2', 'Mapping', 'FourInts',
+                 'Kennel', 'Dog', 'Cat']))
 
 
 if __name__ == '__main__':

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -10,15 +10,13 @@ import unittest
 
 import qiime2.plugin
 import qiime2.sdk
+from qiime2.plugin.plugin import SemanticTypeRecord
 
 from qiime2.core.testing.type import (IntSequence1, IntSequence2, Mapping,
-                                      FourInts)
+                                      FourInts, Kennel, Dog, Cat)
 from qiime2.core.testing.util import get_dummy_plugin
 
 
-# These tests are written to pass regardless of other plugins that may be
-# installed. This is accomplished by only testing pieces we know are defined by
-# the dummy plugin.
 class TestPluginManager(unittest.TestCase):
     def setUp(self):
         self.plugin = get_dummy_plugin()
@@ -28,22 +26,37 @@ class TestPluginManager(unittest.TestCase):
     def test_plugins(self):
         plugins = self.pm.plugins
 
-        self.assertIsInstance(plugins['dummy-plugin'], qiime2.plugin.Plugin)
+        exp = {'dummy-plugin': self.plugin}
+        self.assertEqual(plugins, exp)
 
     def test_semantic_types(self):
         types = self.pm.semantic_types
 
-        self.assertEqual(types['IntSequence1'].semantic_type, IntSequence1)
-        self.assertEqual(types['IntSequence1'].plugin, self.plugin)
+        exp = {
+            'IntSequence1': SemanticTypeRecord(semantic_type=IntSequence1,
+                                               plugin=self.plugin),
+            'IntSequence2': SemanticTypeRecord(semantic_type=IntSequence2,
+                                               plugin=self.plugin),
+            'Mapping': SemanticTypeRecord(semantic_type=Mapping,
+                                          plugin=self.plugin),
+            'FourInts': SemanticTypeRecord(semantic_type=FourInts,
+                                           plugin=self.plugin),
+            'Kennel': SemanticTypeRecord(semantic_type=Kennel,
+                                         plugin=self.plugin),
+            'Dog': SemanticTypeRecord(semantic_type=Dog,
+                                      plugin=self.plugin),
+            'Cat': SemanticTypeRecord(semantic_type=Cat,
+                                      plugin=self.plugin),
+        }
 
-        self.assertEqual(types['IntSequence2'].semantic_type, IntSequence2)
-        self.assertEqual(types['IntSequence2'].plugin, self.plugin)
+        self.assertEqual(types, exp)
 
-        self.assertEqual(types['Mapping'].semantic_type, Mapping)
-        self.assertEqual(types['Mapping'].plugin, self.plugin)
+    def test_importable_types(self):
+        types = self.pm.importable_types
 
-        self.assertEqual(types['FourInts'].semantic_type, FourInts)
-        self.assertEqual(types['FourInts'].plugin, self.plugin)
+        exp = {IntSequence1, IntSequence2, FourInts, Mapping, Kennel[Dog],
+               Kennel[Cat]}
+        self.assertEqual(types, exp)
 
     # TODO: add tests for type/directory/transformer registrations
 


### PR DESCRIPTION
Adds `qiime2.sdk.PluginManager.importable_types` read-only property, which is the set of concrete semantic types that are importable (i.e.  concrete type expressions that are registered with a directory format).

Also made testing sandboxed, such that when the QIIMETEST environment variable is set, only the framework's builtin `dummy-plugin` is discovered. If QIIMETEST is not set, all available plugins are discovered, with the exception of `dummy-plugin`.

This sandboxing solves a couple of issues:

- Unit tests are more robust and easier to write, because when tests are run, only the framework's `dummy-plugin` is discovered.  Previously tests had to be written so they would pass even if other plugins were discovered.

- q2-dummy-types and the framework's `dummy-plugin` are incompatible because they define types with name conflicts. Previously it was not possible to run tests with QIIMETEST and have q2-dummy-types installed at the same time. Now, only one plugin is loaded depending on whether tests are being run or not.