### PR TITLE
ENH: Adds annotations to Actions

### DIFF
--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -13,7 +13,7 @@ import unittest
 import uuid
 
 import qiime2.plugin
-from qiime2.core.type import MethodSignature
+from qiime2.core.type import MethodSignature, Int
 from qiime2.sdk import Artifact, Method, Results
 
 from qiime2.core.testing.method import (concatenate_ints, merge_mappings,
@@ -172,18 +172,40 @@ class TestMethod(unittest.TestCase):
         concatenate_ints = self.plugin.methods['concatenate_ints']
         merge_mappings = self.plugin.methods['merge_mappings']
 
-        for method in concatenate_ints, merge_mappings:
+        concatenate_exp = {
+            'int2': Int, 'ints2': IntSequence1, 'return': (IntSequence1,),
+            'int1': Int, 'ints3': IntSequence2,
+            'ints1': IntSequence1 | IntSequence2}
+        merge_exp = {
+            'mapping2': Mapping, 'mapping1': Mapping, 'return': (Mapping,)}
+
+        mapper = {
+            concatenate_ints: concatenate_exp,
+            merge_mappings: merge_exp}
+
+        for method, exp in mapper.items():
             self.assertEqual(method.__call__.__name__, '__call__')
-            self.assertEqual(method.__call__.__annotations__, {})
+            self.assertEqual(method.__call__.__annotations__, exp)
             self.assertFalse(hasattr(method.__call__, '__wrapped__'))
 
     def test_async_properties(self):
         concatenate_ints = self.plugin.methods['concatenate_ints']
         merge_mappings = self.plugin.methods['merge_mappings']
 
-        for method in concatenate_ints, merge_mappings:
+        concatenate_exp = {
+            'int2': Int, 'ints2': IntSequence1, 'return': (IntSequence1,),
+            'int1': Int, 'ints3': IntSequence2,
+            'ints1': IntSequence1 | IntSequence2}
+        merge_exp = {
+            'mapping2': Mapping, 'mapping1': Mapping, 'return': (Mapping,)}
+
+        mapper = {
+            concatenate_ints: concatenate_exp,
+            merge_mappings: merge_exp}
+
+        for method, exp in mapper.items():
             self.assertEqual(method.async.__name__, 'async')
-            self.assertEqual(method.async.__annotations__, {})
+            self.assertEqual(method.async.__annotations__, exp)
             self.assertFalse(hasattr(method.async, '__wrapped__'))
 
     def test_callable_and_async_signature_with_artifacts_and_parameters(self):
@@ -197,16 +219,19 @@ class TestMethod(unittest.TestCase):
 
             kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
             exp_parameters = [
-                ('ints1', inspect.Parameter('ints1', kind)),
-                ('ints2', inspect.Parameter('ints2', kind)),
-                ('ints3', inspect.Parameter('ints3', kind)),
-                ('int1', inspect.Parameter('int1', kind)),
-                ('int2', inspect.Parameter('int2', kind))
+                ('ints1', inspect.Parameter(
+                    'ints1', kind, annotation=IntSequence1 | IntSequence2)),
+                ('ints2', inspect.Parameter(
+                    'ints2', kind, annotation=IntSequence1)),
+                ('ints3', inspect.Parameter(
+                    'ints3', kind, annotation=IntSequence2)),
+                ('int1', inspect.Parameter(
+                    'int1', kind, annotation=Int)),
+                ('int2', inspect.Parameter(
+                    'int2', kind, annotation=Int))
             ]
-            self.assertEqual(parameters, exp_parameters)
 
-            self.assertEqual(signature.return_annotation,
-                             inspect.Signature.empty)
+            self.assertEqual(parameters, exp_parameters)
 
     def test_callable_and_async_signature_with_no_parameters(self):
         # Signature without parameters (i.e. primitives), only input artifacts.
@@ -219,13 +244,13 @@ class TestMethod(unittest.TestCase):
 
             kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
             exp_parameters = [
-                ('mapping1', inspect.Parameter('mapping1', kind)),
-                ('mapping2', inspect.Parameter('mapping2', kind))
+                ('mapping1', inspect.Parameter(
+                    'mapping1', kind, annotation=Mapping)),
+                ('mapping2', inspect.Parameter(
+                    'mapping2', kind, annotation=Mapping))
             ]
-            self.assertEqual(parameters, exp_parameters)
 
-            self.assertEqual(signature.return_annotation,
-                             inspect.Signature.empty)
+            self.assertEqual(parameters, exp_parameters)
 
     def test_call_with_artifacts_and_parameters(self):
         concatenate_ints = self.plugin.methods['concatenate_ints']

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -15,7 +15,8 @@ import uuid
 
 import qiime2.plugin
 import qiime2.core.type
-from qiime2.core.type import VisualizerSignature
+from qiime2.core.type import VisualizerSignature, Str
+from qiime2.core.type.visualization import Visualization as VisualizationType
 from qiime2.sdk import Artifact, Visualization, Visualizer, Results
 
 from qiime2.core.testing.visualizer import (most_common_viz, mapping_viz,
@@ -133,18 +134,40 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         mapping_viz = self.plugin.visualizers['mapping_viz']
         most_common_viz = self.plugin.visualizers['most_common_viz']
 
-        for visualizer in mapping_viz, most_common_viz:
+        mapping_exp = {
+            'mapping1': Mapping, 'return': (VisualizationType,),
+            'key_label': Str, 'mapping2': Mapping, 'value_label': Str}
+        most_common_exp = {
+            'ints': IntSequence1 | IntSequence2,
+            'return': (VisualizationType,)}
+
+        mapper = {
+            mapping_viz: mapping_exp,
+            most_common_viz: most_common_exp}
+
+        for visualizer, exp in mapper.items():
             self.assertEqual(visualizer.__call__.__name__, '__call__')
-            self.assertEqual(visualizer.__call__.__annotations__, {})
+            self.assertEqual(visualizer.__call__.__annotations__, exp)
             self.assertFalse(hasattr(visualizer.__call__, '__wrapped__'))
 
     def test_async_properties(self):
         mapping_viz = self.plugin.visualizers['mapping_viz']
         most_common_viz = self.plugin.visualizers['most_common_viz']
 
-        for visualizer in mapping_viz, most_common_viz:
+        mapping_exp = {
+            'mapping1': Mapping, 'return': (VisualizationType,),
+            'key_label': Str, 'mapping2': Mapping, 'value_label': Str}
+        most_common_exp = {
+            'ints': IntSequence1 | IntSequence2,
+            'return': (VisualizationType,)}
+
+        mapper = {
+            mapping_viz: mapping_exp,
+            most_common_viz: most_common_exp}
+
+        for visualizer, exp in mapper.items():
             self.assertEqual(visualizer.async.__name__, 'async')
-            self.assertEqual(visualizer.async.__annotations__, {})
+            self.assertEqual(visualizer.async.__annotations__, exp)
             self.assertFalse(hasattr(visualizer.async, '__wrapped__'))
 
     def test_callable_and_async_signature(self):
@@ -157,15 +180,17 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
 
             kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
             exp_parameters = [
-                ('mapping1', inspect.Parameter('mapping1', kind)),
-                ('mapping2', inspect.Parameter('mapping2', kind)),
-                ('key_label', inspect.Parameter('key_label', kind)),
-                ('value_label', inspect.Parameter('value_label', kind))
+                ('mapping1', inspect.Parameter(
+                    'mapping1', kind, annotation=Mapping)),
+                ('mapping2', inspect.Parameter(
+                    'mapping2', kind, annotation=Mapping)),
+                ('key_label', inspect.Parameter(
+                    'key_label', kind, annotation=Str)),
+                ('value_label', inspect.Parameter(
+                    'value_label', kind, annotation=Str))
             ]
-            self.assertEqual(parameters, exp_parameters)
 
-            self.assertEqual(signature.return_annotation,
-                             inspect.Signature.empty)
+            self.assertEqual(parameters, exp_parameters)
 
     def test_callable_and_async_different_signature(self):
         # Test that a different Visualizer object has a different dynamic
@@ -179,12 +204,11 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
 
             kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
             exp_parameters = [
-                ('ints', inspect.Parameter('ints', kind))
+                ('ints', inspect.Parameter(
+                    'ints', kind, annotation=IntSequence1 | IntSequence2))
             ]
-            self.assertEqual(parameters, exp_parameters)
 
-            self.assertEqual(signature.return_annotation,
-                             inspect.Signature.empty)
+            self.assertEqual(parameters, exp_parameters)
 
     def test_call_with_artifacts_and_parameters(self):
         mapping_viz = self.plugin.visualizers['mapping_viz']


### PR DESCRIPTION
As of now, when ``?`` is called on a QIIME 2 Method or Visualizer, this is the general format of the help text produced by Jupyter:
<img width="1168" alt="screen shot 2017-06-12 at 1 21 06 pm" src="https://user-images.githubusercontent.com/6307252/27053545-86f3b37c-4f72-11e7-882c-98c8b6707a8f.png">

This help text is helpful, although it is missing a key component that is now tied to all Methods and Visualizers, due to some new Python functionality, that component being _annotations_. This PR adds annotations (including return annotations) and testing to Actions.

Calling ``?`` with the PR in effect:
<img width="1171" alt="screen shot 2017-06-12 at 1 21 40 pm" src="https://user-images.githubusercontent.com/6307252/27053651-de090978-4f72-11e7-9166-a507f6a131e0.png">
