### PR TITLE
CI: noarch python in conda recipe

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -7,13 +7,12 @@ source:
   path: ../..
 
 build:
-  noarch_python: True
-  preserve_egg_dir: True
+  noarch: python
   script: python setup.py install
 
 requirements:
   build:
-    - python
+    - python 3.5*
     - setuptools
     - pyyaml
     - decorator
@@ -22,7 +21,7 @@ requirements:
     - python-dateutil
 
   run:
-    - python
+    - python 3.5*
     - setuptools
     - pyyaml
     - decorator

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ setup(
     },
     package_data={
         'qiime2.tests': ['data/*']
-    }
+    },
+    zip_safe=False
 )


### PR DESCRIPTION
Also specify acceptable versions of Python in the recipe.

Reference: https://www.continuum.io/blog/developer-blog/condas-new-noarch-packages