### PR TITLE
BUG: fix misformatted error messages from file and directory format `validate`

### DIFF
--- a/qiime2/core/testing/pipeline.py
+++ b/qiime2/core/testing/pipeline.py
@@ -88,9 +88,9 @@ def pointless_pipeline(ctx):
 def failing_pipeline(ctx, int_sequence, break_from='arity'):
     merge_mappings = ctx.get_action('dummy_plugin', 'merge_mappings')
 
-    l = int_sequence.view(list)
-    if l:
-        integer = l[0]
+    list_ = int_sequence.view(list)
+    if list_:
+        integer = list_[0]
     else:
         integer = 0
 

--- a/qiime2/plugin/model/directory_format.py
+++ b/qiime2/plugin/model/directory_format.py
@@ -181,7 +181,7 @@ class DirectoryFormat(FormatBase, metaclass=_DirectoryMeta):
                 self._validate_(level)
             except ValidationError as e:
                 raise ValidationError(
-                    "%s is not a(n) %s: %r"
+                    "%s is not a(n) %s:\n\n%s"
                     % (self.path, self.__class__.__name__, str(e))
                     ) from e
 

--- a/qiime2/plugin/model/file_format.py
+++ b/qiime2/plugin/model/file_format.py
@@ -24,7 +24,7 @@ class _FileFormat(FormatBase, metaclass=abc.ABCMeta):
                 self._validate_(level)
             except ValidationError as e:
                 raise ValidationError(
-                    "%s is not a %s file: %r"
+                    "%s is not a(n) %s file:\n\n%s"
                     % (self.path, self.__class__.__name__, str(e))
                     ) from e
         # TODO: remove this branch

--- a/qiime2/sdk/tests/test_artifact.py
+++ b/qiime2/sdk/tests/test_artifact.py
@@ -327,7 +327,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
             fh.write('abc\n')
             fh.write('123\n')
 
-        error_regex = "foo.txt.*IntSequenceFormat.*Line 3"
+        error_regex = "foo.txt.*IntSequenceFormat.*\n\n.*Line 3"
         with self.assertRaisesRegex(ValidationError, error_regex):
             Artifact.import_data(IntSequence1, fp)
 
@@ -345,7 +345,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
         with open(os.path.join(nested, 'file4.txt'), 'w') as fh:
             fh.write('foo\n')
 
-        error_regex = "file4.txt.*SingleIntFormat.*integer"
+        error_regex = "file4.txt.*SingleIntFormat.*\n\n.*integer"
         with self.assertRaisesRegex(ValidationError, error_regex):
             Artifact.import_data(FourInts, data_dir)
 
@@ -368,7 +368,8 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
         with open(os.path.join(data_dir, 'file2.txt'), 'w') as fh:
             fh.write('2\n')
 
-        error_regex = "test.*RedundantSingleIntDirectoryFormat.*does not match"
+        error_regex = ("test.*RedundantSingleIntDirectoryFormat.*\n\n"
+                       ".*does not match")
         with self.assertRaisesRegex(ValidationError, error_regex):
             Artifact.import_data(SingleInt, data_dir)
 


### PR DESCRIPTION
### Note to reviewer: please "Rebase and merge" because there are two logical commits in this PR.

Commit 1:

Wrapped error messages from the underlying file or directory format were being displayed with `%r` instead of `%s`, making them difficult to read. Also added some newline padding to separate the wrapper's preamble text from the actual error message.

Before:

![image](https://user-images.githubusercontent.com/1847232/31904607-a0147d9c-b7e0-11e7-9ea8-e5706771e430.png)

After:

![image](https://user-images.githubusercontent.com/1847232/31905309-9259e96a-b7e2-11e7-8674-bbeb66b3460c.png)

Commit 2:

Fix "ambiguous variable name" error from new flake8.