### PR TITLE
ENH: support optional artifacts

### DIFF
--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -285,7 +285,7 @@ class ActionProvenanceCapture(ProvenanceCapture):
 
     def add_input(self, name, artifact):
         if artifact is None:
-            self.inputs[name] = artifact
+            self.inputs[name] = None
         else:
             ancestral_provenance = self.add_ancestor(artifact)
             if ancestral_provenance is NotImplemented:

--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -284,11 +284,14 @@ class ActionProvenanceCapture(ProvenanceCapture):
         self.parameters[name] = handler(parameter)
 
     def add_input(self, name, artifact):
-        ancestral_provenance = self.add_ancestor(artifact)
-        if ancestral_provenance is NotImplemented:
-            self.inputs[name] = NoProvenance(artifact.uuid)
+        if artifact is None:
+            self.inputs[name] = artifact
         else:
-            self.inputs[name] = str(artifact.uuid)
+            ancestral_provenance = self.add_ancestor(artifact)
+            if ancestral_provenance is NotImplemented:
+                self.inputs[name] = NoProvenance(artifact.uuid)
+            else:
+                self.inputs[name] = str(artifact.uuid)
 
     def make_action_section(self):
         action = collections.OrderedDict()

--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -62,3 +62,15 @@ def identity_with_optional_metadata(ints: list,
 def identity_with_optional_metadata_category(
         ints: list, metadata: qiime2.MetadataCategory=None) -> list:
     return ints
+
+
+def optional_artifacts_method(ints: list, num1: int, optional1: list=None,
+                              optional2: list=None, num2: int=None) -> list:
+    result = ints + [num1]
+    if optional1 is not None:
+        result += optional1
+    if optional2 is not None:
+        result += optional2
+    if num2 is not None:
+        result += [num2]
+    return result

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -30,7 +30,8 @@ from .method import (concatenate_ints, split_ints, merge_mappings,
                      identity_with_metadata, identity_with_metadata_category,
                      identity_with_optional_metadata,
                      identity_with_optional_metadata_category,
-                     params_only_method, no_input_method)
+                     params_only_method, no_input_method,
+                     optional_artifacts_method)
 from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
 
@@ -222,6 +223,26 @@ dummy_plugin.methods.register_function(
     ],
     name='No input method',
     description='This method does not accept any type of input.'
+)
+
+
+dummy_plugin.methods.register_function(
+    function=optional_artifacts_method,
+    inputs={
+        'ints': IntSequence1,
+        'optional1': IntSequence1,
+        'optional2': IntSequence1 | IntSequence2
+    },
+    parameters={
+        'num1': qiime2.plugin.Int,
+        'num2': qiime2.plugin.Int
+    },
+    outputs=[
+        ('output', IntSequence1)
+    ],
+    name='Optional artifacts method',
+    description='This method declares optional artifacts and concatenates '
+                'whatever integers are supplied as input.'
 )
 
 

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -92,9 +92,10 @@ class PipelineSignature:
             Output name to description string.
 
         """
-        inputs, parameters, outputs = self._parse_signature(
-            callable, inputs, parameters, outputs, input_descriptions,
-            parameter_descriptions, output_descriptions)
+        inputs, parameters, outputs, ordered_parameters = \
+            self._parse_signature(callable, inputs, parameters, outputs,
+                                  input_descriptions, parameter_descriptions,
+                                  output_descriptions)
 
         self._assert_valid_inputs(inputs)
         self._assert_valid_parameters(parameters)
@@ -103,12 +104,13 @@ class PipelineSignature:
         self.inputs = inputs
         self.parameters = parameters
         self.outputs = outputs
+        self.ordered_parameters = ordered_parameters
 
     @property
     def defaults(self):
         return collections.OrderedDict([
-            (name, spec.default) for name, spec in self.parameters.items()
-            if spec.has_default()])
+            (name, spec.default) for name, spec in
+            self.ordered_parameters.items() if spec.has_default()])
 
     def _parse_signature(self, callable, inputs, parameters, outputs,
                          input_descriptions=None, parameter_descriptions=None,
@@ -132,8 +134,8 @@ class PipelineSignature:
         annotated_inputs = collections.OrderedDict()
         annotated_parameters = collections.OrderedDict()
         annotated_outputs = collections.OrderedDict()
+        ordered_parameters = collections.OrderedDict()
 
-        in_parameter_section = False
         for name, parameter in inspect.signature(callable).parameters.items():
             if (parameter.kind == parameter.VAR_POSITIONAL or
                     parameter.kind == parameter.VAR_KEYWORD):
@@ -155,23 +157,21 @@ class PipelineSignature:
                 default = parameter.default
 
             if name in inputs:
-                if in_parameter_section:
-                    # Mixing "parameters" into the "input" section is not
-                    # allowed
-                    raise TypeError("Artifact inputs must come before"
-                                    " parameters in callable signature.")
                 description = input_descriptions.pop(name,
                                                      ParameterSpec.NOVALUE)
-                annotated_inputs[name] = ParameterSpec(
+                param_spec = ParameterSpec(
                     qiime_type=inputs.pop(name), view_type=view_type,
                     default=default, description=description)
+                annotated_inputs[name] = param_spec
+                ordered_parameters[name] = param_spec
             elif name in parameters:
-                in_parameter_section = True
                 description = parameter_descriptions.pop(name,
                                                          ParameterSpec.NOVALUE)
-                annotated_parameters[name] = ParameterSpec(
+                param_spec = ParameterSpec(
                     qiime_type=parameters.pop(name), view_type=view_type,
                     default=default, description=description)
+                annotated_parameters[name] = param_spec
+                ordered_parameters[name] = param_spec
             elif name not in self.builtin_args:
                 raise TypeError("Parameter in callable without QIIME type:"
                                 " %r" % name)
@@ -210,7 +210,8 @@ class PipelineSignature:
                                       *parameter_descriptions,
                                       *output_descriptions])
 
-        return annotated_inputs, annotated_parameters, annotated_outputs
+        return (annotated_inputs, annotated_parameters, annotated_outputs,
+                ordered_parameters)
 
     def _assert_valid_inputs(self, inputs):
         for input_name, spec in inputs.items():
@@ -224,9 +225,11 @@ class PipelineSignature:
                     "Input %r must be a complete semantic type expression, "
                     "not %r" % (input_name, spec.qiime_type))
 
-            if spec.has_default():
-                raise ValueError("Input %r must not have a default value"
-                                 % input_name)
+            if spec.has_default() and spec.default is not None:
+                raise ValueError(
+                    "Input %r has a default value of %r. Only a default "
+                    "value of `None` is supported for inputs."
+                    % (input_name, spec.default))
 
     def _assert_valid_parameters(self, parameters):
         for param_name, spec in parameters.items():
@@ -244,7 +247,7 @@ class PipelineSignature:
                     spec.default is not None and
                     spec.default not in spec.qiime_type):
                 raise TypeError("Default value for parameter %r is not of "
-                                "semantic QIIME type %r or None."
+                                "semantic QIIME type %r or `None`."
                                 % (param_name, spec.qiime_type))
 
     def _assert_valid_outputs(self, outputs):
@@ -277,12 +280,7 @@ class PipelineSignature:
         return params
 
     def check_types(self, **kwargs):
-        for name, spec in self.inputs.items():
-            if kwargs[name] not in spec.qiime_type:
-                raise TypeError("Argument to input %r is not a subtype of"
-                                " %r." % (name, spec.qiime_type))
-
-        for name, spec in self.parameters.items():
+        for name, spec in self.ordered_parameters.items():
             if kwargs[name] not in spec.qiime_type:
                 # A type mismatch is unacceptable unless the value is None
                 # and this parameter's default value is None.
@@ -320,7 +318,8 @@ class PipelineSignature:
         return (type(self) is type(other) and
                 self.inputs == other.inputs and
                 self.parameters == other.parameters and
-                self.outputs == other.outputs)
+                self.outputs == other.outputs and
+                self.ordered_parameters == other.ordered_parameters)
 
     def __ne__(self, other):
         return not (self == other)
@@ -357,5 +356,5 @@ class VisualizerSignature(PipelineSignature):
         if output.has_view_type() and output.view_type is not None:
             raise TypeError(
                 "Visualizer callable cannot return anything. Its return "
-                "annotation must be None, not %r. Write output to "
+                "annotation must be `None`, not %r. Write output to "
                 "`output_dir`." % output.view_type)

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -79,7 +79,8 @@ class TestPlugin(unittest.TestCase):
                           'identity_with_optional_metadata',
                           'identity_with_optional_metadata_category',
                           'params_only_method', 'no_input_method',
-                          'params_only_viz', 'no_input_viz'})
+                          'optional_artifacts_method', 'params_only_viz',
+                          'no_input_viz'})
         for action in actions.values():
             self.assertIsInstance(action, qiime2.sdk.Action)
 
@@ -98,7 +99,8 @@ class TestPlugin(unittest.TestCase):
                           'identity_with_metadata_category',
                           'identity_with_optional_metadata',
                           'identity_with_optional_metadata_category',
-                          'params_only_method', 'no_input_method'})
+                          'params_only_method', 'no_input_method',
+                          'optional_artifacts_method'})
         for method in methods.values():
             self.assertIsInstance(method, qiime2.sdk.Action)
 

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -164,7 +164,7 @@ class Action(metaclass=abc.ABCMeta):
             args = args[1:]
 
             user_input = {name: value for value, name in
-                          zip(args, self.signature.ordered_parameters)}
+                          zip(args, self.signature.signature_order)}
             user_input.update(kwargs)
 
             self.signature.check_types(**user_input)
@@ -264,7 +264,7 @@ class Action(metaclass=abc.ABCMeta):
 
     def _build_annotations(self):
         annotations = {}
-        for name, spec in self.signature.ordered_parameters.items():
+        for name, spec in self.signature.signature_order.items():
             annotations[name] = spec.qiime_type
 
         output = []

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -192,7 +192,7 @@ class Action(metaclass=abc.ABCMeta):
                 recorder = provenance.transformation_recorder(name)
                 artifact = artifacts[name]
                 if artifact is None:
-                    view_args[name] = artifact
+                    view_args[name] = None
                 else:
                     view_args[name] = artifact._view(spec.view_type, recorder)
 

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -366,6 +366,34 @@ class TestMethod(unittest.TestCase):
         self.assertIsInstance(result.uuid, uuid.UUID)
         self.assertEqual(result.view(dict), {'foo': '42'})
 
+    def test_call_with_optional_artifacts(self):
+        method = self.plugin.methods['optional_artifacts_method']
+
+        ints1 = Artifact.import_data(IntSequence1, [0, 42, 43])
+        ints2 = Artifact.import_data(IntSequence1, [99, -22])
+        ints3 = Artifact.import_data(IntSequence2, [43, 43])
+
+        # No optional artifacts provided.
+        obs = method(ints1, 42).output
+
+        self.assertEqual(obs.view(list), [0, 42, 43, 42])
+
+        # One optional artifact provided.
+        obs = method(ints1, 42, optional1=ints2).output
+
+        self.assertEqual(obs.view(list), [0, 42, 43, 42, 99, -22])
+
+        # All optional artifacts provided.
+        obs = method(
+            ints1, 42, optional1=ints2, optional2=ints3, num2=111).output
+
+        self.assertEqual(obs.view(list), [0, 42, 43, 42, 99, -22, 43, 43, 111])
+
+        # Invalid type provided as optional artifact.
+        with self.assertRaisesRegex(TypeError,
+                                    'not a subtype of IntSequence1'):
+            method(ints1, 42, optional1=ints3)
+
     def test_async(self):
         concatenate_ints = self.plugin.methods['concatenate_ints']
 


### PR DESCRIPTION
Methods and visualizers now support optional artifacts. If an artifact is optional the only supported default value is `None`.

With this change, signature inputs and parameters are now allowed to be declared in any order (previously inputs were required to be followed by parameters, and they were not allowed to be mixed).

Removed `Signature.defaults` property in favor of using the `ParameterSpec` objects available within `Signature`.

Fixes #235.