### PR TITLE
Update primitive.py for Range to fix repr bug

### DIFF
--- a/qiime2/core/type/primitive.py
+++ b/qiime2/core/type/primitive.py
@@ -145,10 +145,8 @@ class Range(Predicate):
 
     def __repr__(self):
         args = []
-        if self.start is not _RANGE_DEFAULT_START:
-            args.append(repr(self.start))
-        if self.end is not _RANGE_DEFAULT_END:
-            args.append(repr(self.end))
+        args.append(repr(self.start))
+        args.append(repr(self.end))
         if self.inclusive_start is not _RANGE_DEFAULT_INCLUSIVE_START:
             args.append('inclusive_start=%r' % self.inclusive_start)
         if self.inclusive_end is not _RANGE_DEFAULT_INCLUSIVE_END:


### PR DESCRIPTION
Currently, the repr for a range [1:] with no upper value is the same as the repr for a range [:1] with no lower value.

In [1]: from qiime2.core.type.primitive import Range
In [2]: repr(Range(1, None)) == repr(Range(None, 1))
Out[2]: True

Proposed change forces the repr to include both start and end positions, even if they are the same as the default. This will allow the repr to differentiate between the two ranges in the case above (as when used in parse_type to generate a type from a repr string).