### PR TITLE
ENH: Adds basic docstring to Actions

### DIFF
--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -11,6 +11,7 @@ import concurrent.futures
 import inspect
 import os.path
 import tempfile
+import textwrap
 
 import decorator
 
@@ -40,6 +41,8 @@ def _async_action(action, args, kwargs):
 
 
 class Action(metaclass=abc.ABCMeta):
+    """ QIIME 2 Action """
+
     type = 'action'
 
     __call__ = LateBindingAttribute('_dynamic_call')
@@ -254,6 +257,8 @@ class Action(metaclass=abc.ABCMeta):
     def _set_wrapper_properties(self, wrapper, name):
         wrapper.__name__ = wrapper.__qualname__ = name
         wrapper.__module__ = self.package
+        wrapper.__doc__ = "{}\n\n{}".format(
+            self.name, '\n'.join(textwrap.wrap(self.description, width=79)))
         del wrapper.__annotations__
         # This is necessary so that `inspect` doesn't display the wrapped
         # function's annotations (the annotations apply to the "view API" and
@@ -265,6 +270,8 @@ class Action(metaclass=abc.ABCMeta):
 
 
 class Method(Action):
+    """ QIIME 2 Method """
+
     type = 'method'
 
     # Abstract method implementations:
@@ -319,6 +326,8 @@ class Method(Action):
 
 
 class Visualizer(Action):
+    """ QIIME 2 Visualizer """
+
     type = 'visualizer'
 
     # Abstract method implementations:

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -41,7 +41,7 @@ def _async_action(action, args, kwargs):
 
 
 class Action(metaclass=abc.ABCMeta):
-    """ QIIME 2 Action """
+    """QIIME 2 Action"""
 
     type = 'action'
 
@@ -258,7 +258,7 @@ class Action(metaclass=abc.ABCMeta):
         wrapper.__name__ = wrapper.__qualname__ = name
         wrapper.__module__ = self.package
         wrapper.__doc__ = "{}\n\n{}".format(
-            self.name, '\n'.join(textwrap.wrap(self.description, width=79)))
+            self.name, textwrap.fill(self.description, width=79))
         del wrapper.__annotations__
         # This is necessary so that `inspect` doesn't display the wrapped
         # function's annotations (the annotations apply to the "view API" and
@@ -270,7 +270,7 @@ class Action(metaclass=abc.ABCMeta):
 
 
 class Method(Action):
-    """ QIIME 2 Method """
+    """QIIME 2 Method"""
 
     type = 'method'
 
@@ -326,7 +326,7 @@ class Method(Action):
 
 
 class Visualizer(Action):
-    """ QIIME 2 Visualizer """
+    """QIIME 2 Visualizer"""
 
     type = 'visualizer'
 

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -418,6 +418,16 @@ class TestMethod(unittest.TestCase):
         self.assertEqual(result.left.view(list), [0, 42])
         self.assertEqual(result.right.view(list), [-2, 43, 6])
 
+    def test_docstring(self):
+        method = self.plugin.methods['split_ints']
+        exp = "QIIME 2 Method"
+        self.assertEqual(exp, method.__doc__)
+        obs = method.__call__.__doc__.split('\n')
+        self.assertTrue(obs[0].startswith('Split sequence of integers'))
+        self.assertEqual(len(obs[1]), 0)
+        self.assertTrue(obs[2].startswith('This method splits'))
+        self.assertTrue(obs[3].startswith('(left and'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -403,6 +403,17 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         self.assertIsInstance(output, Results)
         self.assertIsInstance(output.visualization, Visualization)
 
+    def test_docstring(self):
+        visualizer = self.plugin.visualizers['mapping_viz']
+        exp = "QIIME 2 Visualizer"
+        self.assertEqual(exp, visualizer.__doc__)
+        obs = visualizer.__call__.__doc__.split('\n')
+        self.assertTrue(obs[0].startswith('Visualize two'))
+        self.assertEqual(len(obs[1]), 0)
+        self.assertTrue(obs[2].startswith('This visualizer produces an HTML'))
+        self.assertTrue(obs[3].startswith('sorted in alphabetical'))
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -414,6 +414,5 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         self.assertTrue(obs[3].startswith('sorted in alphabetical'))
 
 
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
At the moment, when `?` is called on any QIIME 2 action, this is the help text that Jupyter produces (my examples use ``feature_table.rarefy``):
<img width="1161" alt="screen shot 2017-06-08 at 4 54 15 pm" src="https://user-images.githubusercontent.com/6307252/26955374-3324d014-4c6b-11e7-95a6-62ab1edfd7c1.png">
This is extremely general, and not very helpful to the user. The only arguably useful information it provides is the arguments the function requires. 

After my changes, this is the help text that Jupyter produces:
<img width="1167" alt="screen shot 2017-06-08 at 4 57 59 pm" src="https://user-images.githubusercontent.com/6307252/26955453-a97ed30e-4c6b-11e7-9737-f1c6161aae28.png">
As you can see, now there is more information regarding the Method. The user sees that it is a QIIME 2 Method object, and is given some useful help text. 

fixes #278 
@jairideout, @ebolyen, @thermokarst, very simple, ready for review.