### PR TITLE
BUG: fix optional support in decode_parameters

### DIFF
--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -268,7 +268,9 @@ class PipelineSignature:
     def decode_parameters(self, **kwargs):
         params = {}
         for key, spec in self.parameters.items():
-            if spec.has_default() and spec.default is kwargs[key] is None:
+            if (spec.has_default() and
+                    spec.default is None and
+                    kwargs[key] is None):
                 params[key] = None
             else:
                 params[key] = spec.qiime_type.decode(kwargs[key])
@@ -285,7 +287,8 @@ class PipelineSignature:
                 # A type mismatch is unacceptable unless the value is None
                 # and this parameter's default value is None.
                 if not (spec.has_default() and
-                        spec.default is kwargs[name] is None):
+                        spec.default is None and
+                        kwargs[name] is None):
                     raise TypeError("Argument to parameter %r is not a "
                                     "subtype of %r." % (name, spec.qiime_type))
 

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -268,7 +268,10 @@ class PipelineSignature:
     def decode_parameters(self, **kwargs):
         params = {}
         for key, spec in self.parameters.items():
-            params[key] = spec.qiime_type.decode(kwargs[key])
+            if spec.has_default() and spec.default is kwargs[key] is None:
+                params[key] = None
+            else:
+                params[key] = spec.qiime_type.decode(kwargs[key])
         return params
 
     def check_types(self, **kwargs):


### PR DESCRIPTION
Discovered while updated q2studio.

This should *probably* have unit-tests