### PR TITLE
TST: fix overzealous tests for extract

### DIFF
--- a/qiime2/core/testing/util.py
+++ b/qiime2/core/testing/util.py
@@ -32,10 +32,10 @@ class ArchiveTestingMixin:
 
         Parameters
         ----------
-        archive_filepath : str
+        archive_filepath : str or Path
             Filepath to archive whose members will be verified against the
             `expected` members.
-        root_dir : str
+        root_dir : str or Path
             Root directory of the archive. Will be prepended to the member
             paths in `expected`. This is useful when the archive's root
             directory is not known ahead of time (e.g. when it is a random
@@ -45,6 +45,8 @@ class ArchiveTestingMixin:
             `root_dir`.
 
         """
+        archive_filepath = str(archive_filepath)
+        root_dir = str(root_dir)
         with zipfile.ZipFile(archive_filepath, mode='r') as zf:
             observed = set(zf.namelist())
 
@@ -59,9 +61,9 @@ class ArchiveTestingMixin:
 
         Parameters
         ----------
-        extract_dir : str
+        extract_dir : str or Path
             Path to directory the archive was extracted to.
-        root_dir : str
+        root_dir : str or Path
             Root directory of the archive that was extracted to `extract_dir`.
             This is useful when the archive's root directory is not known ahead
             of time (e.g. when it is a random UUID) and the caller is
@@ -71,6 +73,8 @@ class ArchiveTestingMixin:
             as paths relative to `root_dir`.
 
         """
+        extract_dir = str(extract_dir)
+        root_dir = str(root_dir)
         observed = set()
         for root, _, filenames in os.walk(extract_dir):
             for filename in filenames:

--- a/qiime2/sdk/tests/test_artifact.py
+++ b/qiime2/sdk/tests/test_artifact.py
@@ -11,6 +11,7 @@ import os
 import tempfile
 import unittest
 import uuid
+import pathlib
 
 import qiime2.core.type
 from qiime2.sdk import Artifact
@@ -230,9 +231,11 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
         artifact.save(fp)
 
         root_dir = str(artifact.uuid)
-        output_dir = os.path.join(self.test_dir.name, 'artifact-extract-test')
+        # pathlib normalizes away the `.`, it doesn't matter, but this is the
+        # implementation we're using, so let's test against that assumption.
+        output_dir = pathlib.Path(self.test_dir.name) / 'artifact-extract-test'
         result_dir = Artifact.extract(fp, output_dir=output_dir)
-        self.assertEqual(result_dir, os.path.join(output_dir, root_dir))
+        self.assertEqual(result_dir, str(output_dir / root_dir))
 
         expected = {
             'VERSION',

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -9,6 +9,7 @@
 import os
 import tempfile
 import unittest
+import pathlib
 
 import qiime2.core.type
 from qiime2.sdk import Result, Artifact, Visualization
@@ -80,9 +81,11 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
         artifact.save(fp)
 
         root_dir = str(artifact.uuid)
-        output_dir = os.path.join(self.test_dir.name, 'artifact-extract-test')
+        # pathlib normalizes away the `.`, it doesn't matter, but this is the
+        # implementation we're using, so let's test against that assumption.
+        output_dir = pathlib.Path(self.test_dir.name) / 'artifact-extract-test'
         result_dir = Result.extract(fp, output_dir=output_dir)
-        self.assertEqual(result_dir, os.path.join(output_dir, root_dir))
+        self.assertEqual(result_dir, str(output_dir / root_dir))
 
         expected = {
             'VERSION',
@@ -105,9 +108,9 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
         visualization.save(fp)
 
         root_dir = str(visualization.uuid)
-        output_dir = os.path.join(self.test_dir.name, 'viz-extract-test')
+        output_dir = pathlib.Path(self.test_dir.name) / 'viz-extract-test'
         result_dir = Result.extract(fp, output_dir=output_dir)
-        self.assertEqual(result_dir, os.path.join(output_dir, root_dir))
+        self.assertEqual(result_dir, str(output_dir / root_dir))
 
         expected = {
             'VERSION',

--- a/qiime2/sdk/tests/test_visualization.py
+++ b/qiime2/sdk/tests/test_visualization.py
@@ -11,6 +11,7 @@ import tempfile
 import unittest
 import uuid
 import collections
+import pathlib
 
 import qiime2.core.type
 from qiime2.sdk import Visualization
@@ -193,9 +194,11 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
         visualization.save(fp)
 
         root_dir = str(visualization.uuid)
-        output_dir = os.path.join(self.test_dir.name, 'viz-extract-test')
+        # pathlib normalizes away the `.`, it doesn't matter, but this is the
+        # implementation we're using, so let's test against that assumption.
+        output_dir = pathlib.Path(self.test_dir.name) / 'viz-extract-test'
         result_dir = Visualization.extract(fp, output_dir=output_dir)
-        self.assertEqual(result_dir, os.path.join(output_dir, root_dir))
+        self.assertEqual(result_dir, str(output_dir / root_dir))
 
         expected = {
             'VERSION',


### PR DESCRIPTION
This really only comes up if you set your `TMPDIR` to `.` while running the test suite.