### PR TITLE
ENH: `Metadata.merge`: disallow merging nothing

### DIFF
--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -318,13 +318,13 @@ class Metadata(_MetadataBase):
         The merge will include only those IDs that are shared across **all**
         ``Metadata`` objects being merged (i.e. the merge is an *inner join*).
 
-        Each metadata column being merged must be unique; merging metadata with
-        overlapping columns will result in an error.
+        Each metadata column being merged must have a unique name; merging
+        metadata with overlapping column names will result in an error.
 
         Parameters
         ----------
         others : tuple
-            Zero or more ``Metadata`` objects to merge with this ``Metadata``
+            One or more ``Metadata`` objects to merge with this ``Metadata``
             object.
 
         Returns
@@ -336,13 +336,28 @@ class Metadata(_MetadataBase):
             the column order of ``Metadata`` objects being merged from left to
             right.
 
+        Raises
+        ------
+        ValueError
+            If zero ``Metadata`` objects are provided in `others` (there is
+            nothing to merge in this case).
+
         Notes
         -----
-        The merged metadata object tracks all source artifacts that it was
+        The merged ``Metadata`` object will always have its ``id_header``
+        property set to ``'id'``, regardless of the ``id_header`` values on the
+        ``Metadata`` objects being merged.
+
+        The merged ``Metadata`` object tracks all source artifacts that it was
         built from to preserve provenance (i.e. the ``.artifacts`` property
         on all ``Metadata`` objects is merged).
 
         """
+        if len(others) < 1:
+            raise ValueError(
+                "At least one Metadata object must be provided to merge into "
+                "this Metadata object (otherwise there is nothing to merge).")
+
         dfs = []
         columns = []
         artifacts = []

--- a/qiime2/metadata/tests/test_metadata.py
+++ b/qiime2/metadata/tests/test_metadata.py
@@ -319,15 +319,14 @@ class TestMerge(unittest.TestCase):
     def setUp(self):
         get_dummy_plugin()
 
-    def test_merging_one(self):
+    def test_merging_nothing(self):
         md = Metadata(pd.DataFrame(
             {'a': [1, 2, 3], 'b': [4, 5, 6]},
             index=pd.Index(['id1', 'id2', 'id3'], name='id')))
 
-        obs = md.merge()
-
-        self.assertIsNot(obs, md)
-        self.assertEqual(obs, md)
+        with self.assertRaisesRegex(ValueError,
+                                    'At least one Metadata.*nothing to merge'):
+            md.merge()
 
     def test_merging_two(self):
         md1 = Metadata(pd.DataFrame(


### PR DESCRIPTION
Previous behavior of `Metadata.merge` allowed zero `Metadata` objects as input, which would result in a copy of the `Metadata` object being called upon (i.e. `self`).

New behavior is to raise a `ValueError` if no `Metadata` objects are provided to merge into `self` (there is nothing to merge in that case).

@thermokarst found a bug in q2cli related to this behavior: a merge was always happening even if only a single `Metadata` object was provided as input, making the `id_header` normalize to `'id'`, which is probably not what users would expect to happen.