### PR TITLE
ENH: remove Metadata.from_artifact in favor of Artifact.view(Metadata)

### DIFF
--- a/qiime2/core/archive/tests/test_provenance.py
+++ b/qiime2/core/archive/tests/test_provenance.py
@@ -46,8 +46,8 @@ class TestProvenanceIntegration(unittest.TestCase):
             'Mapping', {'a': 'foo', 'b': 'bar'})
         metadata_artifact_2 = qiime2.Artifact.import_data(
             'Mapping', {'c': 'baz'})
-        m = qiime2.Metadata.from_artifact(metadata_artifact_1)
-        mc = qiime2.Metadata.from_artifact(metadata_artifact_2).get_column('c')
+        m = metadata_artifact_1.view(qiime2.Metadata)
+        mc = metadata_artifact_2.view(qiime2.Metadata).get_column('c')
 
         a = qiime2.Artifact.import_data('IntSequence1', [1, 2, 3])
 
@@ -83,8 +83,8 @@ class TestProvenanceIntegration(unittest.TestCase):
             'Mapping', {'a': 'foo', 'b': 'bar'})
         md_artifact2 = qiime2.Artifact.import_data(
             'Mapping', {'c': 'baz'})
-        md1 = qiime2.Metadata.from_artifact(md_artifact1)
-        md2 = qiime2.Metadata.from_artifact(md_artifact2)
+        md1 = md_artifact1.view(qiime2.Metadata)
+        md2 = md_artifact2.view(qiime2.Metadata)
         merged_md = md1.merge(md2)
         merged_mdc = merged_md.get_column('c')
 

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -180,24 +180,6 @@ class Metadata(_MetadataBase):
         return MetadataReader(filepath).read(into=cls,
                                              column_types=column_types)
 
-    @classmethod
-    def from_artifact(cls, artifact):
-        """
-        Parameters
-        ----------
-        artifact : qiime2.Artifact
-           Loaded artifact object.
-
-        Returns
-        -------
-        Metadata
-
-        """
-        if not artifact.has_metadata():
-            raise ValueError('Artifact has no metadata.')
-
-        return artifact.view(cls)
-
     @property
     def columns(self):
         """Ordered mapping of column names to ColumnProperties.

--- a/qiime2/metadata/tests/test_metadata.py
+++ b/qiime2/metadata/tests/test_metadata.py
@@ -298,42 +298,13 @@ class TestMetadataLoad(unittest.TestCase):
         self.assertEqual(obs_md, exp_md)
 
 
-class TestMetadataFromArtifact(unittest.TestCase):
-    def setUp(self):
-        get_dummy_plugin()
-
-    def test_from_artifact(self):
-        A = Artifact.import_data('Mapping', {'a': '1', 'b': '3'})
-
-        obs_md = Metadata.from_artifact(A)
-
-        exp_df = pd.DataFrame({'a': '1', 'b': '3'},
-                              index=pd.Index(['0'], name='id', dtype=object),
-                              dtype=object)
-        exp_md = Metadata(exp_df)
-        exp_md._add_artifacts([A])
-
-        self.assertEqual(obs_md, exp_md)
-
-    def test_from_bad_artifact(self):
-        A = Artifact.import_data('IntSequence1', [1, 2, 3, 4])
-        with self.assertRaisesRegex(ValueError, 'Artifact has no metadata'):
-            Metadata.from_artifact(A)
-
-    def test_artifacts(self):
-        A = Artifact.import_data('Mapping', {'a': 'abc', 'b': '-42'})
-        md = Metadata.from_artifact(A)
-        obs = md.artifacts
-        self.assertEqual(obs, (A,))
-
-
 class TestGetColumn(unittest.TestCase):
     def setUp(self):
         get_dummy_plugin()
 
     def test_artifacts_are_propagated(self):
         A = Artifact.import_data('Mapping', {'a': '1', 'b': '3'})
-        md = Metadata.from_artifact(A)
+        md = A.view(Metadata)
 
         obs = md.get_column('b')
 
@@ -513,8 +484,8 @@ class TestMerge(unittest.TestCase):
         artifact1 = Artifact.import_data('Mapping', {'a': '1', 'b': '2'})
         artifact2 = Artifact.import_data('Mapping', {'d': '4'})
 
-        md_from_artifact1 = Metadata.from_artifact(artifact1)
-        md_from_artifact2 = Metadata.from_artifact(artifact2)
+        md_from_artifact1 = artifact1.view(Metadata)
+        md_from_artifact2 = artifact2.view(Metadata)
         md_no_artifact = Metadata(pd.DataFrame(
             {'c': ['3', '42']}, index=pd.Index(['0', '1'], name='id')))
 
@@ -700,7 +671,7 @@ class TestEqualityOperators(unittest.TestCase, ReallyEqualMixin):
         # Metadata created from an artifact vs not shouldn't compare equal,
         # even if the data is the same.
         artifact = Artifact.import_data('Mapping', {'a': '1', 'b': '2'})
-        md_from_artifact = Metadata.from_artifact(artifact)
+        md_from_artifact = artifact.view(Metadata)
 
         md_no_artifact = Metadata(md_from_artifact.to_dataframe())
 
@@ -714,8 +685,8 @@ class TestEqualityOperators(unittest.TestCase, ReallyEqualMixin):
         artifact1 = Artifact.import_data('Mapping', {'a': '1', 'b': '2'})
         artifact2 = Artifact.import_data('Mapping', {'a': '1', 'b': '2'})
 
-        md1 = Metadata.from_artifact(artifact1)
-        md2 = Metadata.from_artifact(artifact2)
+        md1 = artifact1.view(Metadata)
+        md2 = artifact2.view(Metadata)
 
         pdt.assert_frame_equal(md1.to_dataframe(), md2.to_dataframe())
         self.assertReallyNotEqual(md1, md2)
@@ -754,8 +725,8 @@ class TestEqualityOperators(unittest.TestCase, ReallyEqualMixin):
 
     def test_equality_with_artifact(self):
         artifact = Artifact.import_data('Mapping', {'a': '1', 'b': '2'})
-        md1 = Metadata.from_artifact(artifact)
-        md2 = Metadata.from_artifact(artifact)
+        md1 = artifact.view(Metadata)
+        md2 = artifact.view(Metadata)
 
         self.assertReallyEqual(md1, md2)
 

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -249,6 +249,10 @@ class Artifact(Result):
         return self._view(view_type)
 
     def _view(self, view_type, recorder=None):
+        if view_type is qiime2.Metadata and not self.has_metadata():
+            raise TypeError(
+                "Artifact %r cannot be viewed as QIIME 2 Metadata." % self)
+
         from_type = transform.ModelType.from_view_type(self.format)
         to_type = transform.ModelType.from_view_type(view_type)
 
@@ -256,7 +260,7 @@ class Artifact(Result):
                                                        recorder=recorder)
         result = transformation(self._archiver.data_dir)
 
-        if view_type is qiime2.metadata.Metadata:
+        if view_type is qiime2.Metadata:
             result._add_artifacts([self])
 
         to_type.set_user_owned(result, True)
@@ -268,7 +272,8 @@ class Artifact(Result):
         Returns
         -------
         bool
-           True if the artifact has metadata, False otherwise.
+           True if the artifact has metadata (i.e. can be viewed as
+           ``qiime2.Metadata``), False otherwise.
 
         """
         from_type = transform.ModelType.from_view_type(self.format)


### PR DESCRIPTION
Removed `Metadata.from_artifact` in favor of `Artifact.view(Metadata)`, which now tracks the source artifact (important for provenance).

Discussed with @ebolyen; there's no need to have two APIs that do the same thing, and using the view API is preferred since `Metadata` doesn't need to be special-cased.

Related to discussion in https://github.com/qiime2/q2-feature-table/issues/136 regarding `Artifact.view(Metadata)` not tracking the source artifact, which is now fixed.