### PR TITLE
TST: add testing methods for optional metadata and optional metadata category

### DIFF
--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -52,3 +52,13 @@ def identity_with_metadata(ints: list, metadata: qiime2.Metadata) -> list:
 def identity_with_metadata_category(ints: list,
                                     metadata: qiime2.MetadataCategory) -> list:
     return ints
+
+
+def identity_with_optional_metadata(ints: list,
+                                    metadata: qiime2.Metadata=None) -> list:
+    return ints
+
+
+def identity_with_optional_metadata_category(
+        ints: list, metadata: qiime2.MetadataCategory=None) -> list:
+    return ints

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -28,6 +28,8 @@ from .type import (IntSequence1, IntSequence2, Mapping, FourInts,
                    Kennel, Dog, Cat)
 from .method import (concatenate_ints, split_ints, merge_mappings,
                      identity_with_metadata, identity_with_metadata_category,
+                     identity_with_optional_metadata,
+                     identity_with_optional_metadata_category,
                      params_only_method, no_input_method)
 from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
@@ -161,6 +163,38 @@ dummy_plugin.methods.register_function(
     ],
     name='Identity',
     description='This method does nothing, but takes a metadata category'
+)
+
+
+dummy_plugin.methods.register_function(
+    function=identity_with_optional_metadata,
+    inputs={
+        'ints': IntSequence1 | IntSequence2
+    },
+    parameters={
+        'metadata': qiime2.plugin.Metadata
+    },
+    outputs=[
+        ('out', IntSequence1)
+    ],
+    name='Identity',
+    description='This method does nothing, but takes optional metadata'
+)
+
+dummy_plugin.methods.register_function(
+    function=identity_with_optional_metadata_category,
+    inputs={
+        'ints': IntSequence1 | IntSequence2
+    },
+    parameters={
+        'metadata': qiime2.plugin.MetadataCategory
+    },
+    outputs=[
+        ('out', IntSequence1)
+    ],
+    name='Identity',
+    description='This method does nothing, but takes an optional metadata '
+                'category'
 )
 
 

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -76,6 +76,8 @@ class TestPlugin(unittest.TestCase):
                           'most_common_viz', 'mapping_viz',
                           'identity_with_metadata',
                           'identity_with_metadata_category',
+                          'identity_with_optional_metadata',
+                          'identity_with_optional_metadata_category',
                           'params_only_method', 'no_input_method',
                           'params_only_viz', 'no_input_viz'})
         for action in actions.values():
@@ -94,6 +96,8 @@ class TestPlugin(unittest.TestCase):
                          {'merge_mappings', 'concatenate_ints', 'split_ints',
                           'identity_with_metadata',
                           'identity_with_metadata_category',
+                          'identity_with_optional_metadata',
+                          'identity_with_optional_metadata_category',
                           'params_only_method', 'no_input_method'})
         for method in methods.values():
             self.assertIsInstance(method, qiime2.sdk.Action)


### PR DESCRIPTION
Adding these methods for testing q2cli's optional metadata support.