### PR TITLE
BUG: fix SingleFileDirectoryFormat transformation

### DIFF
--- a/qiime2/core/testing/format.py
+++ b/qiime2/core/testing/format.py
@@ -26,6 +26,16 @@ class IntSequenceFormat(TextFileFormat):
             return True
 
 
+class IntSequenceFormatV2(IntSequenceFormat):
+    """
+    Same as IntSequenceFormat, but has a header "VERSION 2"
+
+    """
+    def sniff(self):
+        with self.open() as fh:
+            return fh.readline() == 'VERSION 2\n'
+
+
 class MappingFormat(TextFileFormat):
     """
     A mapping of keys to values stored in a TSV file. Since this is a
@@ -58,6 +68,9 @@ class SingleIntFormat(TextFileFormat):
 
 IntSequenceDirectoryFormat = model.SingleFileDirectoryFormat(
     'IntSequenceDirectoryFormat', 'ints.txt', IntSequenceFormat)
+
+IntSequenceV2DirectoryFormat = model.SingleFileDirectoryFormat(
+    'IntSequenceV2DirectoryFormat', 'integers.txt', IntSequenceFormatV2)
 
 
 # This could have been a `SingleFileDirectoryFormat`, but isn't for testing

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -13,9 +13,11 @@ import qiime2.plugin
 
 from .format import (
     IntSequenceFormat,
+    IntSequenceFormatV2,
     MappingFormat,
     SingleIntFormat,
     IntSequenceDirectoryFormat,
+    IntSequenceV2DirectoryFormat,
     MappingDirectoryFormat,
     FourIntsDirectoryFormat
 )
@@ -45,9 +47,9 @@ dummy_plugin.register_semantic_types(IntSequence1, IntSequence2, Mapping,
 
 # Register formats
 dummy_plugin.register_formats(
-    IntSequenceFormat, MappingFormat, SingleIntFormat,
-    IntSequenceDirectoryFormat, MappingDirectoryFormat,
-    FourIntsDirectoryFormat
+    IntSequenceFormat, IntSequenceFormatV2, MappingFormat, SingleIntFormat,
+    IntSequenceDirectoryFormat, IntSequenceV2DirectoryFormat,
+    MappingDirectoryFormat, FourIntsDirectoryFormat
 )
 
 dummy_plugin.register_semantic_type_to_format(
@@ -56,7 +58,7 @@ dummy_plugin.register_semantic_type_to_format(
 )
 dummy_plugin.register_semantic_type_to_format(
     IntSequence2,
-    artifact_format=IntSequenceDirectoryFormat
+    artifact_format=IntSequenceV2DirectoryFormat
 )
 dummy_plugin.register_semantic_type_to_format(
     Mapping,

--- a/qiime2/core/testing/transformer.py
+++ b/qiime2/core/testing/transformer.py
@@ -11,6 +11,7 @@ from .format import (
     FourIntsDirectoryFormat,
     MappingDirectoryFormat,
     IntSequenceFormat,
+    IntSequenceFormatV2,
     SingleIntFormat,
     MappingFormat,
 )
@@ -41,8 +42,25 @@ def _7(data: list) -> IntSequenceFormat:
 
 
 @dummy_plugin.register_transformer
+def _77(data: list) -> IntSequenceFormatV2:
+    ff = IntSequenceFormatV2()
+    with ff.open() as fh:
+        fh.write('VERSION 2\n')
+        for int_ in data:
+            fh.write('%d\n' % int_)
+    return ff
+
+
+@dummy_plugin.register_transformer
 def _9(ff: IntSequenceFormat) -> list:
     with ff.open() as fh:
+        return list(map(int, fh.readlines()))
+
+
+@dummy_plugin.register_transformer
+def _99(ff: IntSequenceFormatV2) -> list:
+    with ff.open() as fh:
+        fh.readline()  # skip header
         return list(map(int, fh.readlines()))
 
 
@@ -50,6 +68,25 @@ def _9(ff: IntSequenceFormat) -> list:
 def _10(ff: IntSequenceFormat) -> collections.Counter:
     with ff.open() as fh:
         return collections.Counter(map(int, fh.readlines()))
+
+
+@dummy_plugin.register_transformer
+def _1010(ff: IntSequenceFormatV2) -> collections.Counter:
+    with ff.open() as fh:
+        fh.readline()  # skip header
+        return collections.Counter(map(int, fh.readlines()))
+
+
+@dummy_plugin.register_transformer
+def _1000(ff: IntSequenceFormat) -> IntSequenceFormatV2:
+    new_ff = IntSequenceFormatV2()
+
+    with new_ff.open() as new_fh, ff.open() as fh:
+        new_fh.write("VERSION 2\n")
+        for line in fh:
+            new_fh.write(line)
+
+    return new_ff
 
 
 @dummy_plugin.register_transformer

--- a/qiime2/core/transform.py
+++ b/qiime2/core/transform.py
@@ -171,10 +171,10 @@ class SingleFileDirectoryFormatType(FormatType):
             return None
 
         if wrap_input:
-            transformer = self._wrap_input(transformer)
+            transformer = in_._wrap_input(transformer)
 
         if wrap_output:
-            transformer = self._wrap_output(transformer)
+            transformer = out_._wrap_output(transformer)
 
         return transformer
 

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -195,6 +195,16 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
 
         self.assertEqual(obs_filename, 'visualization.qzv')
 
+    def test_import_data_single_dirfmt_to_single_dirfmt(self):
+        temp_data_dir = os.path.join(self.test_dir.name, 'import')
+        os.mkdir(temp_data_dir)
+
+        with open(os.path.join(temp_data_dir, 'ints.txt'), 'w') as fh:
+            fh.write("1\n2\n3\n")
+
+        qiime2.Artifact.import_data('IntSequence2', temp_data_dir,
+                                    view_type="IntSequenceDirectoryFormat")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When importing it is sometimes the case that the user is importing a directory
and both the supplied view_type and the registered view_type are
SingleFileDirectoryFormats with only a single transformer between their
respective file-formats. This should be fine, but the implicit transformers of:

XDirFmt -> X => Y -> YDirFmt

were not working (where -> is an implicit transformer and => is a registered
one).