### PR TITLE
BUG: support empty rows in `Metadata.load`

### DIFF
--- a/qiime2/metadata.py
+++ b/qiime2/metadata.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import io
 import itertools
 import os.path
 import sqlite3
@@ -110,21 +111,28 @@ class Metadata:
                 header = peek.split('\t')
                 read_csv_kwargs = {'header': None, 'names': header}
 
+        # HACK: Preprocess file to remove whitespace-only lines (including
+        # lines with tabs). Lines containing tabs can trip up pandas so we
+        # exclude them entirely here. This is a performance hog and can likely
+        # be reverted with the `csv` stdlib module is used to parse.
+        buffer = io.StringIO()
+        with open(path, 'r') as fh:
+            for line in fh:
+                if line.strip():
+                    # Don't write the stripped line because we want to keep
+                    # leading/trailing empty cells, as those may be valid data.
+                    buffer.write(line)
+        buffer.seek(0)
+
         try:
-            df = pd.read_csv(path, sep='\t', dtype=object, comment='#',
+            df = pd.read_csv(buffer, sep='\t', dtype=object, comment='#',
                              skip_blank_lines=True, **read_csv_kwargs)
-
-            # Drop empty rows. This must happen before setting an index because
-            # `dropna()` drops rows regardless of index value. This becomes
-            # problematic when there are no columns (something we allow for);
-            # in that case `dropna()` will drop all rows. We only want to drop
-            # rows if both the index and all cells are empty.
-            df.dropna(axis='index', how='all', inplace=True)
-
             df.set_index(df.columns[0], drop=True, append=False, inplace=True)
         except (pd.io.common.CParserError, KeyError):
             msg = 'Metadata file format is invalid for file %s' % path
             raise ValueError(invalid_metadata_template % msg)
+        finally:
+            buffer.close()
 
         return cls(df)
 

--- a/qiime2/tests/data/metadata/empty-rows.tsv
+++ b/qiime2/tests/data/metadata/empty-rows.tsv
@@ -3,6 +3,7 @@ id1	1	a	foo
 			
 id2	2	b	bar
 			
+	 	  	 
 id3	3	c	42
 			
 			

--- a/qiime2/tests/data/metadata/empty-rows.tsv
+++ b/qiime2/tests/data/metadata/empty-rows.tsv
@@ -1,0 +1,8 @@
+my-index	col1	col2	col3
+id1	1	a	foo
+			
+id2	2	b	bar
+			
+id3	3	c	42
+			
+			

--- a/qiime2/tests/test_metadata.py
+++ b/qiime2/tests/test_metadata.py
@@ -448,6 +448,22 @@ class TestMetadataLoad(unittest.TestCase):
 
         pdt.assert_frame_equal(obs_df, exp_df)
 
+    def test_empty_rows(self):
+        fp = pkg_resources.resource_filename(
+            'qiime2.tests', 'data/metadata/empty-rows.tsv')
+
+        metadata = qiime2.Metadata.load(fp)
+        obs_df = metadata.to_dataframe()
+
+        exp_index = pd.Index(['id1', 'id2', 'id3'], name='my-index',
+                             dtype=object)
+        exp_df = pd.DataFrame({'col1': ['1', '2', '3'],
+                               'col2': ['a', 'b', 'c'],
+                               'col3': ['foo', 'bar', '42']},
+                              index=exp_index, dtype=object)
+
+        pdt.assert_frame_equal(obs_df, exp_df)
+
     def test_qiime1_mapping_file(self):
         fp = pkg_resources.resource_filename(
             'qiime2.tests', 'data/metadata/qiime1.tsv')


### PR DESCRIPTION
Empty rows are now ignored, similar to how blank lines and comments are ignored. In this case, an "empty row" is a row consisting only of empty cells (i.e. only tab characters).

Fixes #336.