### PR TITLE
ENH: adds collection types

### DIFF
--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -222,13 +222,14 @@ class _ZipArchive(_Archive):
 
 
 class Archiver:
-    CURRENT_FORMAT_VERSION = '2'
+    CURRENT_FORMAT_VERSION = '3'
     CURRENT_ARCHIVE = _ZipArchive
     _FORMAT_REGISTRY = {
         # NOTE: add more archive formats as things change
         '0': 'qiime2.core.archive.format.v0:ArchiveFormat',
         '1': 'qiime2.core.archive.format.v1:ArchiveFormat',
-        '2': 'qiime2.core.archive.format.v2:ArchiveFormat'
+        '2': 'qiime2.core.archive.format.v2:ArchiveFormat',
+        '3': 'qiime2.core.archive.format.v3:ArchiveFormat',
     }
 
     @classmethod

--- a/qiime2/core/archive/format/v3.py
+++ b/qiime2/core/archive/format/v3.py
@@ -1,0 +1,16 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import qiime2.core.archive.format.v2 as v2
+
+
+class ArchiveFormat(v2.ArchiveFormat):
+    # Exactly the same as v2, but inputs may be variadic where the UUIDs are in
+    # a YAML sequence. Additionally `Set` is now represented as a sequence
+    # with a custom !set tag.
+    pass

--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -78,3 +78,17 @@ def optional_artifacts_method(ints: list, num1: int, optional1: list=None,
     if num2 is not None:
         result += [num2]
     return result
+
+
+def variadic_input_method(ints: list, int_set: int, nums: int,
+                          opt_nums: int=None) -> list:
+    results = []
+
+    for int_list in ints:
+        results += int_list
+    results += sorted(int_set)
+    results += nums
+    if opt_nums:
+        results += opt_nums
+
+    return results

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -32,7 +32,8 @@ from .method import (concatenate_ints, split_ints, merge_mappings,
                      identity_with_optional_metadata,
                      identity_with_optional_metadata_category,
                      params_only_method, no_input_method,
-                     optional_artifacts_method, long_description_method)
+                     optional_artifacts_method, long_description_method,
+                     variadic_input_method)
 from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
 from .pipeline import (parameter_only_pipeline, typical_pipeline,
@@ -289,6 +290,34 @@ dummy_plugin.methods.register_function(
                 'whatever integers are supplied as input.'
 )
 
+dummy_plugin.methods.register_function(
+    function=variadic_input_method,
+    inputs={
+        'ints': qiime2.plugin.List[IntSequence1 | IntSequence2],
+        'int_set': qiime2.plugin.Set[SingleInt]
+    },
+    parameters={
+        'nums': qiime2.plugin.Set[qiime2.plugin.Int],
+        'opt_nums': qiime2.plugin.List[
+            qiime2.plugin.Int % qiime2.plugin.Range(10, 20)]
+    },
+    outputs=[
+        ('output', IntSequence1)
+    ],
+    name='Test variadic inputs',
+    description='This method concatenates all of its variadic inputs',
+    input_descriptions={
+        'ints': 'A list of int artifacts',
+        'int_set': 'A set of int artifacts'
+    },
+    parameter_descriptions={
+        'nums': 'A set of ints',
+        'opt_nums': 'An optional list of ints'
+    },
+    output_descriptions={
+        'output': 'All of the above mashed together'
+    }
+)
 
 dummy_plugin.visualizers.register_function(
     function=params_only_viz,

--- a/qiime2/core/type/__init__.py
+++ b/qiime2/core/type/__init__.py
@@ -6,17 +6,26 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from .collection import List, Set, is_collection_type
 from .semantic import SemanticType, is_semantic_type, Properties
-from .primitive import (Str, Int, Float, Color, Dict, Set, Metadata, Bool,
-                        MetadataCategory, List, Range, Choices, Arguments,
-                        is_primitive_type)
+from .primitive import (Str, Int, Float, Color, Metadata, Bool,
+                        MetadataCategory, Range, Choices, is_primitive_type)
 from .visualization import Visualization
 from .signature import PipelineSignature, MethodSignature, VisualizerSignature
 
 __all__ = [
-    'SemanticType', 'is_semantic_type', 'is_primitive_type',
-    'Str', 'Int', 'Float', 'Bool', 'Color', 'Dict', 'Set', 'List', 'Metadata',
-    'MetadataCategory', 'Visualization', 'PipelineSignature',
-    'MethodSignature', 'VisualizerSignature', 'Properties', 'Range', 'Choices',
-    'Arguments'
+    # Type Helpers
+    'is_semantic_type', 'is_primitive_type', 'is_collection_type',
+    # Collection Types
+    'Set', 'List',
+    # Semantic Types
+    'SemanticType',
+    'Properties',
+    # Primitive Types
+    'Str', 'Int', 'Float', 'Bool', 'Color', 'Metadata', 'MetadataCategory',
+    'Range', 'Choices',
+    # Visualization Type
+    'Visualization',
+    # Signatures
+    'PipelineSignature', 'MethodSignature', 'VisualizerSignature'
 ]

--- a/qiime2/core/type/collection.py
+++ b/qiime2/core/type/collection.py
@@ -1,0 +1,107 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import json
+
+from . import grammar
+from .primitive import (
+    _PrimitiveBase, is_primitive_type, Metadata, MetadataCategory)
+from .semantic import _SemanticMixin, is_semantic_type
+
+
+def is_collection_type(type_):
+    return isinstance(type_, (_CollectionBase, _CollectionExpression))
+
+
+class _CollectionBase(grammar.CompositeType):
+    def __init__(self, name, view):
+        # Only 1d collections are supported for now
+        self._view = view
+        super().__init__(name, field_names=['elements'])
+
+    def _apply_fields_(self, fields):
+        elements, = fields
+        if is_collection_type(elements):
+            # This must be the first branch, as is_primitive/semantic is true
+            # for collections types as well.
+            raise TypeError("Cannot nest collection types.")
+        elif is_semantic_type(elements):
+            return _CollectionSemantic(self.name, self._view, fields=fields)
+        elif is_primitive_type(elements):
+            if elements is Metadata or elements is MetadataCategory:
+                raise TypeError("Cannot use collections on metadata.")
+            return _CollectionPrimitive(self.name, self._view, fields=fields)
+        else:
+            raise NotImplementedError
+
+
+class _CollectionExpression(grammar.TypeExpression):
+    def __init__(self, name, view, fields=(), predicate=None):
+        self._view = view
+        super().__init__(name, fields, predicate)
+
+    def _is_element_(self, value):
+        contained_type, = self.fields
+        if not isinstance(value, self._view):
+            return False
+        if not value:
+            # Collections of size 1 are not allowed as it overlaps with
+            # optional values in an awkward way that is difficult to explain
+            # to end-users and make interfaces more difficult.
+            return False
+        for el in value:
+            if el not in contained_type:
+                return False
+
+        return True
+
+    def to_ast(self):
+        ast = super().to_ast()
+        ast['type'] = 'collection'
+        return ast
+
+    def _validate_union_(self, other, handshake=False):
+        # This is actually handled really well by the grammar, but interfaces
+        # would need to observe unions which may have multiple collections
+        # or mixes of collections and singletons, which is more complicated
+        # and we don't need it.
+        # If this is supported in the future, we should check that the type
+        # of self and other are the same so that we don't mix primitive and
+        # semantic types.
+        raise TypeError("Unions of collection types are not supported.")
+
+    def _validate_predicate_(self, predicate):
+        # Something like `MinLen(...)` might be handy...
+        raise TypeError("There are no predicates for collection types.")
+
+    def _apply_fields_(self, fields):
+        # Just pass the `view` along.
+        return self.__class__(self.name, self._view, fields=fields,
+                              predicate=self.predicate)
+
+    def is_concrete(self):
+        # Prevent use as an output or artifact type
+        return False
+
+
+class _CollectionPrimitive(_CollectionExpression, _PrimitiveBase):
+    def encode(self, value):
+        return json.dumps(list(value))
+
+    def decode(self, string):
+        return self._view(json.loads(string))
+
+
+class _CollectionSemantic(_CollectionExpression, _SemanticMixin):
+    def is_variant(self, varfield):
+        # Collections shouldn't be part of a composite type
+        return False
+
+
+List = _CollectionBase('List', list)
+Set = _CollectionBase('Set', set)

--- a/qiime2/core/type/grammar.py
+++ b/qiime2/core/type/grammar.py
@@ -43,6 +43,10 @@ class CompositeType(_TypeBase):
 
         self._freeze_()
 
+    def __contains__(self, value):
+        raise TypeError("Cannot check membership of %r, %r is missing"
+                        " arguments for its fields." % (value, self))
+
     def __mod__(self, predicate):
         raise TypeError("Cannot apply predicate %r, %r is missing arguments"
                         " for its fields." % (predicate, self))
@@ -309,6 +313,9 @@ class _SetOperationBase(TypeExpression):
 
     def _validate_predicate_(self, predicate):
         raise TypeError("Cannot apply predicates to union/intersection types.")
+
+    def _is_element_(self, value):
+        return any(value in member for member in self.members)
 
     def to_ast(self):
         return {

--- a/qiime2/core/type/primitive.py
+++ b/qiime2/core/type/primitive.py
@@ -75,7 +75,8 @@ class Range(Predicate):
         self.inclusive_start = inclusive_start
         self.inclusive_end = inclusive_end
 
-        super().__init__(args)
+        truthy = self.start is not None or self.end is not None
+        super().__init__(truthy)
 
     def __hash__(self):
         return (hash(type(self)) ^

--- a/qiime2/core/type/semantic.py
+++ b/qiime2/core/type/semantic.py
@@ -234,12 +234,6 @@ class _SemanticUnionType(grammar.UnionTypeExpression, _SemanticMixin):
     def is_variant(self, varfield):
         return all(m.is_variant(varfield) for m in self)
 
-    def _is_element_(self, value):
-        import qiime2.sdk
-        if not isinstance(value, qiime2.sdk.Artifact):
-            return False
-        return value.type <= self
-
 
 class Properties(grammar.Predicate):
     def __init__(self, include=(), exclude=()):

--- a/qiime2/core/type/tests/test_collection.py
+++ b/qiime2/core/type/tests/test_collection.py
@@ -1,0 +1,153 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+from qiime2.core.type import (
+    is_collection_type, is_primitive_type, is_semantic_type, Set, List,
+    SemanticType, Int, Metadata, MetadataCategory, Range)
+
+
+class TestIsTypes(unittest.TestCase):
+    def test_list_semantic_type(self):
+        Foo = SemanticType('Foo')
+
+        self.assertTrue(is_collection_type(List[Foo]))
+        self.assertTrue(is_semantic_type(List[Foo]))
+        self.assertFalse(is_primitive_type(List[Foo]))
+
+    def test_set_semantic_type(self):
+        Foo = SemanticType('Foo')
+
+        self.assertTrue(is_collection_type(Set[Foo]))
+        self.assertTrue(is_semantic_type(Set[Foo]))
+        self.assertFalse(is_primitive_type(Set[Foo]))
+
+    def test_list_primitive_type(self):
+        self.assertTrue(is_collection_type(List[Int % Range(5)]))
+        self.assertTrue(is_primitive_type(List[Int % Range(5)]))
+        self.assertFalse(is_semantic_type(List[Int % Range(5)]))
+
+    def test_set_primitive_type(self):
+        self.assertTrue(is_collection_type(Set[Int % Range(5)]))
+        self.assertTrue(is_primitive_type(Set[Int % Range(5)]))
+        self.assertFalse(is_semantic_type(Set[Int % Range(5)]))
+
+
+class TestCollectionBase(unittest.TestCase):
+    def test_no_list_metadata(self):
+        with self.assertRaisesRegex(TypeError, 'metadata'):
+            List[Metadata]
+
+    def test_no_set_metadata(self):
+        with self.assertRaisesRegex(TypeError, 'metadata'):
+            List[Metadata]
+
+    def test_no_list_metadata_category(self):
+        with self.assertRaisesRegex(TypeError, 'metadata'):
+            List[MetadataCategory]
+
+    def test_no_set_metadata_category(self):
+        with self.assertRaisesRegex(TypeError, 'metadata'):
+            Set[MetadataCategory]
+
+    def test_no_nesting_list_list(self):
+        with self.assertRaisesRegex(TypeError, 'nest'):
+            List[List[Int]]
+
+    def test_no_nesting_set_set(self):
+        with self.assertRaisesRegex(TypeError, 'nest'):
+            Set[Set[Int]]
+
+    def test_no_nesting_mixed(self):
+        with self.assertRaisesRegex(TypeError, 'nest'):
+            List[Set[Int]]
+
+
+class TestCollectionExpression(unittest.TestCase):
+    def test_no_union(self):
+        with self.assertRaisesRegex(TypeError, 'Union.*supported'):
+            List[Int] | Set[Int]
+
+    def test_union_inside_collection(self):
+        Foo = SemanticType('Foo')
+        Bar = SemanticType('Bar')
+
+        self.assertTrue(List[Foo] <= List[Foo | Bar])
+
+    def test_no_predicate(self):
+        with self.assertRaisesRegex(TypeError, 'no predicate'):
+            List[Int] % Range(5)
+
+    def is_concrete(self):
+        Foo = SemanticType('Foo')
+
+        self.assertFalse(List[Foo].is_concrete())
+        self.assertFalse(Set[Int].is_concrete())
+
+    def test_to_ast_semantic(self):
+        Foo = SemanticType('Foo')
+
+        ast = List[Foo].to_ast()
+        self.assertEqual(ast['fields'][0], Foo.to_ast())
+        self.assertEqual(ast['type'], 'collection')
+
+    def test_to_ast_primitive(self):
+        ast = List[Int % Range(5)].to_ast()
+        self.assertEqual(ast['fields'][0], (Int % Range(5)).to_ast())
+        self.assertEqual(ast['type'], 'collection')
+
+    def test_contains_list_primitive(self):
+        self.assertTrue([1, 2, 3] in List[Int])
+        self.assertTrue([-1, 2, 3] in List[Int])
+
+        self.assertFalse([-1, 2, 3] in List[Int % Range(0, 5)])
+        self.assertFalse([1, 1.1, 1.11] in List[Int])
+        self.assertFalse({1, 2, 3} in List[Int])
+        self.assertFalse(object() in List[Int])
+
+    def test_contains_set_primitive(self):
+        self.assertTrue({1, 2, 3} in Set[Int])
+        self.assertTrue({-1, 2, 3} in Set[Int])
+
+        self.assertFalse({-1, 2, 3} in Set[Int % Range(0, 5)])
+        self.assertFalse({1, 1.1, 1.11} in Set[Int])
+        self.assertFalse([1, 2, 3] in Set[Int])
+        self.assertFalse(object() in Set[Int])
+
+    def test_variant_of_field_members(self):
+        Bar = SemanticType('Bar')
+        Foo = SemanticType('Foo', field_names='foo',
+                           field_members={'foo': List[Bar]})
+        with self.assertRaisesRegex(TypeError, 'is not a variant'):
+            Foo[List[Bar]]
+
+    def test_variant_of_alt(self):
+        Foo = SemanticType('Foo', field_names='foo')
+        Bar = SemanticType('Bar', variant_of=Foo.field['foo'])
+
+        with self.assertRaisesRegex(TypeError, 'is not a variant'):
+            Foo[Set[Bar]]
+
+    def test_encode_decode_set(self):
+        value = List[Int].decode("[1, 2, 3]")
+        self.assertEqual(value, [1, 2, 3])
+
+        json = List[Int].encode(value)
+        self.assertEqual(json, "[1, 2, 3]")
+
+    def test_encode_decode_list(self):
+        value = Set[Int].decode("[1, 2, 3]")
+        self.assertEqual(value, {1, 2, 3})
+
+        json = Set[Int].encode(value)
+        self.assertEqual(json, "[1, 2, 3]")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qiime2/core/type/tests/test_grammar.py
+++ b/qiime2/core/type/tests/test_grammar.py
@@ -196,7 +196,7 @@ class TestTypeExpression(unittest.TestCase):
         a = grammar.TypeExpression('X')
         b = grammar.TypeExpression('Y', fields=(a,))
         c = grammar.TypeExpression('Y', fields=(a,))
-        d = grammar.TypeExpression('Z', predicate=grammar.Predicate())
+        d = grammar.TypeExpression('Z', predicate=grammar.Predicate("stuff"))
 
         self.assertIsInstance(a, collections.Hashable)
         # There really shouldn't be a collision between these:
@@ -435,8 +435,8 @@ class TestTypeExpressionMod(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, 'predicate'):
             X % grammar.Predicate('Other')
 
-    def test_mod_w_falsy_predicate(self):
-        X = grammar.TypeExpression('X', predicate=grammar.Predicate())
+    def test_mod_w_none_predicate(self):
+        X = grammar.TypeExpression('X', predicate=None)
         predicate = grammar.Predicate("Truthy")
         self.assertIs((X % predicate).predicate, predicate)
 

--- a/qiime2/plugin/__init__.py
+++ b/qiime2/plugin/__init__.py
@@ -12,10 +12,10 @@ from .plugin import Plugin
 
 from qiime2.core.type import (SemanticType, Int, Str, Float, Color, Metadata,
                               MetadataCategory, Properties, Range, Choices,
-                              Arguments, Bool, Set, List, Visualization)
+                              Bool, Set, List, Visualization)
 
 
 __all__ = ['TextFileFormat', 'BinaryFileFormat', 'DirectoryFormat', 'Plugin',
            'SemanticType', 'Set', 'List', 'Bool', 'Int', 'Str', 'Float',
            'Color', 'Metadata', 'MetadataCategory', 'Properties', 'Range',
-           'Choices', 'Arguments', 'Visualization', 'ValidationError']
+           'Choices', 'Visualization', 'ValidationError']

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -79,12 +79,12 @@ class TestPlugin(unittest.TestCase):
                           'identity_with_optional_metadata',
                           'identity_with_optional_metadata_category',
                           'params_only_method', 'no_input_method',
-                          'optional_artifacts_method', 'params_only_viz',
-                          'no_input_viz', 'long_description_method',
-                          'parameter_only_pipeline', 'typical_pipeline',
-                          'optional_artifact_pipeline', 'pointless_pipeline',
-                          'visualizer_only_pipeline', 'pipelines_in_pipeline',
-                          'failing_pipeline'})
+                          'optional_artifacts_method', 'variadic_input_method',
+                          'params_only_viz', 'no_input_viz',
+                          'long_description_method', 'parameter_only_pipeline',
+                          'typical_pipeline', 'optional_artifact_pipeline',
+                          'pointless_pipeline', 'visualizer_only_pipeline',
+                          'pipelines_in_pipeline', 'failing_pipeline'})
         for action in actions.values():
             self.assertIsInstance(action, qiime2.sdk.Action)
 
@@ -105,7 +105,8 @@ class TestPlugin(unittest.TestCase):
                           'identity_with_optional_metadata_category',
                           'params_only_method', 'no_input_method',
                           'optional_artifacts_method',
-                          'long_description_method'})
+                          'long_description_method',
+                          'variadic_input_method'})
         for method in methods.values():
             self.assertIsInstance(method, qiime2.sdk.Method)
 

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -210,8 +210,16 @@ class Action(metaclass=abc.ABCMeta):
                         callable_args[name] = None
                     elif spec.has_view_type():
                         recorder = provenance.transformation_recorder(name)
-                        callable_args[name] = artifact._view(
-                            spec.view_type, recorder)
+                        if qtype.is_collection_type(spec.qiime_type):
+                            # Always put in a list. Sometimes the view isn't
+                            # hashable, which isn't relevant, but would break
+                            # a Set[SomeType].
+                            callable_args[name] = [
+                                a._view(spec.view_type, recorder)
+                                for a in user_input[name]]
+                        else:
+                            callable_args[name] = artifact._view(
+                                spec.view_type, recorder)
                     else:
                         callable_args[name] = artifact
 

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -109,6 +109,9 @@ class Result:
         return ("<%s: %r uuid: %s>"
                 % (self.__class__.__name__.lower(), self.type, self.uuid))
 
+    def __hash__(self):
+        return hash(self.uuid)
+
     def __eq__(self, other):
         # Checking the UUID is mostly sufficient but requiring an exact type
         # match makes it safer in case `other` is a subclass or a completely

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -19,7 +19,8 @@ from qiime2.sdk import Artifact, Method, Results
 from qiime2.core.testing.method import (concatenate_ints, merge_mappings,
                                         split_ints, params_only_method,
                                         no_input_method)
-from qiime2.core.testing.type import IntSequence1, IntSequence2, Mapping
+from qiime2.core.testing.type import (
+    IntSequence1, IntSequence2, SingleInt, Mapping)
 from qiime2.core.testing.util import get_dummy_plugin
 
 
@@ -399,6 +400,20 @@ class TestMethod(unittest.TestCase):
         with self.assertRaisesRegex(TypeError,
                                     'not a subtype of IntSequence1'):
             method(ints1, 42, optional1=ints3)
+
+    def test_call_with_variadic_inputs(self):
+        method = self.plugin.methods['variadic_input_method']
+
+        ints = [Artifact.import_data(IntSequence1, [1, 2, 3]),
+                Artifact.import_data(IntSequence2, [4, 5, 6])]
+        int_set = {Artifact.import_data(SingleInt, 7),
+                   Artifact.import_data(SingleInt, 8)}
+        nums = {9, 10}
+        opt_nums = [11, 12, 13]
+
+        result, = method(ints, int_set, nums, opt_nums)
+
+        self.assertEqual(result.view(list), list(range(1, 14)))
 
     def test_async(self):
         concatenate_ints = self.plugin.methods['concatenate_ints']


### PR DESCRIPTION
`Set` and `List` are no longer primitive types, they are collection types. This
means they can be used on primitives (with the exception of metadata) or
semantic types. This enables variadic input artifacts in the framework.

~~**This is still under-tested. I'm going to be making changes to the CLI to make sure this works before returning to this PR**~~