### PR TITLE
ENH: adds basic Pipeline actions

### DIFF
--- a/qiime2/core/archive/__init__.py
+++ b/qiime2/core/archive/__init__.py
@@ -6,8 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from .provenance import ImportProvenanceCapture, ActionProvenanceCapture
+from .provenance import (ImportProvenanceCapture, ActionProvenanceCapture,
+                         PipelineProvenanceCapture)
 from .archiver import Archiver
 
 
-__all__ = ['Archiver', 'ImportProvenanceCapture', 'ActionProvenanceCapture']
+__all__ = ['Archiver', 'ImportProvenanceCapture', 'ActionProvenanceCapture',
+           'PipelineProvenanceCapture']

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -341,3 +341,6 @@ class Archiver:
 
     def orphan(self):
         self.path.orphan()
+
+    def _destructor(self):
+        self.path._destructor()

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -339,8 +339,6 @@ class Archiver:
     def save(self, filepath):
         self.CURRENT_ARCHIVE.save(self.path, filepath)
 
-    def orphan(self):
-        self.path.orphan()
-
+    @property
     def _destructor(self):
-        self.path._destructor()
+        return self.path._destructor

--- a/qiime2/core/archive/format/v2.py
+++ b/qiime2/core/archive/format/v2.py
@@ -12,5 +12,6 @@ import qiime2.core.archive.format.v1 as v1
 class ArchiveFormat(v1.ArchiveFormat):
     # Exactly the same as v1, but in provenance, when the action type isn't
     # import, there is an `output-name` key in the action section with that
-    # node's output name according to the action's signature object.
+    # node's output name according to the action's signature object. Also has
+    # pipeline action types.
     pass

--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -309,3 +309,17 @@ class ActionProvenanceCapture(ProvenanceCapture):
         forked = super().fork()
         forked.output_name = name
         return forked
+
+
+class PipelineProvenanceCapture(ActionProvenanceCapture):
+    def make_action_section(self):
+        action = super().make_action_section()
+        action['alias-of'] = str(self.alias.uuid)
+
+        return action
+
+    def fork(self, name, alias):
+        forked = super().fork(name)
+        forked.alias = alias
+        forked.add_ancestor(alias)
+        return forked

--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -103,8 +103,9 @@ class ProvenanceCapture:
 
         self._build_paths()
 
+    @property
     def _destructor(self):
-        self.path._destructor()
+        return self.path._destructor
 
     def _build_paths(self):
         self.path = qiime2.core.path.ProvenancePath()

--- a/qiime2/core/path.py
+++ b/qiime2/core/path.py
@@ -124,9 +124,6 @@ class InternalDirectory(_ConcretePath):
         # Same reasoning as truediv
         return _ConcretePath(path, str(self))
 
-    def orphan(self):
-        self._destructor.detach()
-
 
 class ArchivePath(InternalDirectory):
     DEFAULT_PREFIX = 'qiime2-archive-'

--- a/qiime2/core/testing/pipeline.py
+++ b/qiime2/core/testing/pipeline.py
@@ -11,8 +11,8 @@ from .type import SingleInt, Mapping
 
 def parameter_only_pipeline(ctx, int1, int2=2, metadata=None):
     identity_with_optional_metadata = ctx.get_action(
-        'dummy-plugin', 'identity_with_optional_metadata')
-    concatenate_ints = ctx.get_action('dummy-plugin', 'concatenate_ints')
+        'dummy_plugin', 'identity_with_optional_metadata')
+    concatenate_ints = ctx.get_action('dummy_plugin', 'concatenate_ints')
 
     ints1 = ctx.make_artifact('IntSequence2', [int1, int2, 3])
     ints2, = identity_with_optional_metadata(ints1, metadata)
@@ -23,8 +23,8 @@ def parameter_only_pipeline(ctx, int1, int2=2, metadata=None):
 
 
 def typical_pipeline(ctx, int_sequence, mapping, do_extra_thing, add=1):
-    split_ints = ctx.get_action('dummy-plugin', 'split_ints')
-    most_common_viz = ctx.get_action('dummy-plugin', 'most_common_viz')
+    split_ints = ctx.get_action('dummy_plugin', 'split_ints')
+    most_common_viz = ctx.get_action('dummy_plugin', 'most_common_viz')
 
     left, right = split_ints(int_sequence)
     if do_extra_thing:
@@ -44,7 +44,7 @@ def typical_pipeline(ctx, int_sequence, mapping, do_extra_thing, add=1):
 
 def optional_artifact_pipeline(ctx, int_sequence, single_int=None):
     optional_artifact_method = ctx.get_action(
-        'dummy-plugin', 'optional_artifacts_method')
+        'dummy_plugin', 'optional_artifacts_method')
 
     if single_int is None:
         # not a nested pipeline, just sharing the ctx object
@@ -56,8 +56,8 @@ def optional_artifact_pipeline(ctx, int_sequence, single_int=None):
 
 
 def visualizer_only_pipeline(ctx, mapping):
-    no_input_viz = ctx.get_action('dummy-plugin', 'no_input_viz')
-    mapping_viz = ctx.get_action('dummy-plugin', 'mapping_viz')
+    no_input_viz = ctx.get_action('dummy_plugin', 'no_input_viz')
+    mapping_viz = ctx.get_action('dummy_plugin', 'mapping_viz')
 
     viz1, = no_input_viz()
     viz2, = mapping_viz(mapping, mapping, 'foo', 'bar')
@@ -66,10 +66,10 @@ def visualizer_only_pipeline(ctx, mapping):
 
 
 def pipelines_in_pipeline(ctx, int_sequence, mapping):
-    pointless_pipeline = ctx.get_action('dummy-plugin', 'pointless_pipeline')
-    typical_pipeline = ctx.get_action('dummy-plugin', 'typical_pipeline')
+    pointless_pipeline = ctx.get_action('dummy_plugin', 'pointless_pipeline')
+    typical_pipeline = ctx.get_action('dummy_plugin', 'typical_pipeline')
     visualizer_only_pipeline = ctx.get_action(
-        'dummy-plugin', 'visualizer_only_pipeline')
+        'dummy_plugin', 'visualizer_only_pipeline')
 
     results = []
     results += pointless_pipeline()
@@ -86,7 +86,7 @@ def pointless_pipeline(ctx):
 
 
 def failing_pipeline(ctx, int_sequence, break_from='arity'):
-    merge_mappings = ctx.get_action('dummy-plugin', 'merge_mappings')
+    merge_mappings = ctx.get_action('dummy_plugin', 'merge_mappings')
 
     l = int_sequence.view(list)
     if l:

--- a/qiime2/core/testing/pipeline.py
+++ b/qiime2/core/testing/pipeline.py
@@ -1,0 +1,101 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from .type import SingleInt, Mapping
+
+
+def parameter_only_pipeline(ctx, int1, int2=2, metadata=None):
+    identity_with_optional_metadata = ctx.import_action(
+        'dummy-plugin', 'identity_with_optional_metadata')
+    concatenate_ints = ctx.import_action(
+        'dummy-plugin', 'concatenate_ints')
+
+    ints1 = ctx.make_artifact('IntSequence2', [int1, int2, 3])
+    ints2, = identity_with_optional_metadata(ints1, metadata)
+    ints3, = identity_with_optional_metadata(ints1, metadata)
+    more_ints, = concatenate_ints(ints3, ints2, ints1, int1=int1, int2=int2)
+
+    return ints1, more_ints
+
+
+def typical_pipeline(ctx, int_sequence, mapping, do_extra_thing, add=1):
+    split_ints = ctx.import_action('dummy-plugin', 'split_ints')
+    most_common_viz = ctx.import_action('dummy-plugin', 'most_common_viz')
+
+    left, right = split_ints(int_sequence)
+    if do_extra_thing:
+        left = ctx.make_artifact(
+            'IntSequence1', [i + add for i in left.view(list)])
+
+    val, = mapping.view(dict).values()
+    # Some kind of runtime failure
+    if val != '42':
+        raise ValueError("Bad mapping")
+
+    left_viz, = most_common_viz(left)
+    right_viz, = most_common_viz(right)
+
+    return mapping, left, right, left_viz, right_viz
+
+
+def optional_artifact_pipeline(ctx, int_sequence, single_int=None):
+    optional_artifact_method = ctx.import_action(
+        'dummy-plugin', 'optional_artifacts_method')
+
+    if single_int is None:
+        # not a nested pipeline, just sharing the ctx object
+        single_int = pointless_pipeline(ctx)
+
+    num1 = single_int.view(int)
+    ints, = optional_artifact_method(int_sequence, num1)
+    return ints
+
+
+def visualizer_only_pipeline(ctx, mapping):
+    no_input_viz = ctx.import_action('dummy-plugin', 'no_input_viz')
+    mapping_viz = ctx.import_action('dummy-plugin', 'mapping_viz')
+
+    viz1, = no_input_viz()
+    viz2, = mapping_viz(mapping, mapping, 'foo', 'bar')
+
+    return viz1, viz2
+
+
+def pipelines_in_pipeline(ctx, int_sequence, mapping):
+    pointless_pipeline = ctx.import_action(
+        'dummy-plugin', 'pointless_pipeline')
+    typical_pipeline = ctx.import_action('dummy-plugin', 'typical_pipeline')
+    visualizer_only_pipeline = ctx.import_action(
+        'dummy-plugin', 'visualizer_only_pipeline')
+
+    results = []
+    results += pointless_pipeline()
+    typical_results = typical_pipeline(int_sequence, mapping, True)
+    results += typical_results
+    results += visualizer_only_pipeline(typical_results[0])
+
+    return tuple(results)
+
+
+def pointless_pipeline(ctx):
+    # Use a real type expression instead of a string.
+    return ctx.make_artifact(SingleInt, 4)
+
+
+def failing_pipeline(ctx, break_from='arity'):
+    merge_mappings = ctx.import_action('dummy-plugin', 'merge_mappings')
+    if break_from == 'arity':
+        return
+    elif break_from == 'type':
+        return ctx.make_artifact(SingleInt, 0)
+    elif break_from == 'method':
+        a = ctx.make_artifact(Mapping, {'foo': 'a'})
+        b = ctx.make_artifact(Mapping, {'foo': 'b'})
+        merge_mappings(a, b)
+    else:
+        raise ValueError('this never works')

--- a/qiime2/core/testing/pipeline.py
+++ b/qiime2/core/testing/pipeline.py
@@ -10,10 +10,9 @@ from .type import SingleInt, Mapping
 
 
 def parameter_only_pipeline(ctx, int1, int2=2, metadata=None):
-    identity_with_optional_metadata = ctx.import_action(
+    identity_with_optional_metadata = ctx.get_action(
         'dummy-plugin', 'identity_with_optional_metadata')
-    concatenate_ints = ctx.import_action(
-        'dummy-plugin', 'concatenate_ints')
+    concatenate_ints = ctx.get_action('dummy-plugin', 'concatenate_ints')
 
     ints1 = ctx.make_artifact('IntSequence2', [int1, int2, 3])
     ints2, = identity_with_optional_metadata(ints1, metadata)
@@ -24,8 +23,8 @@ def parameter_only_pipeline(ctx, int1, int2=2, metadata=None):
 
 
 def typical_pipeline(ctx, int_sequence, mapping, do_extra_thing, add=1):
-    split_ints = ctx.import_action('dummy-plugin', 'split_ints')
-    most_common_viz = ctx.import_action('dummy-plugin', 'most_common_viz')
+    split_ints = ctx.get_action('dummy-plugin', 'split_ints')
+    most_common_viz = ctx.get_action('dummy-plugin', 'most_common_viz')
 
     left, right = split_ints(int_sequence)
     if do_extra_thing:
@@ -44,7 +43,7 @@ def typical_pipeline(ctx, int_sequence, mapping, do_extra_thing, add=1):
 
 
 def optional_artifact_pipeline(ctx, int_sequence, single_int=None):
-    optional_artifact_method = ctx.import_action(
+    optional_artifact_method = ctx.get_action(
         'dummy-plugin', 'optional_artifacts_method')
 
     if single_int is None:
@@ -57,8 +56,8 @@ def optional_artifact_pipeline(ctx, int_sequence, single_int=None):
 
 
 def visualizer_only_pipeline(ctx, mapping):
-    no_input_viz = ctx.import_action('dummy-plugin', 'no_input_viz')
-    mapping_viz = ctx.import_action('dummy-plugin', 'mapping_viz')
+    no_input_viz = ctx.get_action('dummy-plugin', 'no_input_viz')
+    mapping_viz = ctx.get_action('dummy-plugin', 'mapping_viz')
 
     viz1, = no_input_viz()
     viz2, = mapping_viz(mapping, mapping, 'foo', 'bar')
@@ -67,10 +66,9 @@ def visualizer_only_pipeline(ctx, mapping):
 
 
 def pipelines_in_pipeline(ctx, int_sequence, mapping):
-    pointless_pipeline = ctx.import_action(
-        'dummy-plugin', 'pointless_pipeline')
-    typical_pipeline = ctx.import_action('dummy-plugin', 'typical_pipeline')
-    visualizer_only_pipeline = ctx.import_action(
+    pointless_pipeline = ctx.get_action('dummy-plugin', 'pointless_pipeline')
+    typical_pipeline = ctx.get_action('dummy-plugin', 'typical_pipeline')
+    visualizer_only_pipeline = ctx.get_action(
         'dummy-plugin', 'visualizer_only_pipeline')
 
     results = []
@@ -88,7 +86,7 @@ def pointless_pipeline(ctx):
 
 
 def failing_pipeline(ctx, int_sequence, break_from='arity'):
-    merge_mappings = ctx.import_action('dummy-plugin', 'merge_mappings')
+    merge_mappings = ctx.get_action('dummy-plugin', 'merge_mappings')
 
     l = int_sequence.view(list)
     if l:

--- a/qiime2/core/testing/pipeline.py
+++ b/qiime2/core/testing/pipeline.py
@@ -87,15 +87,28 @@ def pointless_pipeline(ctx):
     return ctx.make_artifact(SingleInt, 4)
 
 
-def failing_pipeline(ctx, break_from='arity'):
+def failing_pipeline(ctx, int_sequence, break_from='arity'):
     merge_mappings = ctx.import_action('dummy-plugin', 'merge_mappings')
+
+    l = int_sequence.view(list)
+    if l:
+        integer = l[0]
+    else:
+        integer = 0
+
+    # Made here so that we can make sure it gets cleaned up
+    wrong_output = ctx.make_artifact(SingleInt, integer)
+
     if break_from == 'arity':
-        return
+        return int_sequence, int_sequence, int_sequence
+    elif break_from == 'return-view':
+        return None
     elif break_from == 'type':
-        return ctx.make_artifact(SingleInt, 0)
+        return wrong_output
     elif break_from == 'method':
         a = ctx.make_artifact(Mapping, {'foo': 'a'})
         b = ctx.make_artifact(Mapping, {'foo': 'b'})
+        # has the same key
         merge_mappings(a, b)
     else:
         raise ValueError('this never works')

--- a/qiime2/core/testing/pipeline.py
+++ b/qiime2/core/testing/pipeline.py
@@ -108,5 +108,9 @@ def failing_pipeline(ctx, int_sequence, break_from='arity'):
         b = ctx.make_artifact(Mapping, {'foo': 'b'})
         # has the same key
         merge_mappings(a, b)
+    elif break_from == 'no-plugin':
+        ctx.get_action('not%a$plugin', 'foo')
+    elif break_from == 'no-action':
+        ctx.get_action('dummy_plugin', 'not%a$method')
     else:
         raise ValueError('this never works')

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -37,7 +37,8 @@ from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
 from .pipeline import (parameter_only_pipeline, typical_pipeline,
                        optional_artifact_pipeline, visualizer_only_pipeline,
-                       pipelines_in_pipeline, pointless_pipeline)
+                       pipelines_in_pipeline, pointless_pipeline,
+                       failing_pipeline)
 
 dummy_plugin = qiime2.plugin.Plugin(
     name='dummy-plugin',
@@ -471,4 +472,19 @@ dummy_plugin.pipelines.register_function(
     outputs=[('random_int', SingleInt)],
     name='Get an integer',
     description='Integer was chosen to be 4 by a random dice roll'
+)
+
+dummy_plugin.pipelines.register_function(
+    function=failing_pipeline,
+    inputs={
+        'int_sequence': IntSequence1
+    },
+    parameters={
+        'break_from': qiime2.plugin.Str % qiime2.plugin.Choices(
+            {'arity', 'return-view', 'type', 'method', 'internal'})
+    },
+    outputs=[('mapping', Mapping)],
+    name='Test different ways of failing',
+    description=('This is useful to make sure all of the intermediate stuff is'
+                 ' cleaned up the way it should be.')
 )

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -35,6 +35,9 @@ from .method import (concatenate_ints, split_ints, merge_mappings,
                      optional_artifacts_method, long_description_method)
 from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
+from .pipeline import (parameter_only_pipeline, typical_pipeline,
+                       optional_artifact_pipeline, visualizer_only_pipeline,
+                       pipelines_in_pipeline, pointless_pipeline)
 
 dummy_plugin = qiime2.plugin.Plugin(
     name='dummy-plugin',
@@ -334,4 +337,138 @@ dummy_plugin.visualizers.register_function(
     name='Visualize two mappings',
     description='This visualizer produces an HTML visualization of two '
                 'key-value mappings, each sorted in alphabetical order by key.'
+)
+
+dummy_plugin.pipelines.register_function(
+    function=parameter_only_pipeline,
+    inputs={},
+    parameters={
+        'int1': qiime2.plugin.Int,
+        'int2': qiime2.plugin.Int,
+        'metadata': qiime2.plugin.Metadata
+    },
+    outputs=[
+        ('foo', IntSequence2),
+        ('bar', IntSequence1)
+    ],
+    name='Do multiple things',
+    description='This pipeline only accepts parameters',
+    parameter_descriptions={
+        'int1': 'An integer, the first one in fact',
+        'int2': 'An integer, the second one',
+        'metadata': 'Very little is done with this'
+    },
+    output_descriptions={
+        'foo': 'Foo - "The Integers of 2"',
+        'bar': 'Bar - "What a sequences"'
+    }
+)
+
+dummy_plugin.pipelines.register_function(
+    function=typical_pipeline,
+    inputs={
+        'int_sequence': IntSequence1,
+        'mapping': Mapping
+    },
+    parameters={
+        'do_extra_thing': qiime2.plugin.Bool,
+        'add': qiime2.plugin.Int
+    },
+    outputs=[
+        ('out_map', Mapping),
+        ('left', IntSequence1),
+        ('right', IntSequence1),
+        ('left_viz', qiime2.plugin.Visualization),
+        ('right_viz', qiime2.plugin.Visualization)
+    ],
+    input_descriptions={
+        'int_sequence': 'A sequence of ints',
+        'mapping': 'A map to a number other than 42 will fail'
+    },
+    parameter_descriptions={
+        'do_extra_thing': 'Increment `left` by `add` if true',
+        'add': 'Unused if `do_extra_thing` is false'
+    },
+    output_descriptions={
+        'out_map': 'Same as input',
+        'left': 'Left side of `int_sequence` unless `do_extra_thing`',
+        'right': 'Right side of `int_sequence`',
+        'left_viz': '`left` visualized',
+        'right_viz': '`right` visualized'
+    },
+    name='A typical pipeline with the potential to raise an error',
+    description='Waste some time shuffling data around for no reason'
+)
+
+dummy_plugin.pipelines.register_function(
+    function=optional_artifact_pipeline,
+    inputs={
+        'int_sequence': IntSequence1,
+        'single_int': SingleInt
+    },
+    parameters={},
+    outputs=[
+        ('ints', IntSequence1)
+    ],
+    input_descriptions={
+        'int_sequence': 'Some integers',
+        'single_int': 'An integer'
+    },
+    output_descriptions={
+        'ints': 'More integers'
+    },
+    name='Do stuff normally, but override this one step sometimes',
+    description='Creates its own single_int, unless provided'
+)
+
+dummy_plugin.pipelines.register_function(
+    function=visualizer_only_pipeline,
+    inputs={
+        'mapping': Mapping
+    },
+    parameters={},
+    outputs=[
+        ('viz1', qiime2.plugin.Visualization),
+        ('viz2', qiime2.plugin.Visualization)
+    ],
+    input_descriptions={
+        'mapping': 'A mapping to look at twice'
+    },
+    output_descriptions={
+        'viz1': 'The no input viz',
+        'viz2': 'Our `mapping` seen through the lense of "foo" *and* "bar"'
+    },
+    name='Visualize many things',
+    description='Looks at both nothing and a mapping'
+)
+
+dummy_plugin.pipelines.register_function(
+    function=pipelines_in_pipeline,
+    inputs={
+        'int_sequence': IntSequence1,
+        'mapping': Mapping
+    },
+    parameters={},
+    outputs=[
+        ('int1', SingleInt),
+        ('out_map', Mapping),
+        ('left', IntSequence1),
+        ('right', IntSequence1),
+        ('left_viz', qiime2.plugin.Visualization),
+        ('right_viz', qiime2.plugin.Visualization),
+        ('viz1', qiime2.plugin.Visualization),
+        ('viz2', qiime2.plugin.Visualization)
+    ],
+    name='Do a great many things',
+    description=('Mapping is chained from typical_pipeline into '
+                 'visualizer_only_pipeline')
+)
+
+dummy_plugin.pipelines.register_function(
+    function=pointless_pipeline,
+    inputs={},
+    parameters={},
+    outputs=[('random_int', SingleInt)],
+    name='Get an integer',
+    description='Integer was chosen to be 4 by a random dice roll'
 )

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -481,7 +481,8 @@ dummy_plugin.pipelines.register_function(
     },
     parameters={
         'break_from': qiime2.plugin.Str % qiime2.plugin.Choices(
-            {'arity', 'return-view', 'type', 'method', 'internal'})
+            {'arity', 'return-view', 'type', 'method', 'internal', 'no-plugin',
+             'no-action'})
     },
     outputs=[('mapping', Mapping)],
     name='Test different ways of failing',

--- a/qiime2/core/testing/transformer.py
+++ b/qiime2/core/testing/transformer.py
@@ -94,6 +94,14 @@ def _1000(ff: IntSequenceFormat) -> IntSequenceFormatV2:
 
 
 @dummy_plugin.register_transformer
+def _0202(data: int) -> RedundantSingleIntDirectoryFormat:
+    df = RedundantSingleIntDirectoryFormat()
+    df.int1.write_data(data, int)
+    df.int2.write_data(data, int)
+    return df
+
+
+@dummy_plugin.register_transformer
 def _2020(ff: RedundantSingleIntDirectoryFormat) -> int:
     return ff.int1.view(int)  # int2 must be the same for this format
 

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -274,7 +274,7 @@ class PipelineSignature:
             if spec.has_view_type():
                 raise TypeError(
                     " Pipelines do not support function annotations (found one"
-                    " for %r)." % name)
+                    " for parameter: %r)." % name)
 
     def decode_parameters(self, **kwargs):
         params = {}
@@ -351,8 +351,8 @@ class MethodSignature(PipelineSignature):
                                           parameters.items(),
                                           outputs.items()):
             if not spec.has_view_type():
-                raise TypeError(
-                    "Method is missing a function annotation for %r." % name)
+                raise TypeError("Method is missing a function annotation for"
+                                " parameter: %r" % name)
 
 
 class VisualizerSignature(PipelineSignature):
@@ -379,4 +379,4 @@ class VisualizerSignature(PipelineSignature):
         for name, spec in itertools.chain(inputs.items(), parameters.items()):
             if not spec.has_view_type():
                 raise TypeError("Visualizer is missing a function annotation"
-                                " for %r." % name)
+                                " for parameter: %r" % name)

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -62,9 +62,6 @@ class ParameterSpec(ImmutableBase):
         return not (self == other)
 
 
-# Note: Pipeline doesn't exist yet but it is expected to accept zero or more
-# input semantic types, zero or more parameters, and produce one or more output
-# semantic types or Visualization types.
 class PipelineSignature:
     builtin_args = ('ctx',)
 

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -19,13 +19,19 @@ from .visualization import Visualization
 from ..util import ImmutableBase
 
 
-class _NoValue:
+class __NoValueMeta(type):
     def __repr__(self):
         return "NOVALUE"
 
 
+# This sentinel is a class so that it retains the correct memory address when
+# pickled
+class _NOVALUE(metaclass=__NoValueMeta):
+    pass
+
+
 class ParameterSpec(ImmutableBase):
-    NOVALUE = _NoValue()
+    NOVALUE = _NOVALUE
 
     def __init__(self, qiime_type=NOVALUE, view_type=NOVALUE, default=NOVALUE,
                  description=NOVALUE):

--- a/qiime2/plugin/__init__.py
+++ b/qiime2/plugin/__init__.py
@@ -12,10 +12,10 @@ from .plugin import Plugin
 
 from qiime2.core.type import (SemanticType, Int, Str, Float, Color, Metadata,
                               MetadataCategory, Properties, Range, Choices,
-                              Arguments, Bool, Set, List)
+                              Arguments, Bool, Set, List, Visualization)
 
 
 __all__ = ['TextFileFormat', 'BinaryFileFormat', 'DirectoryFormat', 'Plugin',
            'SemanticType', 'Set', 'List', 'Bool', 'Int', 'Str', 'Float',
            'Color', 'Metadata', 'MetadataCategory', 'Properties', 'Range',
-           'Choices', 'Arguments', 'ValidationError']
+           'Choices', 'Arguments', 'Visualization', 'ValidationError']

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -67,6 +67,7 @@ class Plugin:
 
         self.methods = PluginMethods(self)
         self.visualizers = PluginVisualizers(self)
+        self.pipelines = PluginPipelines(self)
 
         self.formats = {}
         self.types = {}
@@ -82,6 +83,7 @@ class Plugin:
         actions = {}
         actions.update(self.methods)
         actions.update(self.visualizers)
+        actions.update(self.pipelines)
         return types.MappingProxyType(actions)
 
     def register_formats(self, *formats):
@@ -222,3 +224,18 @@ class PluginVisualizers(PluginActions):
                                                  input_descriptions,
                                                  parameter_descriptions)
         self[visualizer.id] = visualizer
+
+
+class PluginPipelines(PluginActions):
+    _subpackage = 'pipelines'
+
+    def register_function(self, function, inputs, parameters, outputs, name,
+                          description, input_descriptions=None,
+                          parameter_descriptions=None,
+                          output_descriptions=None):
+        pipeline = qiime2.sdk.Pipeline._init(function, inputs, parameters,
+                                             outputs, self._package, name,
+                                             description, input_descriptions,
+                                             parameter_descriptions,
+                                             output_descriptions)
+        self[pipeline.id] = pipeline

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -83,7 +83,8 @@ class TestPlugin(unittest.TestCase):
                           'no_input_viz', 'long_description_method',
                           'parameter_only_pipeline', 'typical_pipeline',
                           'optional_artifact_pipeline', 'pointless_pipeline',
-                          'visualizer_only_pipeline', 'pipelines_in_pipeline'})
+                          'visualizer_only_pipeline', 'pipelines_in_pipeline',
+                          'failing_pipeline'})
         for action in actions.values():
             self.assertIsInstance(action, qiime2.sdk.Action)
 
@@ -106,7 +107,7 @@ class TestPlugin(unittest.TestCase):
                           'optional_artifacts_method',
                           'long_description_method'})
         for method in methods.values():
-            self.assertIsInstance(method, qiime2.sdk.Action)
+            self.assertIsInstance(method, qiime2.sdk.Method)
 
     def test_visualizers(self):
         visualizers = self.plugin.visualizers
@@ -115,7 +116,18 @@ class TestPlugin(unittest.TestCase):
                          {'most_common_viz', 'mapping_viz', 'params_only_viz',
                           'no_input_viz'})
         for viz in visualizers.values():
-            self.assertIsInstance(viz, qiime2.sdk.Action)
+            self.assertIsInstance(viz, qiime2.sdk.Visualizer)
+
+    def test_pipelines(self):
+        pipelines = self.plugin.pipelines
+
+        self.assertEqual(pipelines.keys(),
+                         {'parameter_only_pipeline', 'typical_pipeline',
+                          'optional_artifact_pipeline', 'pointless_pipeline',
+                          'visualizer_only_pipeline', 'pipelines_in_pipeline',
+                          'failing_pipeline'})
+        for pipeline in pipelines.values():
+            self.assertIsInstance(pipeline, qiime2.sdk.Pipeline)
 
     # TODO test registration of directory formats.
 

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -80,7 +80,10 @@ class TestPlugin(unittest.TestCase):
                           'identity_with_optional_metadata_category',
                           'params_only_method', 'no_input_method',
                           'optional_artifacts_method', 'params_only_viz',
-                          'no_input_viz', 'long_description_method'})
+                          'no_input_viz', 'long_description_method',
+                          'parameter_only_pipeline', 'typical_pipeline',
+                          'optional_artifact_pipeline', 'pointless_pipeline',
+                          'visualizer_only_pipeline', 'pipelines_in_pipeline'})
         for action in actions.values():
             self.assertIsInstance(action, qiime2.sdk.Action)
 

--- a/qiime2/plugins.py
+++ b/qiime2/plugins.py
@@ -55,8 +55,11 @@ class QIIMEArtifactAPIImporter:
             return self._make_spec(name, plugin, ('visualizers',))
         elif plugin_details[1] == 'methods':
             return self._make_spec(name, plugin, ('methods',))
+        elif plugin_details[1] == 'pipelines':
+            return self._make_spec(name, plugin, ('pipelines',))
         elif plugin_details[1] == 'actions':
-            return self._make_spec(name, plugin, ('methods', 'visualizers'))
+            return self._make_spec(name, plugin, ('methods', 'visualizers',
+                                                  'pipelines'))
         return None
 
     def _make_spec(self, name, plugin, action_types=None):
@@ -85,6 +88,8 @@ class QIIMEArtifactAPIImporter:
                                                      package=spec.name)
             module.visualizers = importlib.import_module('.visualizers',
                                                          package=spec.name)
+            module.pipelines = importlib.import_module('.pipelines',
+                                                       package=spec.name)
             module.actions = importlib.import_module('.actions',
                                                      package=spec.name)
         else:

--- a/qiime2/sdk/__init__.py
+++ b/qiime2/sdk/__init__.py
@@ -6,12 +6,13 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from .action import Action, Method, Visualizer
+from .context import Context
+from .action import Action, Method, Visualizer, Pipeline
 from .plugin_manager import PluginManager
 from .result import Result, Artifact, Visualization
 from .results import Results
 from .util import parse_type, parse_format, UnknownTypeError
 
 __all__ = ['Result', 'Results', 'Artifact', 'Visualization', 'Action',
-           'Method', 'Visualizer', 'PluginManager', 'parse_type',
-           'parse_format', 'UnknownTypeError']
+           'Method', 'Visualizer', 'Pipeline', 'PluginManager', 'parse_type',
+           'parse_format', 'UnknownTypeError', 'Context']

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -431,11 +431,13 @@ class Pipeline(Action):
                             provenance):
         is_subprocess = self._is_subprocess()
         ctx = qiime2.sdk.Context()
-        outputs = callable(ctx, **view_args)
-        outputs = tuplize(outputs)
-        if is_subprocess:
-            for result in ctx._locals:
-                _ALWAYS_PROCESS_CLEANUP.append(result._archiver)
+        try:
+            outputs = callable(ctx, **view_args)
+            outputs = tuplize(outputs)
+        finally:
+            if is_subprocess:
+                for result in ctx._locals:
+                    _ALWAYS_PROCESS_CLEANUP.append(result._archiver)
 
         if len(outputs) != len(output_types):
             raise TypeError(

--- a/qiime2/sdk/context.py
+++ b/qiime2/sdk/context.py
@@ -21,6 +21,7 @@ class Context:
         cleanup as appropriate.
         """
         pm = qiime2.sdk.PluginManager()
+        plugin = plugin.replace('_', '-')
         action = pm.plugins[plugin].actions[action]
         # This factory will create new Contexts with this context as their
         # parent. This allows scope cleanup to happen recursively.

--- a/qiime2/sdk/context.py
+++ b/qiime2/sdk/context.py
@@ -9,39 +9,60 @@
 import qiime2.sdk
 
 
-class ProxyAction:
-    """This class basically exists because .async/multiprocess.map is a thing
-    """
-    def __init__(self, action, locals):
-        self._action = action
-        self._locals = locals
-
-    def __call__(self, *args, **kwargs):
-        results = self._action(*args, **kwargs)
-        self._locals += results  # Our own garbage collection scheme
-        return results
-
-    def __repr__(self):
-        return "<ProxyAction of %r>" % self._action
-
-
 class Context:
-    def __init__(self):
-        self._locals = []
+    def __init__(self, parent=None):
+        self._parent = parent
+        self._scope = None
 
     def import_action(self, plugin: str, action: str):
-        # This singleton is shared across multiprocess on OS's with
-        # copy-on-write semantics for `fork()` which means it isn't
-        # reinitalized. This results in actions with the PID of the parent.
-        # So instead, copy the action and "adopt" the right PID.
         pm = qiime2.sdk.PluginManager()
-        action = pm.plugins[plugin].actions[action].copy()
-        return ProxyAction(action, self._locals)
+        action = pm.plugins[plugin].actions[action]
+        return action.bind(lambda: Context(parent=self))
 
     def make_artifact(self, type, view, view_type=None):
-        a = qiime2.sdk.Artifact.import_data(type, view, view_type=view_type)
-        # This is needed so that in a subprocess situation, we can find
-        # "internal" artifacts which will not be cleaned up correctly due to
-        # `sys._exit`
-        self._locals.append(a)
-        return a
+        artifact = qiime2.sdk.Artifact.import_data(type, view, view_type)
+        self._scope.add_reference(artifact)
+        return artifact
+
+    def __enter__(self):
+        if self._scope is not None:
+            # Prevent odd things from happening to lifecycle cleanup
+            raise Exception('Cannot enter a context twice.')
+        self._scope = Scope(self)
+        return self._scope
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if exc_type is not None:
+            # Something went wrong, teardown everything
+            self._scope.destroy()
+        else:
+            # Everything is fine, just cleanup internal references and hoist
+            self._scope.destroy(internal_only=True)
+            if self._parent is not None:
+                for hoisted in self._scope.iter_hoisted():
+                    self._parent._scope.add_reference(hoisted)
+
+
+class Scope:
+    def __init__(self, ctx):
+        self.ctx = ctx
+        self._locals = []
+        self._hoists = []
+
+    def add_reference(self, ref, hoist=False):
+        if hoist:
+            self._hoists.append(ref)
+        else:
+            self._locals.append(ref)
+
+    def iter_hoisted(self):
+        yield from self._hoists
+
+    def destroy(self, internal_only=False):
+        destructors = self._locals
+        if not internal_only:
+            destructors = destructors + self._hoists
+        for ref in destructors:
+            ref._destructor()
+
+        self.ctx = None

--- a/qiime2/sdk/context.py
+++ b/qiime2/sdk/context.py
@@ -14,17 +14,40 @@ class Context:
         self._parent = parent
         self._scope = None
 
-    def import_action(self, plugin: str, action: str):
+    def get_action(self, plugin: str, action: str):
+        """Return a function matching the callable API of an action.
+
+        This function is aware of the pipeline context and manages its own
+        cleanup as appropriate.
+        """
         pm = qiime2.sdk.PluginManager()
         action = pm.plugins[plugin].actions[action]
-        return action.bind(lambda: Context(parent=self))
+        # This factory will create new Contexts with this context as their
+        # parent. This allows scope cleanup to happen recursively.
+        # A factory is necessary so that independent applications of the
+        # returned callable recieve their own Context objects.
+        return action._bind(lambda: Context(parent=self))
 
     def make_artifact(self, type, view, view_type=None):
+        """Return a new artifact from a given view.
+
+        This artifact is automatically tracked and cleaned by the pipeline
+        context.
+        """
         artifact = qiime2.sdk.Artifact.import_data(type, view, view_type)
+        # self._scope WILL be defined at this point, as pipelines always enter
+        # a scope before deferring to plugin code. (Otherwise cleanup wouldn't
+        # happen)
         self._scope.add_reference(artifact)
         return artifact
 
     def __enter__(self):
+        """For internal use only.
+
+        Creates a scope API that can track references that need to be
+        destroyed.
+
+        """
         if self._scope is not None:
             # Prevent odd things from happening to lifecycle cleanup
             raise Exception('Cannot enter a context twice.')
@@ -36,33 +59,63 @@ class Context:
             # Something went wrong, teardown everything
             self._scope.destroy()
         else:
-            # Everything is fine, just cleanup internal references and hoist
-            self._scope.destroy(internal_only=True)
+            # Everything is fine, just cleanup internal references and pass
+            # ownership off to the parent context.
+            parent_refs = self._scope.destroy(local_references_only=True)
             if self._parent is not None:
-                for hoisted in self._scope.iter_hoisted():
-                    self._parent._scope.add_reference(hoisted)
+                for ref in parent_refs:
+                    self._parent._scope.add_reference(ref)
 
 
 class Scope:
     def __init__(self, ctx):
         self.ctx = ctx
         self._locals = []
-        self._hoists = []
+        self._parent_locals = []
 
-    def add_reference(self, ref, hoist=False):
-        if hoist:
-            self._hoists.append(ref)
-        else:
-            self._locals.append(ref)
+    def add_reference(self, ref):
+        """Add a reference to something destructable that is owned by this
+           scope.
+        """
+        self._locals.append(ref)
 
-    def iter_hoisted(self):
-        yield from self._hoists
+    def add_parent_reference(self, ref):
+        """Add a reference to something destructable that will be owned by the
+           parent scope. The reason it needs to be tracked is so that on
+           failure, a context can still identify what will (no longer) be
+           returned.
+        """
+        self._parent_locals.append(ref)
 
-    def destroy(self, internal_only=False):
-        destructors = self._locals
-        if not internal_only:
-            destructors = destructors + self._hoists
-        for ref in destructors:
+    def destroy(self, local_references_only=False):
+        """Destroy all references and clear state.
+
+        Parameters
+        ----------
+        local_references_only : bool
+            Whether to destroy references that will belong to the parent scope.
+        Returns
+        -------
+        list
+            The list of references that were not destroyed.
+
+        """
+        local_refs = self._locals
+        parent_refs = self._parent_locals
+
+        # Unset instance state, handy to prevent cycles in GC, and also causes
+        # catastrophic failure if some invariant is violated.
+        del self._locals
+        del self._parent_locals
+        del self.ctx
+
+        for ref in local_refs:
             ref._destructor()
 
-        self.ctx = None
+        if local_references_only:
+            return parent_refs
+
+        for ref in parent_refs:
+            ref._destructor()
+
+        return []

--- a/qiime2/sdk/context.py
+++ b/qiime2/sdk/context.py
@@ -1,0 +1,47 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import qiime2.sdk
+
+
+class ProxyAction:
+    """This class basically exists because .async/multiprocess.map is a thing
+    """
+    def __init__(self, action, locals):
+        self._action = action
+        self._locals = locals
+
+    def __call__(self, *args, **kwargs):
+        results = self._action(*args, **kwargs)
+        self._locals += results  # Our own garbage collection scheme
+        return results
+
+    def __repr__(self):
+        return "<ProxyAction of %r>" % self._action
+
+
+class Context:
+    def __init__(self):
+        self._locals = []
+
+    def import_action(self, plugin: str, action: str):
+        # This singleton is shared across multiprocess on OS's with
+        # copy-on-write semantics for `fork()` which means it isn't
+        # reinitalized. This results in actions with the PID of the parent.
+        # So instead, copy the action and "adopt" the right PID.
+        pm = qiime2.sdk.PluginManager()
+        action = pm.plugins[plugin].actions[action].copy()
+        return ProxyAction(action, self._locals)
+
+    def make_artifact(self, type, view, view_type=None):
+        a = qiime2.sdk.Artifact.import_data(type, view, view_type=view_type)
+        # This is needed so that in a subprocess situation, we can find
+        # "internal" artifacts which will not be cleaned up correctly due to
+        # `sys._exit`
+        self._locals.append(a)
+        return a

--- a/qiime2/sdk/context.py
+++ b/qiime2/sdk/context.py
@@ -22,12 +22,21 @@ class Context:
         """
         pm = qiime2.sdk.PluginManager()
         plugin = plugin.replace('_', '-')
-        action = pm.plugins[plugin].actions[action]
+        try:
+            plugin_obj = pm.plugins[plugin]
+        except KeyError:
+            raise ValueError("A plugin named %r could not be found." % plugin)
+
+        try:
+            action_obj = plugin_obj.actions[action]
+        except KeyError:
+            raise ValueError("An action named %r was not found for plugin %r"
+                             % (action, plugin))
         # This factory will create new Contexts with this context as their
         # parent. This allows scope cleanup to happen recursively.
         # A factory is necessary so that independent applications of the
         # returned callable recieve their own Context objects.
-        return action._bind(lambda: Context(parent=self))
+        return action_obj._bind(lambda: Context(parent=self))
 
     def make_artifact(self, type, view, view_type=None):
         """Return a new artifact from a given view.

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -130,8 +130,9 @@ class Result:
         # format tranformations may return the invoked transformers
         return None
 
-    def _orphan(self):
-        self._archiver.orphan()
+    @property
+    def _destructor(self):
+        return self._archiver._destructor
 
     def save(self, filepath):
         if not filepath.endswith(self.extension):

--- a/qiime2/sdk/tests/test_pipeline.py
+++ b/qiime2/sdk/tests/test_pipeline.py
@@ -188,6 +188,16 @@ class TestPipeline(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, 'this never works'):
                 call(self.int_sequence, break_from='internal')
 
+    def test_failing_from_missing_plugin(self):
+        for call in self.iter_callables('failing_pipeline'):
+            with self.assertRaisesRegex(ValueError, 'plugin.*not\%a\$plugin'):
+                call(self.int_sequence, break_from='no-plugin')
+
+    def test_failing_from_missing_action(self):
+        for call in self.iter_callables('failing_pipeline'):
+            with self.assertRaisesRegex(ValueError, 'action.*not\%a\$method'):
+                call(self.int_sequence, break_from='no-action')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/sdk/tests/test_pipeline.py
+++ b/qiime2/sdk/tests/test_pipeline.py
@@ -1,0 +1,168 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+import inspect
+
+import pandas as pd
+
+import qiime2
+import qiime2.sdk
+from qiime2.core.testing.util import get_dummy_plugin
+from qiime2.core.testing.type import IntSequence1, SingleInt, Mapping
+from qiime2.plugin import Visualization, Int, Bool
+
+
+class TestPipeline(unittest.TestCase):
+    def setUp(self):
+        self.plugin = get_dummy_plugin()
+        self.single_int = qiime2.Artifact.import_data(SingleInt, -1)
+        self.int_sequence = qiime2.Artifact.import_data(IntSequence1,
+                                                        [1, 2, 3])
+        self.mapping = qiime2.Artifact.import_data(Mapping, {'foo': '42'})
+
+    def test_private_constructor(self):
+        with self.assertRaisesRegex(NotImplementedError,
+                                    'Pipeline constructor.*private'):
+            qiime2.sdk.Pipeline()
+
+    def test_from_function_spot_check(self):
+        typical_pipeline = self.plugin.pipelines['typical_pipeline']
+        self.assertEqual(typical_pipeline.id, 'typical_pipeline')
+
+        assert typical_pipeline.signature.inputs
+        for spec in typical_pipeline.signature.inputs.values():
+            assert spec.has_description()
+            assert spec.has_qiime_type()
+            assert not spec.has_view_type()
+            assert not spec.has_default()
+
+        spec = typical_pipeline.signature.parameters['add']
+        assert spec.has_default()
+
+    def test_from_function_optional(self):
+        optional_artifact_pipeline = self.plugin.pipelines[
+            'optional_artifact_pipeline']
+
+        spec = optional_artifact_pipeline.signature.inputs['single_int']
+        assert spec.has_default()
+
+    def test_is_callable(self):
+        assert callable(self.plugin.pipelines['typical_pipeline'])
+
+    def test_callable_and_async_signature(self):
+        # Shouldn't include `ctx`
+        typical_pipeline = self.plugin.pipelines['typical_pipeline']
+        kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
+        exp_parameters = [
+            ('int_sequence', inspect.Parameter(
+                'int_sequence', kind, annotation=IntSequence1)),
+            ('mapping', inspect.Parameter(
+                'mapping', kind, annotation=Mapping)),
+            ('do_extra_thing', inspect.Parameter(
+                'do_extra_thing', kind, annotation=Bool)),
+            ('add', inspect.Parameter(
+                'add', kind, default=1, annotation=Int))
+        ]
+
+        for callable_attr in '__call__', 'async':
+            signature = inspect.Signature.from_callable(
+                getattr(typical_pipeline, callable_attr))
+            parameters = list(signature.parameters.items())
+
+            self.assertEqual(parameters, exp_parameters)
+
+    def test_signatures_independent(self):
+        typical_pipeline = self.plugin.pipelines['typical_pipeline']
+        parameter_only_pipeline = self.plugin.pipelines[
+            'parameter_only_pipeline']
+
+        for callable_attr in '__call__', 'async':
+            signature_a = inspect.Signature.from_callable(
+                getattr(typical_pipeline, callable_attr))
+
+            signature_b = inspect.Signature.from_callable(
+                getattr(parameter_only_pipeline, callable_attr))
+
+            self.assertNotEqual(signature_a, signature_b)
+
+    def iter_callables(self, name):
+        pipeline = self.plugin.pipelines[name]
+        yield pipeline
+        yield lambda *args, **kwargs: pipeline.async(*args, **kwargs).result()
+
+    def test_parameter_only_pipeline(self):
+        index = pd.Index(['a', 'b', 'c'], dtype=object)
+        df = pd.DataFrame({'col1': ['2', '1', '3']}, index=index, dtype=object)
+        metadata = qiime2.Metadata(df)
+        for call in self.iter_callables('parameter_only_pipeline'):
+            results = call(100)
+            self.assertEqual(results.foo.view(list), [100, 2, 3])
+            self.assertEqual(results.bar.view(list),
+                             [100, 2, 3, 100, 2, 3, 100, 2, 3, 100, 2])
+
+            results = call(3, int2=4, metadata=metadata)
+            self.assertEqual(results.foo.view(list), [3, 4, 3])
+            self.assertEqual(results.bar.view(list),
+                             [3, 4, 3, 3, 4, 3, 3, 4, 3, 3, 4])
+
+    def test_typical_pipeline(self):
+        for call in self.iter_callables('typical_pipeline'):
+            results = call(self.int_sequence, self.mapping, False)
+
+            self.assertEqual(results.left_viz.type, Visualization)
+            self.assertEqual(results.left.view(list), [1])
+            self.assertEqual(results.right.view(list), [2, 3])
+            self.assertNotEqual(results.out_map.uuid, self.mapping.uuid)
+            self.assertEqual(results.out_map.view(dict),
+                             self.mapping.view(dict))
+
+            results = call(self.int_sequence, self.mapping, True, add=5)
+            self.assertEqual(results.left.view(list), [6])
+            self.assertEqual(results.right.view(list), [2, 3])
+
+            with self.assertRaisesRegex(ValueError, 'Bad mapping'):
+                m = qiime2.Artifact.import_data(Mapping, {'a': 1})
+                call(self.int_sequence, m, False)
+
+    def test_optional_artifact_pipeline(self):
+        for call in self.iter_callables('optional_artifact_pipeline'):
+            ints, = call(self.int_sequence)
+            self.assertEqual(ints.view(list), [1, 2, 3, 4])
+
+            ints, = call(self.int_sequence, single_int=self.single_int)
+            self.assertEqual(ints.view(list), [1, 2, 3, -1])
+
+    def test_visualizer_only_pipeline(self):
+        for call in self.iter_callables('visualizer_only_pipeline'):
+            viz1, viz2 = call(self.mapping)
+
+            self.assertEqual(viz1.type, Visualization)
+            self.assertEqual(viz2.type, Visualization)
+
+    def test_pipeline_in_pipeline(self):
+        for call in self.iter_callables('pipelines_in_pipeline'):
+            results = call(self.int_sequence, self.mapping)
+
+            self.assertEqual(results.int1.view(int), 4)
+            self.assertEqual(results.right_viz.type, Visualization)
+            self.assertEqual(len(results), 8)
+
+            with self.assertRaisesRegex(ValueError, 'Bad mapping'):
+                m = qiime2.Artifact.import_data(Mapping, {1: 1})
+                call(self.int_sequence, m)
+
+    def test_pointless_pipeline(self):
+        for call in self.iter_callables('pointless_pipeline'):
+            single_int, = call()
+            self.assertEqual(single_int.type, SingleInt)
+            self.assertEqual(single_int.view(int), 4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qiime2/sdk/tests/test_pipeline.py
+++ b/qiime2/sdk/tests/test_pipeline.py
@@ -163,6 +163,31 @@ class TestPipeline(unittest.TestCase):
             self.assertEqual(single_int.type, SingleInt)
             self.assertEqual(single_int.view(int), 4)
 
+    def test_failing_from_arity(self):
+        for call in self.iter_callables('failing_pipeline'):
+            with self.assertRaisesRegex(TypeError, 'match number.*3.*1'):
+                call(self.int_sequence, break_from='arity')
+
+    def test_failing_from_return_view(self):
+        for call in self.iter_callables('failing_pipeline'):
+            with self.assertRaisesRegex(TypeError, 'Result objects'):
+                call(self.int_sequence, break_from='return-view')
+
+    def test_failing_from_method(self):
+        for call in self.iter_callables('failing_pipeline'):
+            with self.assertRaisesRegex(ValueError, "Key 'foo' exists"):
+                call(self.int_sequence, break_from='method')
+
+    def test_failing_from_type(self):
+        for call in self.iter_callables('failing_pipeline'):
+            with self.assertRaisesRegex(TypeError, 'Mapping.*SingleInt'):
+                call(self.int_sequence, break_from='type')
+
+    def test_failing_from_internal(self):
+        for call in self.iter_callables('failing_pipeline'):
+            with self.assertRaisesRegex(ValueError, 'this never works'):
+                call(self.int_sequence, break_from='internal')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -47,7 +47,7 @@ class TestImports(unittest.TestCase):
         self._check_methods(module.methods)
         self._check_visualizers(module.visualizers)
         self.assertEqual(set(x for x in dir(module) if not x.startswith('_')),
-                         {'visualizers', 'methods', 'actions'})
+                         {'visualizers', 'methods', 'actions', 'pipelines'})
 
     def _check_methods(self, module):
         self._check_spec(module, 'qiime2.plugins.dummy_plugin.methods', False)


### PR DESCRIPTION
TODO:
  - [x] tighten up registration w.r.t. view annotations (or lack thereof)
  - [x] write tests
  - [x] actual lifetime management of artifacts
  - [x] write more tests


Pipelines work otherwise! And cleanup is handled even when calling with `.async`