### PR TITLE
ENH: adds citations and transformers to provenance

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - pandas
     - tzlocal
     - python-dateutil
+    - bibtexparser
 
 test:
   imports:

--- a/qiime2/__init__.py
+++ b/qiime2/__init__.py
@@ -20,6 +20,7 @@ del get_versions
 # to be compatible.
 __release__ = '.'.join(__version__.split('.')[:2])
 __citations__ = tuple(Citations.load('citations.bib', package='qiime2'))
+__website__ = 'https://qiime2.org'
 
 __all__ = ['Artifact', 'Visualization', 'Metadata', 'MetadataColumn',
            'CategoricalMetadataColumn', 'NumericMetadataColumn']

--- a/qiime2/__init__.py
+++ b/qiime2/__init__.py
@@ -9,6 +9,7 @@
 from qiime2.sdk import Artifact, Visualization
 from qiime2.metadata import (Metadata, MetadataColumn,
                              CategoricalMetadataColumn, NumericMetadataColumn)
+from qiime2.plugin import Citations
 from ._version import get_versions
 
 __version__ = get_versions()['version']
@@ -18,6 +19,7 @@ del get_versions
 # and pre/post-release tags. All versions within a train release are expected
 # to be compatible.
 __release__ = '.'.join(__version__.split('.')[:2])
+__citations__ = tuple(Citations.load('citations.bib', package='qiime2'))
 
 __all__ = ['Artifact', 'Visualization', 'Metadata', 'MetadataColumn',
            'CategoricalMetadataColumn', 'NumericMetadataColumn']

--- a/qiime2/citations.bib
+++ b/qiime2/citations.bib
@@ -1,0 +1,11 @@
+@article{caporaso2010qiime,
+  title={QIIME allows analysis of high-throughput community sequencing data},
+  author={Caporaso, J Gregory and Kuczynski, Justin and Stombaugh, Jesse and Bittinger, Kyle and Bushman, Frederic D and Costello, Elizabeth K and Fierer, Noah and Pena, Antonio Gonzalez and Goodrich, Julia K and Gordon, Jeffrey I and others},
+  journal={Nature methods},
+  volume={7},
+  number={5},
+  pages={335},
+  year={2010},
+  publisher={Nature Publishing Group},
+  doi={10.1038/nmeth.f.303}
+}

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -222,7 +222,7 @@ class _ZipArchive(_Archive):
 
 
 class Archiver:
-    CURRENT_FORMAT_VERSION = '3'
+    CURRENT_FORMAT_VERSION = '4'
     CURRENT_ARCHIVE = _ZipArchive
     _FORMAT_REGISTRY = {
         # NOTE: add more archive formats as things change
@@ -230,6 +230,7 @@ class Archiver:
         '1': 'qiime2.core.archive.format.v1:ArchiveFormat',
         '2': 'qiime2.core.archive.format.v2:ArchiveFormat',
         '3': 'qiime2.core.archive.format.v3:ArchiveFormat',
+        '4': 'qiime2.core.archive.format.v4:ArchiveFormat',
     }
 
     @classmethod
@@ -336,6 +337,10 @@ class Archiver:
     @property
     def provenance_dir(self):
         return getattr(self._fmt, 'provenance_dir', None)
+
+    @property
+    def citations(self):
+        return getattr(self._fmt, 'citations', ())
 
     def save(self, filepath):
         self.CURRENT_ARCHIVE.save(self.path, filepath)

--- a/qiime2/core/archive/format/tests/test_util.py
+++ b/qiime2/core/archive/format/tests/test_util.py
@@ -52,10 +52,10 @@ class TestArtifactVersion(unittest.TestCase, ArchiveTestingMixin):
             version = zf.read(os.path.join(root_dir, 'VERSION'))
         self.assertRegex(str(version), '^.*archive: 0.*$')
 
-    def test_write_v1_archive(self):
+    def test_write_v4_archive(self):
         fp = os.path.join(self.temp_dir.name, 'artifact_v1.qza')
 
-        with artifact_version(1):
+        with artifact_version(4):
             artifact = Artifact._from_view(FourInts, [-1, 42, 0, 43], list,
                                            self.provenance_capture)
             artifact.save(fp)
@@ -70,10 +70,11 @@ class TestArtifactVersion(unittest.TestCase, ArchiveTestingMixin):
             'data/nested/file4.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml',
         }
         self.assertArchiveMembers(fp, root_dir, expected)
 
         with zipfile.ZipFile(fp, mode='r') as zf:
             version = zf.read(os.path.join(root_dir, 'VERSION'))
-        self.assertRegex(str(version), '^.*archive: 1.*$')
+        self.assertRegex(str(version), '^.*archive: 4.*$')

--- a/qiime2/core/archive/format/v4.py
+++ b/qiime2/core/archive/format/v4.py
@@ -1,0 +1,34 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import qiime2.core.archive.format.v3 as v3
+
+from qiime2.core.cite import Citations
+
+
+class ArchiveFormat(v3.ArchiveFormat):
+    # Adds a transformers section to action.yaml and adds citations via the
+    # !cite yaml type which references the /provenance/citations.bib file
+    # (this is nested like everything else in the /provenance/artifacts/
+    # directories).
+
+    @property
+    def citations(self):
+        files = []
+        files.append(str(self.provenance_dir / 'citations.bib'))
+
+        if (self.provenance_dir / 'artifacts').exists():
+            for ancestor in (self.provenance_dir / 'artifacts').iterdir():
+                if (ancestor / 'citations.bib').exists():
+                    files.append(str(ancestor / 'citations.bib'))
+
+        citations = Citations()
+        for f in files:
+            citations.update(Citations.load(f))
+
+        return citations

--- a/qiime2/core/archive/format/v4.py
+++ b/qiime2/core/archive/format/v4.py
@@ -12,10 +12,14 @@ from qiime2.core.cite import Citations
 
 
 class ArchiveFormat(v3.ArchiveFormat):
-    # Adds a transformers section to action.yaml and adds citations via the
-    # !cite yaml type which references the /provenance/citations.bib file
-    # (this is nested like everything else in the /provenance/artifacts/
-    # directories).
+    # - Adds a transformers section to action.yaml
+    # - Adds citations via the !cite yaml type which references the
+    #   /provenance/citations.bib file (this is nested like everything else
+    #                                   in the /provenance/artifacts/
+    #                                   directories).
+    # - environment:framework has been updated to be a nested object,
+    #   its schema is identical to a environment:plugins:<entry> object.
+    #   Prior to v4, it was only a version string.
 
     @property
     def citations(self):

--- a/qiime2/core/archive/tests/test_archiver.py
+++ b/qiime2/core/archive/tests/test_archiver.py
@@ -90,6 +90,7 @@ class TestArchiver(unittest.TestCase, ArchiveTestingMixin):
             'data/ints.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -107,6 +108,7 @@ class TestArchiver(unittest.TestCase, ArchiveTestingMixin):
             'data/ints.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -150,6 +152,7 @@ class TestArchiver(unittest.TestCase, ArchiveTestingMixin):
                 '%s/data/ints.txt' % root_dir,
                 '%s/provenance/metadata.yaml' % root_dir,
                 '%s/provenance/VERSION' % root_dir,
+                '%s/provenance/citations.bib' % root_dir,
                 '%s/provenance/action/action.yaml' % root_dir
             }
 
@@ -196,6 +199,7 @@ class TestArchiver(unittest.TestCase, ArchiveTestingMixin):
             'data/nested/foo.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -218,6 +222,7 @@ class TestArchiver(unittest.TestCase, ArchiveTestingMixin):
             'data/nested/foo.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -279,6 +284,7 @@ class TestArchiver(unittest.TestCase, ArchiveTestingMixin):
                 '%s/data/ints.txt' % root_dir,
                 '%s/provenance/metadata.yaml' % root_dir,
                 '%s/provenance/VERSION' % root_dir,
+                '%s/provenance/citations.bib' % root_dir,
                 '%s/provenance/action/action.yaml' % root_dir,
                 '%s/VERSION' % second_root_dir
             }

--- a/qiime2/core/archive/tests/test_citations.py
+++ b/qiime2/core/archive/tests/test_citations.py
@@ -1,0 +1,90 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+import qiime2
+from qiime2.core.testing.type import IntSequence1
+from qiime2.core.testing.util import get_dummy_plugin
+
+
+class TestCitationsTracked(unittest.TestCase):
+    def setUp(self):
+        self.plugin = get_dummy_plugin()
+
+    def test_import(self):
+        data = qiime2.Artifact.import_data(IntSequence1, [1, 2, 3, 4])
+        archiver = data._archiver
+
+        expected = [
+            ('framework|qiime2:%s|0' % qiime2.__version__,
+             'QIIME allows analysis of high-throughput community sequencing'
+             ' data'),
+            ('plugin|dummy-plugin:0.0.0-dev|0',
+             'Does knuckle cracking lead to arthritis of the fingers?'),
+            ('plugin|dummy-plugin:0.0.0-dev|1',
+             'Of flying frogs and levitrons'),
+            ('transformer|dummy-plugin:0.0.0-dev|'
+             'builtins:list->IntSequenceDirectoryFormat|0',
+             'An in-depth analysis of a piece of shit: distribution of'
+             ' Schistosoma mansoni and hookworm eggs in human stool'),
+            ('view|dummy-plugin:0.0.0-dev|IntSequenceDirectoryFormat|0',
+             'Walking with coffee: Why does it spill?')]
+
+        obs = list(map(lambda item: (item[0], item[1].fields['title']),
+                       archiver.citations.items()))
+
+        self.assertEqual(obs, expected)
+
+        with (archiver.provenance_dir / 'action' / 'action.yaml').open() as fh:
+            action_yaml = fh.read()
+
+        for key, _ in expected:
+            self.assertIn('!cite %r' % key, action_yaml)
+
+    def test_action(self):
+        data = qiime2.Artifact.import_data(IntSequence1, [1, 2, 3, 4])
+        action = self.plugin.methods['split_ints']
+
+        left, right = action(data)
+        archiver = left._archiver
+
+        expected = [
+            ('framework|qiime2:%s|0' % qiime2.__version__,
+             'QIIME allows analysis of high-throughput community sequencing'
+             ' data'),
+            ('action|dummy-plugin:0.0.0-dev|method:split_ints|0',
+             'Sword swallowing and its side effects'),
+            ('action|dummy-plugin:0.0.0-dev|method:split_ints|1',
+             'Response behaviors of Svalbard reindeer towards humans and'
+             ' humans disguised as polar bears on Edge\u00f8ya'),
+            ('plugin|dummy-plugin:0.0.0-dev|0',
+             'Does knuckle cracking lead to arthritis of the fingers?'),
+            ('plugin|dummy-plugin:0.0.0-dev|1',
+             'Of flying frogs and levitrons'),
+            ('view|dummy-plugin:0.0.0-dev|IntSequenceDirectoryFormat|0',
+             'Walking with coffee: Why does it spill?'),
+            ('transformer|dummy-plugin:0.0.0-dev|'
+             'builtins:list->IntSequenceDirectoryFormat|0',
+             'An in-depth analysis of a piece of shit: distribution of'
+             ' Schistosoma mansoni and hookworm eggs in human stool')]
+
+        obs = list(map(lambda item: (item[0], item[1].fields['title']),
+                       archiver.citations.items()))
+
+        self.assertEqual(obs, expected)
+
+        with (archiver.provenance_dir / 'action' / 'action.yaml').open() as fh:
+            action_yaml = fh.read()
+
+        for key, _ in expected:
+            self.assertIn('!cite %r' % key, action_yaml)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qiime2/core/cite.py
+++ b/qiime2/core/cite.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 import os
 import pkg_resources
 import collections
@@ -25,7 +33,8 @@ class Citations(collections.OrderedDict):
             except Exception as e:
                 raise ValueError("There was a problem loading the BiBTex file:"
                                  "%r" % path) from e
-        entries = {}
+
+        entries = collections.OrderedDict()
         for entry in db.entries:
             id_ = entry.pop('ID')
             type_ = entry.pop('ENTRYTYPE')
@@ -36,19 +45,8 @@ class Citations(collections.OrderedDict):
 
         return cls(entries)
 
-    @classmethod
-    def unformatted_citation(cls, text):
-        return CitationRecord('misc', {'note': text})
-
-    @classmethod
-    def website_citation(cls, url):
-        return CitationRecord('misc', {
-            'note': 'No citation available. Cite plugin website.',
-            'url': url
-        })
-
     def __iter__(self):
-        yield from self.values()
+        return iter(self.values())
 
     def save(self, filepath):
         entries = []

--- a/qiime2/core/format.py
+++ b/qiime2/core/format.py
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import qiime2.core.path as qpath
+
+
+class FormatBase:
+    def __init__(self, path=None, mode='w'):
+        import qiime2.plugin.model as model
+        if path is None:
+            if mode != 'w':
+                raise ValueError("A path must be provided when reading.")
+        else:
+            if mode != 'r':
+                raise ValueError("A path must be omitted when writing.")
+
+        if mode == 'w':
+            self.path = qpath.OutPath(
+                # TODO: parents shouldn't know about their children
+                dir=isinstance(self, model.DirectoryFormat),
+                prefix='q2-%s-' % self.__class__.__name__)
+        else:
+            self.path = qpath.InPath(path)
+
+        self._mode = mode
+
+    def __str__(self):
+        return str(self.path)

--- a/qiime2/core/testing/citations.bib
+++ b/qiime2/core/testing/citations.bib
@@ -1,0 +1,98 @@
+@article{unger1998does,
+  title={Does knuckle cracking lead to arthritis of the fingers?},
+  author={Unger, Donald L},
+  journal={Arthritis \& Rheumatology},
+  volume={41},
+  number={5},
+  pages={949--950},
+  year={1998},
+  publisher={Wiley Online Library}
+}
+
+@article{berry1997flying,
+  title={Of flying frogs and levitrons},
+  author={Berry, Michael Victor and Geim, Andre Konstantin},
+  journal={European Journal of Physics},
+  volume={18},
+  number={4},
+  pages={307},
+  year={1997},
+  publisher={IOP Publishing}
+}
+
+@article{mayer2012walking,
+  title={Walking with coffee: Why does it spill?},
+  author={Mayer, Hans C and Krechetnikov, Rouslan},
+  journal={Physical Review E},
+  volume={85},
+  number={4},
+  pages={046117},
+  year={2012},
+  publisher={APS}
+}
+
+@article{baerheim1994effect,
+  title={Effect of ale, garlic, and soured cream on the appetite of leeches},
+  author={Baerheim, Anders and Sandvik, Hogne},
+  journal={BMJ},
+  volume={309},
+  number={6970},
+  pages={1689},
+  year={1994},
+  publisher={British Medical Journal Publishing Group}
+}
+
+@article{witcombe2006sword,
+  title={Sword swallowing and its side effects},
+  author={Witcombe, Brian and Meyer, Dan},
+  journal={BMJ},
+  volume={333},
+  number={7582},
+  pages={1285--1287},
+  year={2006},
+  publisher={British Medical Journal Publishing Group}
+}
+
+@article{reimers2012response,
+  title={Response behaviors of Svalbard reindeer towards humans and humans disguised as polar bears on Edge{\o}ya},
+  author={Reimers, Eigil and Eftest{\o}l, Sindre},
+  journal={Arctic, antarctic, and alpine research},
+  volume={44},
+  number={4},
+  pages={483--489},
+  year={2012},
+  publisher={BioOne}
+}
+
+@article{barbeito1967microbiological,
+  title={Microbiological laboratory hazard of bearded men},
+  author={Barbeito, Manuel S and Mathews, Charles T and Taylor, Larry A},
+  journal={Applied microbiology},
+  volume={15},
+  number={4},
+  pages={899--906},
+  year={1967},
+  publisher={Am Soc Microbiol}
+}
+
+@article{krauth2012depth,
+  title={An in-depth analysis of a piece of shit: distribution of Schistosoma mansoni and hookworm eggs in human stool},
+  author={Krauth, Stefanie J and Coulibaly, Jean T and Knopp, Stefanie and Traor{\'e}, Mahamadou and N'Goran, Eli{\'e}zer K and Utzinger, J{\"u}rg},
+  journal={PLoS neglected tropical diseases},
+  volume={6},
+  number={12},
+  pages={e1969},
+  year={2012},
+  publisher={Public Library of Science}
+}
+
+@article{silvers1997effects,
+  title={The effects of pre-existing inappropriate highlighting on reading comprehension},
+  author={Silvers, Vicki L and Kreiner, David S},
+  journal={Literacy Research and Instruction},
+  volume={36},
+  number={3},
+  pages={217--223},
+  year={1997},
+  publisher={Taylor \& Francis}
+}

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -8,6 +8,7 @@
 
 from importlib import import_module
 
+import qiime2
 from qiime2.plugin import (Plugin, Bool, Int, Str, Choices, Range, List, Set,
                            Visualization, Metadata, MetadataColumn,
                            Categorical, Numeric)
@@ -51,8 +52,8 @@ dummy_plugin = Plugin(
     version='0.0.0-dev',
     website='https://github.com/qiime2/qiime2',
     package='qiime2.core.testing',
-    citation_text='No relevant citation.',
-    user_support_text='For help, see https://qiime2.org'
+    user_support_text='For help, see https://qiime2.org',
+    citations=qiime2.__citations__
 )
 
 import_module('qiime2.core.testing.transformer')

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -8,7 +8,6 @@
 
 from importlib import import_module
 
-import qiime2
 from qiime2.plugin import (Plugin, Bool, Int, Str, Choices, Range, List, Set,
                            Visualization, Metadata, MetadataColumn,
                            Categorical, Numeric)
@@ -44,7 +43,9 @@ from .pipeline import (parameter_only_pipeline, typical_pipeline,
                        optional_artifact_pipeline, visualizer_only_pipeline,
                        pipelines_in_pipeline, pointless_pipeline,
                        failing_pipeline)
+from ..cite import Citations
 
+citations = Citations.load('citations.bib', package='qiime2.core.testing')
 dummy_plugin = Plugin(
     name='dummy-plugin',
     description='Description of dummy plugin.',
@@ -53,7 +54,7 @@ dummy_plugin = Plugin(
     website='https://github.com/qiime2/qiime2',
     package='qiime2.core.testing',
     user_support_text='For help, see https://qiime2.org',
-    citations=qiime2.__citations__
+    citations=[citations['unger1998does'], citations['berry1997flying']]
 )
 
 import_module('qiime2.core.testing.transformer')
@@ -64,11 +65,17 @@ dummy_plugin.register_semantic_types(IntSequence1, IntSequence2, Mapping,
 
 # Register formats
 dummy_plugin.register_formats(
-    IntSequenceFormat, IntSequenceFormatV2, MappingFormat, SingleIntFormat,
-    IntSequenceDirectoryFormat, IntSequenceV2DirectoryFormat,
-    MappingDirectoryFormat, FourIntsDirectoryFormat, UnimportableFormat,
-    UnimportableDirectoryFormat, RedundantSingleIntDirectoryFormat
-)
+    IntSequenceFormatV2, MappingFormat, IntSequenceV2DirectoryFormat,
+    MappingDirectoryFormat)
+
+dummy_plugin.register_formats(
+    FourIntsDirectoryFormat, UnimportableDirectoryFormat, UnimportableFormat,
+    citations=[citations['baerheim1994effect']])
+
+dummy_plugin.register_views(
+    int, IntSequenceFormat, IntSequenceDirectoryFormat,
+    SingleIntFormat, RedundantSingleIntDirectoryFormat,
+    citations=[citations['mayer2012walking']])
 
 dummy_plugin.register_semantic_type_to_format(
     IntSequence1,
@@ -112,7 +119,8 @@ dummy_plugin.methods.register_function(
     ],
     name='Concatenate integers',
     description='This method concatenates integers into a single sequence in '
-                'the order they are provided.'
+                'the order they are provided.',
+    citations=[citations['baerheim1994effect']]
 )
 
 # TODO update to use TypeMap so IntSequence1 | IntSequence2 are accepted, and
@@ -131,7 +139,9 @@ dummy_plugin.methods.register_function(
     description='This method splits a sequence of integers in half, returning '
                 'the two halves (left and right). If the input sequence\'s '
                 'length is not evenly divisible by 2, the right half will '
-                'have one more element than the left.'
+                'have one more element than the left.',
+    citations=[
+        citations['witcombe2006sword'], citations['reimers2012response']]
 )
 
 dummy_plugin.methods.register_function(
@@ -386,7 +396,8 @@ dummy_plugin.visualizers.register_function(
     description='This visualizer produces HTML and TSV outputs containing the '
                 'input sequence of integers ordered from most- to '
                 'least-frequently occurring, along with their respective '
-                'frequencies.'
+                'frequencies.',
+    citations=[citations['barbeito1967microbiological']]
 )
 
 # TODO add optional parameters to this method when they are supported
@@ -427,7 +438,7 @@ dummy_plugin.pipelines.register_function(
     output_descriptions={
         'foo': 'Foo - "The Integers of 2"',
         'bar': 'Bar - "What a sequences"'
-    }
+    },
 )
 
 dummy_plugin.pipelines.register_function(
@@ -463,7 +474,8 @@ dummy_plugin.pipelines.register_function(
         'right_viz': '`right` visualized'
     },
     name='A typical pipeline with the potential to raise an error',
-    description='Waste some time shuffling data around for no reason'
+    description='Waste some time shuffling data around for no reason',
+    citations=citations  # ALL of them.
 )
 
 dummy_plugin.pipelines.register_function(

--- a/qiime2/core/testing/transformer.py
+++ b/qiime2/core/testing/transformer.py
@@ -19,7 +19,7 @@ from .format import (
     UnimportableFormat,
     RedundantSingleIntDirectoryFormat
 )
-from .plugin import dummy_plugin
+from .plugin import dummy_plugin, citations
 
 
 @dummy_plugin.register_transformer
@@ -36,7 +36,7 @@ def _5(ff: SingleIntFormat) -> int:
         return int(fh.read())
 
 
-@dummy_plugin.register_transformer
+@dummy_plugin.register_transformer(citations=[citations['krauth2012depth']])
 def _7(data: list) -> IntSequenceFormat:
     ff = IntSequenceFormat()
     with ff.open() as fh:
@@ -45,7 +45,7 @@ def _7(data: list) -> IntSequenceFormat:
     return ff
 
 
-@dummy_plugin.register_transformer
+@dummy_plugin.register_transformer(citations=citations)
 def _77(data: list) -> IntSequenceFormatV2:
     ff = IntSequenceFormatV2()
     with ff.open() as fh:
@@ -122,7 +122,7 @@ def _12(data: dict) -> MappingFormat:
     return ff
 
 
-@dummy_plugin.register_transformer
+@dummy_plugin.register_transformer(citations=[citations['silvers1997effects']])
 def _13(df: MappingDirectoryFormat) -> dict:
     # If this had been a `SingleFileDirectoryFormat` then this entire
     # transformer would have been redundant (the framework could infer it).

--- a/qiime2/core/util.py
+++ b/qiime2/core/util.py
@@ -16,6 +16,18 @@ import collections
 import decorator
 
 
+def get_view_name(view):
+    from .format import FormatBase
+    if not isinstance(view, type):
+        view = view.__class__
+
+    if issubclass(view, FormatBase):
+        # Not qualname because we don't have a notion of "nested" formats
+        return view.__name__
+
+    return ':'.join([view.__module__, view.__qualname__])
+
+
 def tuplize(x):
     if type(x) is not tuple:
         return (x,)

--- a/qiime2/plugin/__init__.py
+++ b/qiime2/plugin/__init__.py
@@ -9,6 +9,7 @@
 from .model import (TextFileFormat, BinaryFileFormat, DirectoryFormat,
                     ValidationError)
 from .plugin import Plugin
+from .cite import Citations, CitationRecord
 
 from qiime2.core.type import (SemanticType, Int, Str, Float, Color, Metadata,
                               MetadataColumn, Categorical, Numeric, Properties,
@@ -19,4 +20,4 @@ __all__ = ['TextFileFormat', 'BinaryFileFormat', 'DirectoryFormat', 'Plugin',
            'SemanticType', 'Set', 'List', 'Bool', 'Int', 'Str', 'Float',
            'Color', 'Metadata', 'MetadataColumn', 'Categorical', 'Numeric',
            'Properties', 'Range', 'Choices', 'Visualization',
-           'ValidationError']
+           'ValidationError', 'Citations', 'CitationRecord']

--- a/qiime2/plugin/__init__.py
+++ b/qiime2/plugin/__init__.py
@@ -9,8 +9,7 @@
 from .model import (TextFileFormat, BinaryFileFormat, DirectoryFormat,
                     ValidationError)
 from .plugin import Plugin
-from .cite import Citations, CitationRecord
-
+from qiime2.core.cite import Citations, CitationRecord
 from qiime2.core.type import (SemanticType, Int, Str, Float, Color, Metadata,
                               MetadataColumn, Categorical, Numeric, Properties,
                               Range, Choices, Bool, Set, List, Visualization)

--- a/qiime2/plugin/cite.py
+++ b/qiime2/plugin/cite.py
@@ -12,7 +12,7 @@ class Citations(dict):
     @classmethod
     def load(cls, path, package=None):
         if package is not None:
-            root = pkg_resources.resource_filename(package, '..')
+            root = pkg_resources.resource_filename(package, '.')
             root = os.path.abspath(root)
             path = os.path.join(root, path)
 

--- a/qiime2/plugin/cite.py
+++ b/qiime2/plugin/cite.py
@@ -1,0 +1,48 @@
+import os
+import pkg_resources
+import collections
+
+import bibtexparser as bp
+
+
+CitationRecord = collections.namedtuple('CitationRecord', ['type', 'fields'])
+
+
+class Citations(dict):
+    @classmethod
+    def load(cls, path, package=None):
+        if package is not None:
+            root = pkg_resources.resource_filename(package, '..')
+            root = os.path.abspath(root)
+            path = os.path.join(root, path)
+
+        with open(path) as fh:
+            try:
+                db = bp.load(fh)
+            except Exception as e:
+                raise ValueError("There was a problem loading the BiBTex file:"
+                                 "%r" % path) from e
+        entries = {}
+        for entry in db.entries:
+            id_ = entry.pop('ID')
+            type_ = entry.pop('ENTRYTYPE')
+            if id_ in entries:
+                raise ValueError("Duplicate entry-key found in BibTex file: %r"
+                                 % id_)
+            entries[id_] = CitationRecord(type_, entry)
+
+        return cls(entries)
+
+    @classmethod
+    def unformatted_citation(cls, text):
+        return CitationRecord('misc', {'note': text})
+
+    @classmethod
+    def website_citation(cls, url):
+        return CitationRecord('misc', {
+            'note': 'No citation available. Cite plugin website.',
+            'url': url
+        })
+
+    def __iter__(self):
+        yield from self.values()

--- a/qiime2/plugin/model/base.py
+++ b/qiime2/plugin/model/base.py
@@ -6,31 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime2.core.path as qpath
+from qiime2.core.format import FormatBase
 
 
-class FormatBase:
-    def __init__(self, path=None, mode='w'):
-        import qiime2.plugin.model as model
-        if path is None:
-            if mode != 'w':
-                raise ValueError("A path must be provided when reading.")
-        else:
-            if mode != 'r':
-                raise ValueError("A path must be omitted when writing.")
-
-        if mode == 'w':
-            self.path = qpath.OutPath(
-                # TODO: parents shouldn't know about their children
-                dir=isinstance(self, model.DirectoryFormat),
-                prefix='q2-%s-' % self.__class__.__name__)
-        else:
-            self.path = qpath.InPath(path)
-
-        self._mode = mode
-
-    def __str__(self):
-        return str(self.path)
+__all__ = ['FormatBase', 'ValidationError', '_check_validation_level']
 
 
 class ValidationError(Exception):

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -31,24 +31,12 @@ TypeFormatRecord = collections.namedtuple(
 
 class Plugin:
     def __init__(self, name, version, website, package,
-                 citation_text=None, user_support_text=None,
-                 short_description=None, description=None, citations=None):
+                 user_support_text=None, short_description=None,
+                 description=None, citations=None):
         self.name = name
         self.version = version
         self.website = website
         self.package = package
-        if citations is None:
-            if citation_text:
-                # Use legacy citation system
-                self.citations = [
-                    Citations.unformatted_citation(citation_text)]
-            else:
-                self.citations = [Citations.website_citation(self.website)]
-        elif citation_text is not None:
-            raise ValueError("citation_text should not be used if citations"
-                             " are available.")
-        else:
-            self.citations = list(citations)
 
         if user_support_text is None:
             self.user_support_text = ('Please post to the QIIME 2 forum for '
@@ -68,6 +56,11 @@ class Plugin:
                                 % self.website)
         else:
             self.description = description
+
+        if citations is None:
+            self.citations = []
+        else:
+            self.citations = tuple(citations)
 
         self.methods = PluginMethods(self)
         self.visualizers = PluginVisualizers(self)
@@ -102,7 +95,7 @@ class Plugin:
         if citations is None:
             citations = []
         else:
-            citations = list(citations)
+            citations = tuple(citations)
 
         for view in views:
             if not isinstance(view, type):
@@ -143,7 +136,7 @@ class Plugin:
         if citations is None:
             citations = []
         else:
-            citations = list(citations)
+            citations = tuple(citations)
 
         def decorator(transformer):
             annotations = transformer.__annotations__.copy()
@@ -235,7 +228,7 @@ class PluginMethods(PluginActions):
         if citations is None:
             citations = []
         else:
-            citations = list(citations)
+            citations = tuple(citations)
 
         method = qiime2.sdk.Method._init(function, inputs, parameters, outputs,
                                          self._package, name, description,
@@ -254,7 +247,7 @@ class PluginVisualizers(PluginActions):
         if citations is None:
             citations = []
         else:
-            citations = list(citations)
+            citations = tuple(citations)
 
         visualizer = qiime2.sdk.Visualizer._init(function, inputs, parameters,
                                                  self._package, name,
@@ -275,7 +268,7 @@ class PluginPipelines(PluginActions):
         if citations is None:
             citations = []
         else:
-            citations = list(citations)
+            citations = tuple(citations)
 
         pipeline = qiime2.sdk.Pipeline._init(function, inputs, parameters,
                                              outputs, self._package, name,

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -13,7 +13,6 @@ import qiime2.sdk
 import qiime2.core.type.grammar as grammar
 from qiime2.plugin.model import DirectoryFormat
 from qiime2.plugin.model.base import FormatBase
-from qiime2.plugin.cite import Citations
 from qiime2.core.type import is_semantic_type
 from qiime2.core.util import get_view_name
 
@@ -30,7 +29,7 @@ TypeFormatRecord = collections.namedtuple(
 
 
 class Plugin:
-    def __init__(self, name, version, website, package,
+    def __init__(self, name, version, website, package, citation_text=None,
                  user_support_text=None, short_description=None,
                  description=None, citations=None):
         self.name = name
@@ -58,7 +57,7 @@ class Plugin:
             self.description = description
 
         if citations is None:
-            self.citations = []
+            self.citations = ()
         else:
             self.citations = tuple(citations)
 
@@ -93,7 +92,7 @@ class Plugin:
 
     def register_views(self, *views, citations=None):
         if citations is None:
-            citations = []
+            citations = ()
         else:
             citations = tuple(citations)
 
@@ -134,7 +133,7 @@ class Plugin:
         #   ...
         # ```
         if citations is None:
-            citations = []
+            citations = ()
         else:
             citations = tuple(citations)
 
@@ -226,7 +225,7 @@ class PluginMethods(PluginActions):
                           parameter_descriptions=None,
                           output_descriptions=None, citations=None):
         if citations is None:
-            citations = []
+            citations = ()
         else:
             citations = tuple(citations)
 
@@ -245,7 +244,7 @@ class PluginVisualizers(PluginActions):
                           description, input_descriptions=None,
                           parameter_descriptions=None, citations=None):
         if citations is None:
-            citations = []
+            citations = ()
         else:
             citations = tuple(citations)
 
@@ -266,7 +265,7 @@ class PluginPipelines(PluginActions):
                           parameter_descriptions=None,
                           output_descriptions=None, citations=None):
         if citations is None:
-            citations = []
+            citations = ()
         else:
             citations = tuple(citations)
 

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -32,8 +32,8 @@ class TestPlugin(unittest.TestCase):
     def test_package(self):
         self.assertEqual(self.plugin.package, 'qiime2.core.testing')
 
-    def test_citation_text(self):
-        self.assertEqual(self.plugin.citation_text, 'No relevant citation.')
+    def test_citations(self):
+        self.assertEqual(self.plugin.citations[0].type, 'article')
 
     def test_user_support_text(self):
         self.assertEqual(self.plugin.user_support_text,
@@ -47,15 +47,13 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(self.plugin.description,
                          'Description of dummy plugin.')
 
-    def test_citation_text_default(self):
+    def test_citations_default(self):
         plugin = qiime2.plugin.Plugin(
             name='local-dummy-plugin',
             version='0.0.0-dev',
             website='https://github.com/qiime2/qiime2',
             package='qiime2.core.testing')
-        self.assertTrue(plugin.citation_text.startswith('No citation'))
-        self.assertTrue(plugin.citation_text.endswith(
-                            plugin.website))
+        self.assertEqual(plugin.citations, ())
 
     def test_user_support_text_default(self):
         plugin = qiime2.plugin.Plugin(

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -130,9 +130,8 @@ class Action(metaclass=abc.ABCMeta):
                 self._callable.__name__)
         return markdown_source_template % {'source': source}
 
-    def get_import_path(self, repr=True):
-        d = '.' if repr else ':'
-        return ''.join([self.package, d, self.id])
+    def get_import_path(self):
+        return self.package + '.' + self.id
 
     def __repr__(self):
         return "<%s %s>" % (self.type, self.get_import_path())

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -50,6 +50,7 @@ class PluginManager:
         self.semantic_types = {}
         self.transformers = collections.defaultdict(dict)
         self.formats = {}
+        self.views = {}
         self.type_formats = []
 
         # These are all dependent loops, each requires the loop above it to
@@ -78,14 +79,16 @@ class PluginManager:
                                  % transformer_record)
             self.transformers[input][output] = transformer_record
 
-        for name, record in plugin.formats.items():
-            if name in self.formats:
+        for name, record in plugin.views.items():
+            if name in self.views:
                 raise NameError(
-                    "Duplicate format registration (%r) defined in plugins: %r"
+                    "Duplicate view registration (%r) defined in plugins: %r"
                     " and %r" %
                     (name, record.plugin.name, self.formats[name].plugin.name)
                 )
+            self.views[name] = record
 
+        for name, record in plugin.formats.items():
             # TODO: remove this when `sniff` is removed
             fmt = record.format
             if hasattr(fmt, 'sniff') and hasattr(fmt, '_validate_'):

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -94,6 +94,10 @@ class Result:
     def format(self):
         return self._archiver.format
 
+    @property
+    def citations(self):
+        return self._archiver.citations
+
     def __init__(self):
         raise NotImplementedError(
             "%(classname)s constructor is private, use `%(classname)s.load`, "

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -233,7 +233,7 @@ class Artifact(Result):
         from_type = transform.ModelType.from_view_type(view_type)
         to_type = transform.ModelType.from_view_type(output_dir_fmt)
 
-        recorder = provenance_capture.transformation_recorder('result')
+        recorder = provenance_capture.transformation_recorder('return')
         transformation = from_type.make_transformation(to_type,
                                                        recorder=recorder)
         result = transformation(view)

--- a/qiime2/sdk/tests/test_artifact.py
+++ b/qiime2/sdk/tests/test_artifact.py
@@ -104,6 +104,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
             'data/nested/file4.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -164,6 +165,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
             'data/nested/file4.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -179,6 +181,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
             'data/nested/file4.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -251,6 +254,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
             'data/nested/file4.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -96,6 +96,7 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
             'data/nested/file4.txt',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -119,6 +120,7 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
             'data/css/style.css',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 

--- a/qiime2/sdk/tests/test_visualization.py
+++ b/qiime2/sdk/tests/test_visualization.py
@@ -83,6 +83,7 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
             'data/css/style.css',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -120,6 +121,7 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
             'data/css/style.css',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -133,6 +135,7 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
             'data/css/style.css',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -207,6 +210,7 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
             'data/css/style.css',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -245,12 +245,15 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
             'data/css/style.css',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml',
             'provenance/artifacts/%s/metadata.yaml' % artifact1.uuid,
             'provenance/artifacts/%s/VERSION' % artifact1.uuid,
+            'provenance/artifacts/%s/citations.bib' % artifact1.uuid,
             'provenance/artifacts/%s/action/action.yaml' % artifact1.uuid,
             'provenance/artifacts/%s/metadata.yaml' % artifact2.uuid,
             'provenance/artifacts/%s/VERSION' % artifact2.uuid,
+            'provenance/artifacts/%s/citations.bib' % artifact2.uuid,
             'provenance/artifacts/%s/action/action.yaml' % artifact2.uuid
         }
 
@@ -290,9 +293,11 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
             'data/index.tsv',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml',
             'provenance/artifacts/%s/metadata.yaml' % artifact.uuid,
             'provenance/artifacts/%s/VERSION' % artifact.uuid,
+            'provenance/artifacts/%s/citations.bib' % artifact.uuid,
             'provenance/artifacts/%s/action/action.yaml' % artifact.uuid
         }
 
@@ -318,6 +323,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
             'data/index.html',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -342,6 +348,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
             'data/index.html',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml'
         }
 
@@ -385,12 +392,15 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
             'data/css/style.css',
             'provenance/metadata.yaml',
             'provenance/VERSION',
+            'provenance/citations.bib',
             'provenance/action/action.yaml',
             'provenance/artifacts/%s/metadata.yaml' % artifact1.uuid,
             'provenance/artifacts/%s/VERSION' % artifact1.uuid,
+            'provenance/artifacts/%s/citations.bib' % artifact1.uuid,
             'provenance/artifacts/%s/action/action.yaml' % artifact1.uuid,
             'provenance/artifacts/%s/metadata.yaml' % artifact2.uuid,
             'provenance/artifacts/%s/VERSION' % artifact2.uuid,
+            'provenance/artifacts/%s/citations.bib' % artifact2.uuid,
             'provenance/artifacts/%s/action/action.yaml' % artifact2.uuid
         }
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         ]
     },
     package_data={
-        'qiime2.metadata.tests': ['data/*/*']
+        'qiime2.metadata.tests': ['data/*/*'],
+        'qiime2': ['citations.bib']
     },
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     },
     package_data={
         'qiime2.metadata.tests': ['data/*/*'],
+        'qiime2.core.testing': ['citations.bib'],
         'qiime2': ['citations.bib']
     },
     zip_safe=False,


### PR DESCRIPTION
fixes #344 
fixes #354 
fixes #113 

Transformers are added for methods (input and output), visualizers (input only), and import (output only). Pipelines do not have transformers by nature, and so do not create that section in action.yaml.

Citations are bibtex files with a YAML type `!cite '<citation key>'`. There is a new object in `qiime2.plugin` called `Citations` which is just a dictionary, but it has a `.load()` method which will load a `citations.bib` file from somewhere. See this PR for example: https://github.com/qiime2/q2-emperor/pull/59

TODO:

- [x] fix now broken unit-tests
- [x] write tests

Questions:

 - `plugin.citation_text` is expected by a bunch of things. It would be best to just remove it entirely and use the new `citations`, this will break a bunch of things. 
 - I don't have a way to format the bibtex, does that matter at this stage? What would q2cli for example use?
- `citation_text` at registration is currently converted to `@misc{ note={...} }` which isn't awesome. Worse, special characters like `&` aren't converted to `\&` when written. I think ideally we would switch everything to use bibtex directly, so it's not really a longterm issue, but can we drop `citation_text` completely for registration?