### PR TITLE
ENH: Adds full Numpydoc-compliant docstring to Actions

### DIFF
--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -45,8 +45,8 @@ def no_input_method() -> dict:
     return {'foo': 42}
 
 
-def long_description_method(name: 'hello world', age: int) -> dict:
-    return {'foo': 42}
+def long_description_method(mapping1:dict, name: str, age: int) -> dict:
+    return {name: age}
 
 
 def identity_with_metadata(ints: list, metadata: qiime2.Metadata) -> list:

--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -45,7 +45,7 @@ def no_input_method() -> dict:
     return {'foo': 42}
 
 
-def long_description_method(mapping1:dict, name: str, age: int) -> dict:
+def long_description_method(mapping1: dict, name: str, age: int) -> dict:
     return {name: age}
 
 

--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -45,6 +45,10 @@ def no_input_method() -> dict:
     return {'foo': 42}
 
 
+def long_description_method(name: 'hello world', age: int) -> dict:
+    return {'foo': 42}
+
+
 def identity_with_metadata(ints: list, metadata: qiime2.Metadata) -> list:
     return ints
 

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -31,7 +31,7 @@ from .method import (concatenate_ints, split_ints, merge_mappings,
                      identity_with_optional_metadata,
                      identity_with_optional_metadata_category,
                      params_only_method, no_input_method,
-                     long_description_method)
+                     optional_artifacts_method, long_description_method)
 from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
 

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -179,7 +179,7 @@ dummy_plugin.methods.register_function(
     ],
     output_descriptions={
         'out': ("This is a very long description. If asked about its length,"
-                 " I would have to say it is greater than 79 characters.")
+                " I would have to say it is greater than 79 characters.")
     },
     name="Long Description",
     description=("This is a very long description. If asked about its length,"

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -125,10 +125,15 @@ dummy_plugin.methods.register_function(
         'mapping1': Mapping,
         'mapping2': Mapping
     },
+    input_descriptions={
+        'mapping1': 'Mapping object to be merged'
+    },
     parameters={},
     outputs=[
         ('merged_mapping', Mapping)
     ],
+    output_descriptions={
+        'merged_mapping': 'Resulting merged Mapping object'},
     name='Merge mappings',
     description='This method merges two mappings into a single new mapping. '
                 'If a key is shared between mappings and the values differ, '

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -30,7 +30,8 @@ from .method import (concatenate_ints, split_ints, merge_mappings,
                      identity_with_metadata, identity_with_metadata_category,
                      identity_with_optional_metadata,
                      identity_with_optional_metadata_category,
-                     params_only_method, no_input_method)
+                     params_only_method, no_input_method,
+                     long_description_method)
 from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
 
@@ -153,6 +154,24 @@ dummy_plugin.methods.register_function(
     ],
     name='Identity',
     description='This method does nothing, but takes metadata'
+)
+
+dummy_plugin.methods.register_function(
+    function=long_description_method,
+    inputs={},
+    parameters={
+        'name': qiime2.plugin.Str,
+        'age': qiime2.plugin.Int
+    },
+    parameter_descriptions={
+        'name': """This is a very long description. If asked about its length,\
+ I would have to say it is greater than 79 characters."""
+    },
+    outputs=[
+        ('out', Mapping)
+    ],
+    name="Long Description",
+    description="This method does nothing, but includes a long annotation"
 )
 
 dummy_plugin.methods.register_function(

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -158,20 +158,32 @@ dummy_plugin.methods.register_function(
 
 dummy_plugin.methods.register_function(
     function=long_description_method,
-    inputs={},
+    inputs={
+        'mapping1': Mapping
+    },
+    input_descriptions={
+        'mapping1': ("This is a very long description. If asked about its "
+                     "length, I would have to say it is greater than 79 "
+                     "characters.")
+    },
     parameters={
         'name': qiime2.plugin.Str,
         'age': qiime2.plugin.Int
     },
     parameter_descriptions={
-        'name': """This is a very long description. If asked about its length,\
- I would have to say it is greater than 79 characters."""
+        'name': ("This is a very long description. If asked about its length,"
+                 " I would have to say it is greater than 79 characters.")
     },
     outputs=[
         ('out', Mapping)
     ],
+    output_descriptions={
+        'out': ("This is a very long description. If asked about its length,"
+                 " I would have to say it is greater than 79 characters.")
+    },
     name="Long Description",
-    description="This method does nothing, but includes a long annotation"
+    description=("This is a very long description. If asked about its length,"
+                 " I would have to say it is greater than 79 characters.")
 )
 
 dummy_plugin.methods.register_function(

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -79,8 +79,8 @@ class TestPlugin(unittest.TestCase):
                           'identity_with_optional_metadata',
                           'identity_with_optional_metadata_category',
                           'params_only_method', 'no_input_method',
-                          'params_only_viz', 'no_input_viz',
-                          'long_description_method'})
+                          'optional_artifacts_method', 'params_only_viz',
+                          'no_input_viz', 'long_description_method'})
         for action in actions.values():
             self.assertIsInstance(action, qiime2.sdk.Action)
 
@@ -100,6 +100,7 @@ class TestPlugin(unittest.TestCase):
                           'identity_with_optional_metadata',
                           'identity_with_optional_metadata_category',
                           'params_only_method', 'no_input_method',
+                          'optional_artifacts_method',
                           'long_description_method'})
         for method in methods.values():
             self.assertIsInstance(method, qiime2.sdk.Action)

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -79,7 +79,8 @@ class TestPlugin(unittest.TestCase):
                           'identity_with_optional_metadata',
                           'identity_with_optional_metadata_category',
                           'params_only_method', 'no_input_method',
-                          'params_only_viz', 'no_input_viz'})
+                          'params_only_viz', 'no_input_viz',
+                          'long_description_method'})
         for action in actions.values():
             self.assertIsInstance(action, qiime2.sdk.Action)
 
@@ -98,7 +99,8 @@ class TestPlugin(unittest.TestCase):
                           'identity_with_metadata_category',
                           'identity_with_optional_metadata',
                           'identity_with_optional_metadata_category',
-                          'params_only_method', 'no_input_method'})
+                          'params_only_method', 'no_input_method',
+                          'long_description_method'})
         for method in methods.values():
             self.assertIsInstance(method, qiime2.sdk.Action)
 

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -288,11 +288,12 @@ class Action(metaclass=abc.ABCMeta):
         numpydoc += "{}\n\n".format(self.description)
 
         sig = self.signature
+        params = True if len(sig.inputs) != 0 else False
 
         numpydoc += "{}".format(self._build_section(
             "Parameters", sig.inputs))
         numpydoc += "{}".format(self._build_section(
-            "Parameters", sig.parameters, parameters=True))
+            "Parameters", sig.parameters, parameters=params))
         numpydoc += ("\n" if len(sig.parameters) != 0 or
                      len(sig.inputs) != 0 else "")
         numpydoc += "{}\n".format(self._build_section(

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -278,8 +278,8 @@ class Action(metaclass=abc.ABCMeta):
 
     def _build_numpydoc(self):
         numpydoc = []
-        numpydoc.append(textwrap.fill(self.name, width=79))
-        numpydoc.append(textwrap.fill(self.description, width=79))
+        numpydoc.append(textwrap.fill(self.name, width=75))
+        numpydoc.append(textwrap.fill(self.description, width=75))
 
         sig = self.signature
         params = collections.OrderedDict()
@@ -302,18 +302,16 @@ class Action(metaclass=abc.ABCMeta):
             section.append(header)
             section.append('-'*len(header))
             for key, value in iterable.items():
-                section.append(
+                variable_line = (
                     "{item} : {type}".format(item=key, type=value.qiime_type))
                 if value.has_default():
-                    section[-1] += ", optional"
+                    variable_line += ", optional"
+                section.append(variable_line)
                 if value.has_description():
                     section.append(textwrap.indent(textwrap.fill(
-                        str(value.description), width=79), '    '))
+                        str(value.description), width=71), '    '))
 
-        if section:
-            return '\n'.join(section).strip()
-        else:
-            return ""
+        return '\n'.join(section).strip()
 
     def _is_subprocess(self):
         return self._pid != os.getpid()

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -456,6 +456,8 @@ class TestMethod(unittest.TestCase):
             self.plugin.methods['identity_with_optional_metadata'])
         no_input_method = self.plugin.methods['no_input_method']
         params_only_method = self.plugin.methods['params_only_method']
+        long_description_method = self.plugin.methods[
+            'long_description_method']
 
         self.assertEqual(merge_mappings.__doc__, 'QIIME 2 Method')
 
@@ -475,6 +477,9 @@ class TestMethod(unittest.TestCase):
         params_only = params_only_method.__call__.__doc__
         self.assertEqual(exp_params_only, params_only)
 
+        long_desc = long_description_method.__call__.__doc__.split('\n\n')[2]
+        self.assertEqual(exp_long_description, long_desc)
+
 
 exp_merge_calldoc = """\
 Merge mappings
@@ -491,14 +496,14 @@ mapping2 : Mapping
 Returns
 -------
 merged_mapping : Mapping
-    Resulting merged Mapping object\
+    Resulting merged Mapping object
 """
 
 exp_split_ints_return = """\
 Returns
 -------
 left : IntSequence1
-right : IntSequence1\
+right : IntSequence1
 """
 
 
@@ -516,7 +521,7 @@ This method does not accept any type of input.
 
 Returns
 -------
-out : Mapping\
+out : Mapping
 """
 
 exp_params_only = """\
@@ -531,9 +536,18 @@ age : Int
 
 Returns
 -------
-out : Mapping\
+out : Mapping
 """
 
+exp_long_description = """\
+Parameters
+----------
+name : Str
+    This is a very long description. If asked about its length, I would have \
+to say
+    it is greater than 79 characters.
+age : Int\
+"""
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -107,10 +107,16 @@ class TestMethod(unittest.TestCase):
                 'mapping1': Mapping,
                 'mapping2': Mapping
             },
+            input_descriptions={
+                'mapping1': 'Mapping object to be merged'
+            },
             parameters={},
             outputs=[
                 ('merged_mapping', Mapping)
-            ]
+            ],
+            output_descriptions={
+                'merged_mapping': 'Resulting merged Mapping object'
+            }
         )
         self.assertEqual(method.signature, exp_sig)
 
@@ -444,14 +450,79 @@ class TestMethod(unittest.TestCase):
         self.assertEqual(result.right.view(list), [-2, 43, 6])
 
     def test_docstring(self):
-        method = self.plugin.methods['split_ints']
-        exp = "QIIME 2 Method"
-        self.assertEqual(exp, method.__doc__)
-        obs = method.__call__.__doc__.split('\n')
-        self.assertTrue(obs[0].startswith('Split sequence of integers'))
-        self.assertEqual(len(obs[1]), 0)
-        self.assertTrue(obs[2].startswith('This method splits'))
-        self.assertTrue(obs[3].startswith('(left and'))
+        merge_mappings = self.plugin.methods['merge_mappings']
+        split_ints = self.plugin.methods['split_ints']
+        identity_with_optional_metadata = (
+            self.plugin.methods['identity_with_optional_metadata'])
+        no_input_method = self.plugin.methods['no_input_method']
+
+        self.assertEqual(merge_mappings.__doc__, 'QIIME 2 Method')
+
+        merge_calldoc = merge_mappings.__call__.__doc__
+        self.assertEqual(merge_calldoc, exp_merge_calldoc)
+        self.assertIn("No description available", merge_calldoc)
+
+        split_ints_return = split_ints.__call__.__doc__.split('\n\n')[3]
+        self.assertEqual(exp_split_ints_reuturn, split_ints_return)
+
+        optional_params = (
+            identity_with_optional_metadata.__call__.__doc__.split('\n\n')[2])
+        self.assertEqual(exp_optional_params, optional_params)
+
+        no_input_method = no_input_method.__call__.__doc__
+        self.assertEqual(exp_no_input_method, no_input_method)
+
+
+exp_merge_calldoc = """\
+Merge mappings
+
+This method merges two mappings into a single new mapping. If a key is \
+shared between mappings and the values differ, an error will be raised.
+
+Parameters
+----------
+mapping1: Mapping
+    Mapping object to be merged
+mapping2: Mapping
+    No description available
+
+Returns
+-------
+merged_mapping: Mapping
+    Resulting merged Mapping object
+
+"""
+
+exp_split_ints_reuturn = """\
+Returns
+-------
+left: IntSequence1
+    No description available
+right: IntSequence1
+    No description available\
+"""
+
+
+exp_optional_params = """\
+Parameters
+----------
+ints: IntSequence1 | IntSequence2
+    No description available
+metadata: Metadata, optional
+    No description available\
+"""
+
+exp_no_input_method = """\
+No input method
+
+This method does not accept any type of input.
+
+Returns
+-------
+out: Mapping
+    No description available
+
+"""
 
 
 if __name__ == '__main__':

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -455,6 +455,7 @@ class TestMethod(unittest.TestCase):
         identity_with_optional_metadata = (
             self.plugin.methods['identity_with_optional_metadata'])
         no_input_method = self.plugin.methods['no_input_method']
+        params_only_method = self.plugin.methods['params_only_method']
 
         self.assertEqual(merge_mappings.__doc__, 'QIIME 2 Method')
 

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -459,7 +459,7 @@ class TestMethod(unittest.TestCase):
         self.assertEqual(merge_mappings.__doc__, 'QIIME 2 Method')
 
         merge_calldoc = merge_mappings.__call__.__doc__
-        self.assertEqual(merge_calldoc, exp_merge_calldoc)
+        self.assertEqual(exp_merge_calldoc, merge_calldoc)
         self.assertIn("No description available", merge_calldoc)
 
         split_ints_return = split_ints.__call__.__doc__.split('\n\n')[3]
@@ -471,6 +471,9 @@ class TestMethod(unittest.TestCase):
 
         no_input_method = no_input_method.__call__.__doc__
         self.assertEqual(exp_no_input_method, no_input_method)
+
+        params_only = params_only_method.__call__.__doc__
+        self.assertEqual(exp_params_only, params_only)
 
 
 exp_merge_calldoc = """\
@@ -516,6 +519,25 @@ exp_no_input_method = """\
 No input method
 
 This method does not accept any type of input.
+
+Returns
+-------
+out: Mapping
+    No description available
+
+"""
+
+exp_params_only = """\
+Parameters only method
+
+This method only accepts parameters.
+
+Parameters
+----------
+name: Str
+    No description available
+age: Int
+    No description available
 
 Returns
 -------

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -461,10 +461,9 @@ class TestMethod(unittest.TestCase):
 
         merge_calldoc = merge_mappings.__call__.__doc__
         self.assertEqual(exp_merge_calldoc, merge_calldoc)
-        self.assertIn("No description available", merge_calldoc)
 
         split_ints_return = split_ints.__call__.__doc__.split('\n\n')[3]
-        self.assertEqual(exp_split_ints_reuturn, split_ints_return)
+        self.assertEqual(exp_split_ints_return, split_ints_return)
 
         optional_params = (
             identity_with_optional_metadata.__call__.__doc__.split('\n\n')[2])
@@ -480,40 +479,34 @@ class TestMethod(unittest.TestCase):
 exp_merge_calldoc = """\
 Merge mappings
 
-This method merges two mappings into a single new mapping. If a key is \
-shared between mappings and the values differ, an error will be raised.
+This method merges two mappings into a single new mapping. If a key is shared
+between mappings and the values differ, an error will be raised.
 
 Parameters
 ----------
-mapping1: Mapping
+mapping1 : Mapping
     Mapping object to be merged
-mapping2: Mapping
-    No description available
+mapping2 : Mapping
 
 Returns
 -------
-merged_mapping: Mapping
-    Resulting merged Mapping object
-
+merged_mapping : Mapping
+    Resulting merged Mapping object\
 """
 
-exp_split_ints_reuturn = """\
+exp_split_ints_return = """\
 Returns
 -------
-left: IntSequence1
-    No description available
-right: IntSequence1
-    No description available\
+left : IntSequence1
+right : IntSequence1\
 """
 
 
 exp_optional_params = """\
 Parameters
 ----------
-ints: IntSequence1 | IntSequence2
-    No description available
-metadata: Metadata, optional
-    No description available\
+ints : IntSequence1 | IntSequence2
+metadata : Metadata, optional\
 """
 
 exp_no_input_method = """\
@@ -523,9 +516,7 @@ This method does not accept any type of input.
 
 Returns
 -------
-out: Mapping
-    No description available
-
+out : Mapping\
 """
 
 exp_params_only = """\
@@ -535,16 +526,12 @@ This method only accepts parameters.
 
 Parameters
 ----------
-name: Str
-    No description available
-age: Int
-    No description available
+name : Str
+age : Int
 
 Returns
 -------
-out: Mapping
-    No description available
-
+out : Mapping\
 """
 
 

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -505,15 +505,15 @@ class TestMethod(unittest.TestCase):
         params_only = params_only_method.__call__.__doc__
         self.assertEqual(exp_params_only, params_only)
 
-        long_desc = long_description_method.__call__.__doc__.split('\n\n')[2]
+        long_desc = long_description_method.__call__.__doc__
         self.assertEqual(exp_long_description, long_desc)
 
 
 exp_merge_calldoc = """\
 Merge mappings
 
-This method merges two mappings into a single new mapping. If a key is shared
-between mappings and the values differ, an error will be raised.
+This method merges two mappings into a single new mapping. If a key is
+shared between mappings and the values differ, an error will be raised.
 
 Parameters
 ----------
@@ -568,13 +568,26 @@ out : Mapping
 """
 
 exp_long_description = """\
+Long Description
+
+This is a very long description. If asked about its length, I would have to
+say it is greater than 79 characters.
+
 Parameters
 ----------
+mapping1 : Mapping
+    This is a very long description. If asked about its length, I would
+    have to say it is greater than 79 characters.
 name : Str
-    This is a very long description. If asked about its length, I would have \
-to say
-    it is greater than 79 characters.
-age : Int\
+    This is a very long description. If asked about its length, I would
+    have to say it is greater than 79 characters.
+age : Int
+
+Returns
+-------
+out : Mapping
+    This is a very long description. If asked about its length, I would
+    have to say it is greater than 79 characters.
 """
 
 if __name__ == '__main__':

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -428,10 +428,81 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         self.assertIsInstance(output.visualization, Visualization)
 
     def test_docstring(self):
-        visualizer = self.plugin.visualizers['mapping_viz']
-        exp = "QIIME 2 Visualizer"
-        self.assertEqual(exp, visualizer.__doc__)
+        mapping_viz = self.plugin.visualizers['mapping_viz']
+        common_viz = self.plugin.visualizers['most_common_viz']
+        params_only_viz = self.plugin.visualizers['params_only_viz']
+        no_input_viz = self.plugin.visualizers['no_input_viz']
+
+        obs = mapping_viz.__call__.__doc__
+        self.assertEqual(obs, exp_mapping_viz)
+
+        obs = common_viz.__call__.__doc__
+        self.assertEqual(obs, exp_common_viz)
+
+        obs = params_only_viz.__call__.__doc__
+        self.assertEqual(obs, exp_params_only_viz)
+
+        obs= no_input_viz.__call__.__doc__
+        self.assertEqual(obs, exp_no_input_viz)
 
 
+exp_mapping_viz = """\
+Visualize two mappings
+
+This visualizer produces an HTML visualization of two key-value mappings,
+each sorted in alphabetical order by key.
+
+Parameters
+----------
+mapping1 : Mapping
+mapping2 : Mapping
+key_label : Str
+value_label : Str
+
+Returns
+-------
+visualization : Visualization
+"""
+
+exp_common_viz = """\
+Visualize most common integers
+
+This visualizer produces HTML and TSV outputs containing the input sequence
+of integers ordered from most- to least-frequently occurring, along with
+their respective frequencies.
+
+Parameters
+----------
+ints : IntSequence1 | IntSequence2
+
+Returns
+-------
+visualization : Visualization
+"""
+
+exp_params_only_viz = """\
+Parameters only viz
+
+This visualizer only accepts parameters.
+
+Parameters
+----------
+name : Str, optional
+age : Int, optional
+
+Returns
+-------
+visualization : Visualization
+"""
+
+exp_no_input_viz = """\
+No input viz
+
+This visualizer does not accept any type of input.
+
+Returns
+-------
+visualization : Visualization
+"""
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -431,11 +431,6 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         visualizer = self.plugin.visualizers['mapping_viz']
         exp = "QIIME 2 Visualizer"
         self.assertEqual(exp, visualizer.__doc__)
-        obs = visualizer.__call__.__doc__.split('\n')
-        self.assertTrue(obs[0].startswith('Visualize two'))
-        self.assertEqual(len(obs[1]), 0)
-        self.assertTrue(obs[2].startswith('This visualizer produces an HTML'))
-        self.assertTrue(obs[3].startswith('sorted in alphabetical'))
 
 
 if __name__ == '__main__':

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -442,7 +442,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         obs = params_only_viz.__call__.__doc__
         self.assertEqual(obs, exp_params_only_viz)
 
-        obs= no_input_viz.__call__.__doc__
+        obs = no_input_viz.__call__.__doc__
         self.assertEqual(obs, exp_no_input_viz)
 
 


### PR DESCRIPTION
Previously, calling `?` on a QIIME 2 Action (`merge_mappings`) yielded the following call docstring:

<img width="1142" alt="screen shot 2017-06-27 at 3 03 55 pm" src="https://user-images.githubusercontent.com/6307252/27612315-cb716d30-5b4a-11e7-86a7-3e9c57e03493.png">

There could be much more information in this docstring, so I have added functionality which creates a full Numpydoc-compliant docstring for any QIIME 2 Method. Calling `?` on the Action now yields:

<img width="1145" alt="screen shot 2017-06-27 at 3 03 11 pm" src="https://user-images.githubusercontent.com/6307252/27612373-0ce0716c-5b4b-11e7-91a8-597b20f958b9.png">

@jairideout
fixes #280