### PR TITLE
add sdk.util.artifact_actions

### DIFF
--- a/qiime2/sdk/tests/test_util.py
+++ b/qiime2/sdk/tests/test_util.py
@@ -17,9 +17,6 @@ class TestUtil(unittest.TestCase):
         obs = qiime2.sdk.util.artifact_actions(None)
         self.assertEqual(obs, [])
 
-        obs = qiime2.sdk.util.artifact_actions('ShouldBeEmpty')
-        self.assertEqual(obs, [])
-
         # For simplicity, we are gonna test the names of the plugin and
         # the actions
         obs = [(x.name, [yy.name for yy in y])
@@ -27,6 +24,14 @@ class TestUtil(unittest.TestCase):
         exp = [('dummy-plugin', [
             'Do stuff normally, but override this one step sometimes'])]
         self.assertEqual(obs, exp)
+
+        obs = [(x.name, [yy.name for yy in y])
+               for x, y in qiime2.sdk.util.artifact_actions('Kennel[Cat]')]
+        self.assertEqual(obs, [])
+
+        with self.assertRaises(qiime2.sdk.util.UnknownTypeError):
+            qiime2.sdk.util.artifact_actions('ShouldBeEmpty')
+
 
 
 if __name__ == '__main__':

--- a/qiime2/sdk/tests/test_util.py
+++ b/qiime2/sdk/tests/test_util.py
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+import qiime2
+import qiime2.sdk
+
+
+class TestUtil(unittest.TestCase):
+    def test_artifact_actions(self):
+        obs = qiime2.sdk.util.artifact_actions(None)
+        self.assertEqual(obs, [])
+
+        obs = qiime2.sdk.util.artifact_actions('ShouldBeEmpty')
+        self.assertEqual(obs, [])
+
+        # For simplicity, we are gonna test the names of the plugin and
+        # the actions
+        obs = [(x.name, [yy.name for yy in y])
+               for x, y in qiime2.sdk.util.artifact_actions('SingleInt')]
+        exp = [('dummy-plugin', [
+            'Do stuff normally, but override this one step sometimes'])]
+        self.assertEqual(obs, exp)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qiime2/sdk/tests/test_util.py
+++ b/qiime2/sdk/tests/test_util.py
@@ -33,6 +33,5 @@ class TestUtil(unittest.TestCase):
             qiime2.sdk.util.artifact_actions('ShouldBeEmpty')
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/sdk/tests/test_util.py
+++ b/qiime2/sdk/tests/test_util.py
@@ -14,23 +14,39 @@ import qiime2.sdk
 
 class TestUtil(unittest.TestCase):
     def test_artifact_actions(self):
-        obs = qiime2.sdk.util.artifact_actions(None)
+        obs = qiime2.sdk.util.actions_by_input_type(None)
         self.assertEqual(obs, [])
 
         # For simplicity, we are gonna test the names of the plugin and
         # the actions
         obs = [(x.name, [yy.name for yy in y])
-               for x, y in qiime2.sdk.util.artifact_actions('SingleInt')]
+               for x, y in qiime2.sdk.util.actions_by_input_type('SingleInt')]
         exp = [('dummy-plugin', [
             'Do stuff normally, but override this one step sometimes'])]
         self.assertEqual(obs, exp)
 
         obs = [(x.name, [yy.name for yy in y])
-               for x, y in qiime2.sdk.util.artifact_actions('Kennel[Cat]')]
+               for x, y in qiime2.sdk.util.actions_by_input_type(
+               'Kennel[Cat]')]
         self.assertEqual(obs, [])
 
+        obs = [(x.name, [yy.name for yy in y])
+               for x, y in qiime2.sdk.util.actions_by_input_type(
+               'IntSequence1')]
+        exp = [('dummy-plugin', [
+            'A typical pipeline with the potential to raise an error',
+            'Concatenate integers', 'Identity', 'Identity', 'Identity',
+            'Do a great many things', 'Identity', 'Identity', 'Identity',
+            'Visualize most common integers',
+            'Split sequence of integers in half',
+            'Test different ways of failing', 'Optional artifacts method',
+            'Do stuff normally, but override this one step sometimes'])]
+        self.assertEqual(len(obs), 1)
+        self.assertEqual(obs[0][0], exp[0][0])
+        self.assertCountEqual(obs[0][1], exp[0][1])
+
         with self.assertRaises(qiime2.sdk.util.UnknownTypeError):
-            qiime2.sdk.util.artifact_actions('ShouldBeEmpty')
+            qiime2.sdk.util.actions_by_input_type('ShouldBeEmpty')
 
 
 if __name__ == '__main__':

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -110,13 +110,12 @@ def artifact_actions(string):
     if string is not None:
         query_type = qiime2.sdk.util.parse_type(string)
 
-        if string is not None:
-            pm = qiime2.sdk.PluginManager()
-            for pgn, pg in pm.plugins.items():
-                actions = list({a for an, a in pg.actions.items()
-                                for iname, i in a.signature.inputs.items()
-                                if i.qiime_type >= query_type})
-                if actions:
-                    commands.append((pg, actions))
+        pm = qiime2.sdk.PluginManager()
+        for pgn, pg in pm.plugins.items():
+            actions = list({a for an, a in pg.actions.items()
+                            for iname, i in a.signature.inputs.items()
+                            if i.qiime_type >= query_type})
+            if actions:
+                commands.append((pg, actions))
 
     return commands

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -92,3 +92,29 @@ def parse_format(format_str):
     except KeyError:
         raise TypeError("No format: %s" % format_str)
     return format_record.format
+
+
+def artifact_actions(string):
+    """Plugins and actions that have as input the artifact type (string)
+
+    Parameters
+    ----------
+    string : str
+        QIIME2 artifact type
+
+    Returns
+    -------
+    list of tuples: [(q2.plugin, [q2.actions, ...]), ...]
+    """
+    commands = []
+
+    if string is not None:
+        pm = qiime2.sdk.PluginManager()
+        for pgn, pg in pm.plugins.items():
+            actions = list({a for an, a in pg.actions.items()
+                            for iname, i in a.signature.inputs.items()
+                            if str(i.qiime_type) == string})
+            if actions:
+                commands.append((pg, actions))
+
+    return commands

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -94,7 +94,7 @@ def parse_format(format_str):
     return format_record.format
 
 
-def artifact_actions(string):
+def actions_by_input_type(string):
     """Plugins and actions that have as input the artifact type (string)
 
     Parameters

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -107,14 +107,16 @@ def artifact_actions(string):
     list of tuples: [(q2.plugin, [q2.actions, ...]), ...]
     """
     commands = []
-
     if string is not None:
-        pm = qiime2.sdk.PluginManager()
-        for pgn, pg in pm.plugins.items():
-            actions = list({a for an, a in pg.actions.items()
-                            for iname, i in a.signature.inputs.items()
-                            if str(i.qiime_type) == string})
-            if actions:
-                commands.append((pg, actions))
+        query_type = qiime2.sdk.util.parse_type(string)
+
+        if string is not None:
+            pm = qiime2.sdk.PluginManager()
+            for pgn, pg in pm.plugins.items():
+                actions = list({a for an, a in pg.actions.items()
+                                for iname, i in a.signature.inputs.items()
+                                if i.qiime_type >= query_type})
+                if actions:
+                    commands.append((pg, actions))
 
     return commands


### PR DESCRIPTION
Perhaps a description might be useful. Basically, this adds a new method to retrieve all plugins and their actions with a given input. This could be helpful to figure out which actions can be applied on a given input. 