### PR TITLE
ENH: Set matplotlib backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ test: all
 	QIIMETEST= nosetests
 
 install: all
-	python setup.py install
+	python setup.py install && \
+	mkdir -p $(CONDA_PREFIX)/etc/conda/activate.d && \
+	cp scripts/activate_matplotlib.sh $(CONDA_PREFIX)/etc/conda/activate.d/ && \
+	mkdir -p $(CONDA_PREFIX)/etc/conda/deactivate.d && \
+	cp scripts/deactivate_matplotlib.sh $(CONDA_PREFIX)/etc/conda/deactivate.d/
 
 dev: all
 	pip install -e .

--- a/scripts/activate_matplotlib.sh
+++ b/scripts/activate_matplotlib.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export MPLBACKEND='Agg'

--- a/scripts/deactivate_matplotlib.sh
+++ b/scripts/deactivate_matplotlib.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+unset MPLBACKEND


### PR DESCRIPTION
This relies on the fact that QIIME 2 is officially distributed with
`conda` - the `make install` directive will set up `conda` activate and
deactivate hooks responsible for setting the appropriate matplotlib
environment variables.

---

I tested this locally by running the following build command:

```bash
$ conda build \
  -c https://conda.anaconda.org/qiime2 \
  -c https://conda.anaconda.org/conda-forge \
  -c defaults \
  -c https://conda.anaconda.org/bioconda \
  -c https://conda.anaconda.org/biocore \
  --override-channels --python 3.5 --output-folder ~/Desktop/bldr ci/recipe
```

Then, unpacking a viewing the built bz2:

```bash
$ tree ~/Desktop/bldr/osx-64/qiime2-2017.9.0.dev0+4.g1af7d13-py35_0/ -L 4
/Users/matthew/Desktop/bldr/osx-64/qiime2-2017.9.0.dev0+4.g1af7d13-py35_0/
├── etc
│   └── conda
│       ├── activate.d
│       │   └── activate_matplotlib.sh
│       └── deactivate.d
│           └── deactivate_matplotlib.sh
├── info
│   ├── about.json
...
```

And finally:

```bash
$ echo $MPLBACKEND

$ source activate q2dev-2017.9
(q2dev-2017.9) $ echo $MPLBACKEND
Agg
(q2dev-2017.9) $ source deactivate
$ echo $MPLBACKEND

$ # yay!
```