### PR TITLE
ENH: More clear error message when running SQL

### DIFF
--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -446,7 +446,7 @@ class Metadata(_MetadataBase):
         except sqlite3.OperationalError as e:
             conn.close()
             raise ValueError("Selection of IDs failed with query:\n %s\n\n"
-                             "If one of the  metadata column names specified "
+                             "If one of the metadata column names specified "
                              "in the `where` statement is on this list "
                              "of reserved keywords "
                              "(http://www.sqlite.org/lang_keywords.html), "

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -443,10 +443,15 @@ class Metadata(_MetadataBase):
 
         try:
             c.execute(query)
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as e:
             conn.close()
-            raise ValueError("Selection of IDs failed with query:\n %s"
-                             % query)
+            raise ValueError("Selection of IDs failed with query:\n %s\n\n"
+                             "If one of the  metadata column names specified "
+                             "in the `where` statement is on this list "
+                             "of reserved keywords "
+                             "(http://www.sqlite.org/lang_keywords.html), "
+                             "please ensure it is quoted appropriately in the "
+                             "`where` statement." % query) from e
 
         ids = set(c.fetchall())
         conn.close()


### PR DESCRIPTION
Fixes #353 

---

This change doesn't do anything to prevent users from providing unquoted reserved keywords in their queries, but it provides a path forward when they do by:

1. Alerting the user to the need to quote reserved keywords, and provides them a URL to learn more about that.
2. Chains the original `sqlite3` driver exception. This is less helpful for the reserved keyword case, but is pretty cool in general, because it shows things like missing columns, or other syntax errors:

```bash
qiime feature-table filter-samples \
  --i-table table.qza \
  --m-metadata-file keywords.tsv \
  --p-where "Peanut='thedog'" \
  --o-filtered-table reserved.qza \
  --verbose
Traceback (most recent call last):
  File "/Users/matthew/src/qiime2/qiime2/qiime2/metadata/metadata.py", line 445, in get_ids
    c.execute(query)
sqlite3.OperationalError: no such column: Peanut

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/matthew/opt/miniconda3/envs/q2dev/lib/python3.5/site-packages/q2cli/commands.py", line 246, in __call__
    results = action(**arguments)
  File "<decorator-gen-248>", line 2, in filter_samples
  File "/Users/matthew/src/qiime2/qiime2/qiime2/sdk/action.py", line 228, in bound_callable
    output_types, provenance)
  File "/Users/matthew/src/qiime2/qiime2/qiime2/sdk/action.py", line 363, in _callable_executor_
    output_views = self._callable(**view_args)
  File "/Users/matthew/opt/miniconda3/envs/q2dev/lib/python3.5/site-packages/q2_feature_table/_filter.py", line 73, in filter_samples
    where=where, axis='sample', exclude_ids=exclude_ids)
  File "/Users/matthew/opt/miniconda3/envs/q2dev/lib/python3.5/site-packages/q2_feature_table/_filter.py", line 46, in _filter_table
    ids_to_keep = metadata.get_ids(where=where)
  File "/Users/matthew/src/qiime2/qiime2/qiime2/metadata/metadata.py", line 454, in get_ids
    "`where` statement." % query) from e
ValueError: Selection of IDs failed with query:
 SELECT "#SampleID" FROM metadata WHERE Peanut='thedog' GROUP BY "#SampleID" ORDER BY "#SampleID";

If one of the  metadata column names specified in the `where` statement is on this list of reserved keywords (http://www.sqlite.org/lang_keywords.html), please ensure it is quoted appropriately in the `where` statement.

Plugin error from feature-table:

  Selection of IDs failed with query:
   SELECT "#SampleID" FROM metadata WHERE Peanut='thedog' GROUP BY "#SampleID" ORDER BY "#SampleID";

  If one of the  metadata column names specified in the `where` statement is on this list of reserved keywords (http://www.sqlite.org/lang_keywords.html), please ensure it is quoted appropriately in the `where` statement.

See above for debug info.
```

Note, the tests are unmodified in this PR because we are still raising the same exception, just chaining on the originator, too.