### PR TITLE
ENH: support methods/visualizers without input artifacts

### DIFF
--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -35,6 +35,16 @@ def merge_mappings(mapping1: dict, mapping2: dict) -> dict:
     return merged
 
 
+# No input artifacts, only parameters.
+def params_only_method(name: str, age: int) -> dict:
+    return {name: age}
+
+
+# No input artifacts or parameters.
+def no_input_method() -> dict:
+    return {'foo': 42}
+
+
 def identity_with_metadata(ints: list, metadata: qiime2.Metadata) -> list:
     return ints
 

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -25,8 +25,10 @@ from .format import (
 from .type import (IntSequence1, IntSequence2, Mapping, FourInts,
                    Kennel, Dog, Cat)
 from .method import (concatenate_ints, split_ints, merge_mappings,
-                     identity_with_metadata, identity_with_metadata_category)
-from .visualizer import most_common_viz, mapping_viz
+                     identity_with_metadata, identity_with_metadata_category,
+                     params_only_method, no_input_method)
+from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
+                         no_input_viz)
 
 dummy_plugin = qiime2.plugin.Plugin(
     name='dummy-plugin',
@@ -157,6 +159,55 @@ dummy_plugin.methods.register_function(
     name='Identity',
     description='This method does nothing, but takes a metadata category'
 )
+
+
+dummy_plugin.methods.register_function(
+    function=params_only_method,
+    inputs={},
+    parameters={
+        'name': qiime2.plugin.Str,
+        'age': qiime2.plugin.Int
+    },
+    outputs=[
+        ('out', Mapping)
+    ],
+    name='Parameters only method',
+    description='This method only accepts parameters.'
+)
+
+
+dummy_plugin.methods.register_function(
+    function=no_input_method,
+    inputs={},
+    parameters={},
+    outputs=[
+        ('out', Mapping)
+    ],
+    name='No input method',
+    description='This method does not accept any type of input.'
+)
+
+
+dummy_plugin.visualizers.register_function(
+    function=params_only_viz,
+    inputs={},
+    parameters={
+        'name': qiime2.plugin.Str,
+        'age': qiime2.plugin.Int
+    },
+    name='Parameters only viz',
+    description='This visualizer only accepts parameters.'
+)
+
+
+dummy_plugin.visualizers.register_function(
+    function=no_input_viz,
+    inputs={},
+    parameters={},
+    name='No input viz',
+    description='This visualizer does not accept any type of input.'
+)
+
 
 dummy_plugin.visualizers.register_function(
     function=most_common_viz,

--- a/qiime2/core/testing/visualizer.py
+++ b/qiime2/core/testing/visualizer.py
@@ -40,6 +40,23 @@ def multi_html_viz(output_dir: str, ints: list) -> None:
         fh.write('</body></html>')
 
 
+# No input artifacts, only parameters.
+def params_only_viz(output_dir: str, name: str='Foo Bar', age: int=42):
+    with open(os.path.join(output_dir, 'index.html'), 'w') as fh:
+        fh.write('<html><body>\n')
+        fh.write('Name: %s\n' % name)
+        fh.write('Age: %s\n' % age)
+        fh.write('</body></html>')
+
+
+# No input artifacts or parameters.
+def no_input_viz(output_dir: str):
+    with open(os.path.join(output_dir, 'index.html'), 'w') as fh:
+        fh.write('<html><body>\n')
+        fh.write('Hello, World!\n')
+        fh.write('</body></html>')
+
+
 # Multiple input artifacts and parameters, and a nested directory with required
 # resources for rendering.
 def mapping_viz(output_dir: str, mapping1: dict, mapping2: dict,

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -62,7 +62,7 @@ class ParameterSpec(ImmutableBase):
         return not (self == other)
 
 
-# Note: Pipeline doesn't exist yet but it is expected to accept one or more
+# Note: Pipeline doesn't exist yet but it is expected to accept zero or more
 # input semantic types, zero or more parameters, and produce one or more output
 # semantic types or Visualization types.
 class PipelineSignature:
@@ -213,10 +213,6 @@ class PipelineSignature:
         return annotated_inputs, annotated_parameters, annotated_outputs
 
     def _assert_valid_inputs(self, inputs):
-        if len(inputs) == 0:
-            raise TypeError("%s requires at least one input"
-                            % self.__class__.__name__)
-
         for input_name, spec in inputs.items():
             if not is_semantic_type(spec.qiime_type):
                 raise TypeError(

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -75,7 +75,9 @@ class TestPlugin(unittest.TestCase):
                          {'merge_mappings', 'concatenate_ints', 'split_ints',
                           'most_common_viz', 'mapping_viz',
                           'identity_with_metadata',
-                          'identity_with_metadata_category'})
+                          'identity_with_metadata_category',
+                          'params_only_method', 'no_input_method',
+                          'params_only_viz', 'no_input_viz'})
         for action in actions.values():
             self.assertIsInstance(action, qiime2.sdk.Action)
 
@@ -91,7 +93,8 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(methods.keys(),
                          {'merge_mappings', 'concatenate_ints', 'split_ints',
                           'identity_with_metadata',
-                          'identity_with_metadata_category'})
+                          'identity_with_metadata_category',
+                          'params_only_method', 'no_input_method'})
         for method in methods.values():
             self.assertIsInstance(method, qiime2.sdk.Action)
 
@@ -99,7 +102,8 @@ class TestPlugin(unittest.TestCase):
         visualizers = self.plugin.visualizers
 
         self.assertEqual(visualizers.keys(),
-                         {'most_common_viz', 'mapping_viz'})
+                         {'most_common_viz', 'mapping_viz', 'params_only_viz',
+                          'no_input_viz'})
         for viz in visualizers.values():
             self.assertIsInstance(viz, qiime2.sdk.Action)
 


### PR DESCRIPTION
Methods and visualizers are no longer required to accept at least one input artifact.

Fixes #261.