### PR TITLE
plugins should have a description that can be used by interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Build Status](https://travis-ci.org/qiime2/qiime2.svg?branch=master)](https://travis-ci.org/qiime2/qiime2)
 
-Source code repository for the QIIME 2 framework. Visit https://qiime2.org to learn more about the QIIME 2 project.
+Source code repository for the QIIME 2 framework. Visit [https://qiime2.org](https://qiime2.org) to learn more about the QIIME 2 project.

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -27,6 +27,8 @@ from .visualizer import most_common_viz, mapping_viz
 
 dummy_plugin = qiime2.plugin.Plugin(
     name='dummy-plugin',
+    description='Description of dummy plugin.',
+    short_description='Dummy plugin for testing.',
     version='0.0.0-dev',
     website='https://github.com/qiime2/qiime2',
     package='qiime2.core.testing',

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -36,9 +36,9 @@ class Plugin:
         ]
         return dumper.represent_dict(items)
 
-    def __init__(self, name, version, website, package, 
-        description=None, short_description=None, 
-        citation_text=None, user_support_text=None):
+    def __init__(self, name, version, website, package,
+                 description=None, short_description=None,
+                 citation_text=None, user_support_text=None):
         self.name = name
         self.version = version
         self.website = website

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -37,8 +37,8 @@ class Plugin:
         return dumper.represent_dict(items)
 
     def __init__(self, name, version, website, package,
-                 description=None, short_description=None,
-                 citation_text=None, user_support_text=None):
+                 citation_text=None, user_support_text=None,
+                 short_description=None, description=None):
         self.name = name
         self.version = version
         self.website = website
@@ -54,16 +54,16 @@ class Plugin:
                                       % self.website)
         else:
             self.user_support_text = user_support_text
+        if short_description is None:
+            self.short_description = ''
+        else:
+            self.short_description = short_description
         if description is None:
             self.description = ('No description available. '
                                 'See plugin website: %s'
                                 % self.website)
         else:
             self.description = description
-        if short_description is None:
-            self.short_description = ''
-        else:
-            self.short_description = short_description
 
         self.methods = PluginMethods(self)
         self.visualizers = PluginVisualizers(self)

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -36,8 +36,9 @@ class Plugin:
         ]
         return dumper.represent_dict(items)
 
-    def __init__(self, name, version, website, package, citation_text=None,
-                 user_support_text=None):
+    def __init__(self, name, version, website, package, 
+        description=None, short_description=None, 
+        citation_text=None, user_support_text=None):
         self.name = name
         self.version = version
         self.website = website
@@ -53,6 +54,16 @@ class Plugin:
                                       % self.website)
         else:
             self.user_support_text = user_support_text
+        if description is None:
+            self.description = ('No description available. '
+                                'See plugin website: %s'
+                                % self.website)
+        else:
+            self.description = description
+        if short_description is None:
+            self.short_description = ''
+        else:
+            self.short_description = short_description
 
         self.methods = PluginMethods(self)
         self.visualizers = PluginVisualizers(self)

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -39,13 +39,13 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(self.plugin.user_support_text,
                          'For help, see https://qiime2.org')
 
-    def test_description_text(self):
-        self.assertEqual(self.plugin.description,
-                         'Description of dummy plugin.')
-
     def test_short_description_text(self):
         self.assertEqual(self.plugin.short_description,
                          'Dummy plugin for testing.')
+
+    def test_description_text(self):
+        self.assertEqual(self.plugin.description,
+                         'Description of dummy plugin.')
 
     def test_citation_text_default(self):
         plugin = qiime2.plugin.Plugin(

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -39,6 +39,14 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(self.plugin.user_support_text,
                          'For help, see https://qiime2.org')
 
+    def test_description_text(self):
+        self.assertEqual(self.plugin.description,
+                         'Description of dummy plugin.')
+
+    def test_short_description_text(self):
+        self.assertEqual(self.plugin.short_description,
+                         'Dummy plugin for testing.')
+
     def test_citation_text_default(self):
         plugin = qiime2.plugin.Plugin(
             name='local-dummy-plugin',


### PR DESCRIPTION
* Added `description` and `short_description` params to plugin class
* Each has default value of None so we retain backwards-compatibility
* Added default values for each in the style of the default values for the other optional params in that class 
* Added basic unit tests for each in the style of the unit tests I saw for plugins
* Added a link to the Markdown README for improved readability

This is in response to [issue #81](https://github.com/qiime2/qiime2/issues/81#issuecomment-279822099)