### PR TITLE
ENH: adds notebook server-extension for viewing results

### DIFF
--- a/qiime2/__init__.py
+++ b/qiime2/__init__.py
@@ -24,3 +24,8 @@ __website__ = 'https://qiime2.org'
 
 __all__ = ['Artifact', 'Visualization', 'Metadata', 'MetadataColumn',
            'CategoricalMetadataColumn', 'NumericMetadataColumn']
+
+
+# Used by `jupyter serverextension enable`
+def _jupyter_server_extension_paths():
+    return [{"module": "qiime2.jupyter"}]

--- a/qiime2/jupyter/__init__.py
+++ b/qiime2/jupyter/__init__.py
@@ -1,0 +1,12 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from .hooks import load_jupyter_server_extension
+from .template import make_html
+
+__all__ = ['make_html', 'load_jupyter_server_extension']

--- a/qiime2/jupyter/handlers.py
+++ b/qiime2/jupyter/handlers.py
@@ -1,0 +1,65 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os
+import pathlib
+
+import tornado.web as web
+from notebook.base.handlers import IPythonHandler
+
+import qiime2.core.archive.archiver as archiver
+
+
+class _ArchiveCheck(archiver._Archive):
+    """This is only what is needed to verify a path is an archive"""
+    # TODO: make this part of the archiver API at some point
+    def open(self, relpath):
+        abspath = os.path.join(str(self.path), str(self.uuid), relpath)
+        return open(abspath, 'r')
+
+    def relative_iterdir(self, relpath='.'):
+        for p in pathlib.Path(self.path).iterdir():
+            yield str(p.relative_to(self.path))
+
+
+class QIIME2RedirectHandler(IPythonHandler):
+    """Add a location to location_store for later retrieval"""
+    def initialize(self, result_store):
+        self.result_store = result_store
+
+    def get(self):
+        location = self.get_query_argument('location')
+        if not os.path.exists(location):
+            # Client DOM should explain that the user should re-run the cell
+            self.send_error(428)  # Precondition Required
+            return
+        # is it actually a QIIME 2 result, or a random part of the filesystem
+        archive = _ArchiveCheck(pathlib.Path(location))
+        self.result_store[archive.uuid] = os.path.join(
+            location, str(archive.uuid), 'data')
+
+        self.redirect('view/%s/' % archive.uuid)
+
+
+class QIIME2ResultHandler(web.StaticFileHandler):
+    def initialize(self, path, default_filename):
+        super().initialize(path, default_filename)
+        self.result_store = path  # path is actually result_store
+
+    @classmethod
+    def get_absolute_path(cls, root, path):
+        uuid, path = path.split('/', 1)
+        root = root[uuid]
+        # This is janky, but validate_absolute_path is the only thing
+        # that will use this data, so it can know to unpack the tuple again
+        return (super().get_absolute_path(root, path), uuid)
+
+    def validate_absolute_path(self, root, abspath_uuid):
+        absolute_path, uuid = abspath_uuid
+        root = self.result_store[uuid]
+        return super().validate_absolute_path(root, absolute_path)

--- a/qiime2/jupyter/handlers.py
+++ b/qiime2/jupyter/handlers.py
@@ -36,7 +36,7 @@ class QIIME2RedirectHandler(IPythonHandler):
         location = self.get_query_argument('location')
         if not os.path.exists(location):
             # Client DOM should explain that the user should re-run the cell
-            self.send_error(428)  # Precondition Required
+            self.send_error(409)  # Conflict
             return
         # is it actually a QIIME 2 result, or a random part of the filesystem
         archive = _ArchiveCheck(pathlib.Path(location))

--- a/qiime2/jupyter/hooks.py
+++ b/qiime2/jupyter/hooks.py
@@ -1,0 +1,27 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+
+def load_jupyter_server_extension(nb_server):
+    from .handlers import QIIME2RedirectHandler, QIIME2ResultHandler
+    from notebook.utils import url_path_join
+
+    result_store = {}
+    app = nb_server.web_app
+
+    def route(path):
+        return url_path_join(app.settings['base_url'], 'qiime2', path)
+
+    app.add_handlers(r'.*', [
+        (route(r'redirect'), QIIME2RedirectHandler,
+         {'result_store': result_store}),
+        (route(r'view/(.*)'), QIIME2ResultHandler,
+         # This *is* odd, but it's because we are tricking StaticFileHandler
+         {'path': result_store,
+          'default_filename': 'index.html'})
+    ])

--- a/qiime2/jupyter/template.py
+++ b/qiime2/jupyter/template.py
@@ -1,0 +1,51 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import urllib.parse
+
+
+def make_html(location):
+    url = "/qiime2/redirect?location={location}".format(
+        location=urllib.parse.quote(location))
+    # This is dark magic. An image has an onload handler, which let's me
+    # grab the parent dom in an anonymous way without needing to scope the
+    # output cells of Jupyter with some kind of random ID.
+    # Using transparent pixel from: https://stackoverflow.com/a/14115340/579416
+    return ('<div><img onload="({anon_func})(this.parentElement, \'{url}\')"'
+            ' src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAAL'
+            'AAAAAABAAEAAAICRAEAOw==" /></div>'.format(
+                anon_func=_anonymous_function, url=url))
+
+
+# 404 - the extension isn't installed
+# 428 - the result went out of scope, re-run cell
+# 302->200 - set up the iframe for that location
+_anonymous_function = '''\
+function(div, url){
+var baseURL = require.toUrl('').split('/').slice(0, -2).join('/');
+url = baseURL + url;
+fetch(url).then(function(res) {
+    if (res.status === 404) {
+        div.innerHTML = 'Install QIIME 2 Jupyter extension with:<br />' +
+                        '<code>jupyter serverextension enable --py qiime2' +
+                        ' --sys-prefix</code><br />then restart your server.';
+    } else if (res.status === 428) {
+        div.innerHTML = 'Visualization no longer in scope. Re-run this cell' +
+                        ' to see the visualization.';
+    } else if (res.ok) {
+        url = res.url;
+        div.innerHTML = '<iframe src=\\'' + url + '\\' style=\\'' +
+                        'width: 100%; height: 700px; border: 0;\\'>' +
+                        '</iframe><hr />Open in a: <a href=\\'' + url + '\\'' +
+                        ' target=\\'_blank\\'>new window</a>'
+    } else {
+        div.innerHTML = 'Something has gone wrong. Check notebook server for' +
+                        ' errors.';
+    }
+});
+}'''

--- a/qiime2/jupyter/template.py
+++ b/qiime2/jupyter/template.py
@@ -27,7 +27,15 @@ def make_html(location):
 # 302->200 - set up the iframe for that location
 _anonymous_function = '''\
 function(div, url){
-var baseURL = require.toUrl('').split('/').slice(0, -2).join('/');
+if (typeof require !== 'undefined') {
+    var baseURL = require.toUrl('').split('/').slice(0, -2).join('/');
+} else {
+    var baseURL = JSON.parse(
+        document.getElementById('jupyter-config-data').innerHTML).baseUrl;
+}
+if (baseURL === '/') {
+    baseURL = '';
+}
 url = baseURL + url;
 fetch(url).then(function(res) {
     if (res.status === 404) {

--- a/qiime2/jupyter/template.py
+++ b/qiime2/jupyter/template.py
@@ -31,17 +31,17 @@ if (typeof require !== 'undefined') {
     var baseURL = require.toUrl('').split('/').slice(0, -2).join('/');
 } else {
     var baseURL = JSON.parse(
-        document.getElementById('jupyter-config-data').innerHTML).baseUrl;
-}
-if (baseURL === '/') {
-    baseURL = '';
+        document.getElementById('jupyter-config-data').innerHTML
+    ).baseUrl.slice(0, -1);
 }
 url = baseURL + url;
 fetch(url).then(function(res) {
     if (res.status === 404) {
         div.innerHTML = 'Install QIIME 2 Jupyter extension with:<br />' +
                         '<code>jupyter serverextension enable --py qiime2' +
-                        ' --sys-prefix</code><br />then restart your server.';
+                        ' --sys-prefix</code><br />then restart your server.' +
+                        '<br /><br />(Interactive output not available on ' +
+                        'static notebook viewer services like nbviewer.)';
     } else if (res.status === 409) {
         div.innerHTML = 'Visualization no longer in scope. Re-run this cell' +
                         ' to see the visualization.';

--- a/qiime2/jupyter/template.py
+++ b/qiime2/jupyter/template.py
@@ -34,7 +34,7 @@ fetch(url).then(function(res) {
         div.innerHTML = 'Install QIIME 2 Jupyter extension with:<br />' +
                         '<code>jupyter serverextension enable --py qiime2' +
                         ' --sys-prefix</code><br />then restart your server.';
-    } else if (res.status === 428) {
+    } else if (res.status === 409) {
         div.innerHTML = 'Visualization no longer in scope. Re-run this cell' +
                         ' to see the visualization.';
     } else if (res.ok) {

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -332,3 +332,7 @@ class Visualization(Result):
                 else:
                     result[ext] = str(relpath) if relative else str(abspath)
         return result
+
+    def _repr_html_(self):
+        from qiime2.jupyter import make_html
+        return make_html(str(self._archiver.path))


### PR DESCRIPTION
fixes #340 

This supports `base_url` config so it should work with JupyterHub. 
The `_html_repr_` is able to provides instructions:
  - when the extension isn't installed.
  - when the kernel has been restarted and the page reloaded (i.e. viz is out of scope)

I think this will be of interest to @ElDeveloper, @bassio, and @jakereps.

I've done a bunch of local testing, but this could use more!
To install, just run:
```bash
jupyter serverextension enable --py qiime2 --sys-prefix
```
  -or-
repr a QIIME 2 visualization which will produce the above instructions.