### PR TITLE
NEW: adds checksums to archive structure

### DIFF
--- a/qiime2/core/archive/format/v5.py
+++ b/qiime2/core/archive/format/v5.py
@@ -1,0 +1,27 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import qiime2.core.archive.format.v4 as v4
+from qiime2.core.util import md5sum_directory, to_checksum_format
+
+
+class ArchiveFormat(v4.ArchiveFormat):
+    CHECKSUM_FILE = 'checksums.md5'
+    # Adds `checksums.md5` to root of directory structure
+
+    @classmethod
+    def write(cls, archive_record, type, format, data_initializer,
+              provenance_capture):
+        super().write(archive_record, type, format, data_initializer,
+                      provenance_capture)
+
+        checksums = md5sum_directory(str(archive_record.root))
+        with (archive_record.root / cls.CHECKSUM_FILE).open('w') as fh:
+            for item in checksums.items():
+                fh.write(to_checksum_format(*item))
+                fh.write('\n')

--- a/qiime2/core/archive/tests/test_archiver.py
+++ b/qiime2/core/archive/tests/test_archiver.py
@@ -16,6 +16,7 @@ import pathlib
 from qiime2.core.archive import Archiver
 from qiime2.core.archive import ImportProvenanceCapture
 from qiime2.core.archive.archiver import _ZipArchive
+from qiime2.core.archive.format.util import artifact_version
 from qiime2.core.testing.format import IntSequenceDirectoryFormat
 from qiime2.core.testing.type import IntSequence1
 from qiime2.core.testing.util import ArchiveTestingMixin
@@ -364,27 +365,12 @@ class TestArchiver(unittest.TestCase, ArchiveTestingMixin):
                                             'f47bc36040d5c7db08e4b3a457dcfbb2')
                           })
 
-    def setup_old_archiver(self):
-        class OldArchiver(Archiver):
-            # Quickest way to get the old code running
-            CURRENT_FORMAT_VERSION = '4'
-
-        def data_initializer(data_dir):
-            fp = os.path.join(str(data_dir), 'ints.txt')
-            with open(fp, 'w') as fh:
-                fh.write('1\n')
-                fh.write('2\n')
-                fh.write('3\n')
-
-        return OldArchiver.from_data(
-            IntSequence1, IntSequenceDirectoryFormat,
-            data_initializer=data_initializer,
-            provenance_capture=ImportProvenanceCapture())
-
     def test_checksum_backwards_compat(self):
-        archiver = self.setup_old_archiver()
+        self.tearDown()
+        with artifact_version(4):
+            self.setUp()
 
-        diff = archiver.validate_checksums()
+        diff = self.archiver.validate_checksums()
 
         self.assertEqual(diff.added, {})
         self.assertEqual(diff.removed, {})

--- a/qiime2/core/exceptions.py
+++ b/qiime2/core/exceptions.py
@@ -1,0 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+
+class ValidationError(Exception):
+    pass

--- a/qiime2/core/tests/test_util.py
+++ b/qiime2/core/tests/test_util.py
@@ -295,11 +295,7 @@ class TestChecksumFormat(unittest.TestCase):
 
     def check_roundtrip(self, filepath, checksum):
         line = util.to_checksum_format(filepath, checksum)
-        print(line)
         new_fp, new_chks = util.from_checksum_format(line)
-
-        print(filepath)
-        print(new_fp)
 
         self.assertEqual(new_fp, filepath)
         self.assertEqual(new_chks, checksum)

--- a/qiime2/core/tests/test_util.py
+++ b/qiime2/core/tests/test_util.py
@@ -254,5 +254,69 @@ class TestMD5SumDirectory(unittest.TestCase):
             ]))
 
 
+class TestChecksumFormat(unittest.TestCase):
+    def test_to_simple(self):
+        line = util.to_checksum_format('this/is/a/filepath',
+                                       'd9724aeba59d8cea5265f698b2c19684')
+        self.assertEqual(
+            line, 'd9724aeba59d8cea5265f698b2c19684  this/is/a/filepath')
+
+    def test_from_simple(self):
+        fp, chks = util.from_checksum_format(
+            'd9724aeba59d8cea5265f698b2c19684  this/is/a/filepath')
+
+        self.assertEqual(fp, 'this/is/a/filepath')
+        self.assertEqual(chks, 'd9724aeba59d8cea5265f698b2c19684')
+
+    def test_to_hard(self):
+        # two kinds of backslash n to trip up the escaping:
+        line = util.to_checksum_format('filepath/\n/with/\\newline',
+                                       '939aaaae6098ebdab049b0f3abe7b68c')
+
+        # Note raw string
+        self.assertEqual(
+            line,
+            r'\939aaaae6098ebdab049b0f3abe7b68c  filepath/\n/with/\\newline')
+
+    def test_from_hard(self):
+        fp, chks = util.from_checksum_format(
+            r'\939aaaae6098ebdab049b0f3abe7b68c  filepath/\n/with/\\newline'
+            + '\n')  # newline from a checksum "file"
+
+        self.assertEqual(fp, 'filepath/\n/with/\\newline')
+        self.assertEqual(chks, '939aaaae6098ebdab049b0f3abe7b68c')
+
+    def test_from_legacy_format(self):
+        fp, chks = util.from_checksum_format(
+            r'0ed29022ace300b4d96847882daaf0ef *this/means/binary/mode')
+
+        self.assertEqual(fp, 'this/means/binary/mode')
+        self.assertEqual(chks, '0ed29022ace300b4d96847882daaf0ef')
+
+    def check_roundtrip(self, filepath, checksum):
+        line = util.to_checksum_format(filepath, checksum)
+        print(line)
+        new_fp, new_chks = util.from_checksum_format(line)
+
+        print(filepath)
+        print(new_fp)
+
+        self.assertEqual(new_fp, filepath)
+        self.assertEqual(new_chks, checksum)
+
+    def test_nonsense(self):
+        self.check_roundtrip(
+            r'^~gpfh)bU)WvN/;3jR6H-*={iEBM`(flY2>_|5mp8{-h>Ou\{{ImLT>h;XuC,.#',
+            '89241859050e5a43ccb5f7aa0bca7a3a')
+
+        self.check_roundtrip(
+            r"l5AAPGKLP5Mcv0b`@zDR\XTTnF;[2M>O/>,d-^Nti'vpH\{>q)/4&CuU/xQ}z,O",
+            'c47d43cadb60faf30d9405a3e2592b26')
+
+        self.check_roundtrip(
+            r'FZ\rywG:7Q%"J@}Rk>\&zbWdS0nhEl_k1y1cMU#Lk_"*#*/uGi>Evl7M1suNNVE',
+            '9c7753f252116473994e8bffba2c620b')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/plugin/model/base.py
+++ b/qiime2/plugin/model/base.py
@@ -7,13 +7,10 @@
 # ----------------------------------------------------------------------------
 
 from qiime2.core.format import FormatBase
+from qiime2.core.exceptions import ValidationError
 
 
 __all__ = ['FormatBase', 'ValidationError', '_check_validation_level']
-
-
-class ValidationError(Exception):
-    pass
 
 
 # TODO: once sniff is dropped, move this up into FormatBase as validate method

--- a/qiime2/sdk/tests/test_artifact.py
+++ b/qiime2/sdk/tests/test_artifact.py
@@ -97,6 +97,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(artifact.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/file1.txt',
             'data/file2.txt',
@@ -158,6 +159,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(artifact.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/file1.txt',
             'data/file2.txt',
@@ -174,6 +176,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(artifact.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/file1.txt',
             'data/file2.txt',
@@ -247,6 +250,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
 
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/file1.txt',
             'data/file2.txt',

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -232,7 +232,8 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
         with (artifact._archiver.root_dir / 'extra.file').open('w') as fh:
             fh.write('uh oh')
 
-        with self.assertRaisesRegex(exceptions.ValidationError, 'extra\.file'):
+        with self.assertRaisesRegex(exceptions.ValidationError,
+                                    r'extra\.file'):
             artifact.validate()
 
     def test_validate_vizualization_good(self):
@@ -249,7 +250,8 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
         with (visualization._archiver.root_dir / 'extra.file').open('w') as fh:
             fh.write('uh oh')
 
-        with self.assertRaisesRegex(exceptions.ValidationError, 'extra\.file'):
+        with self.assertRaisesRegex(exceptions.ValidationError,
+                                    r'extra\.file'):
             visualization.validate()
 
 

--- a/qiime2/sdk/tests/test_visualization.py
+++ b/qiime2/sdk/tests/test_visualization.py
@@ -78,6 +78,7 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(visualization.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/index.html',
             'data/css/style.css',
@@ -116,6 +117,7 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(visualization.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/index.html',
             'data/css/style.css',
@@ -130,6 +132,7 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(visualization.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/index.html',
             'data/css/style.css',
@@ -205,6 +208,7 @@ class TestVisualization(unittest.TestCase, ArchiveTestingMixin):
 
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/index.html',
             'data/css/style.css',

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -240,6 +240,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(result.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/index.html',
             'data/css/style.css',
@@ -288,6 +289,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(result.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/index.html',
             'data/index.tsv',
@@ -319,6 +321,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(result.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/index.html',
             'provenance/metadata.yaml',
@@ -344,6 +347,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(result.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/index.html',
             'provenance/metadata.yaml',
@@ -387,6 +391,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         root_dir = str(result.uuid)
         expected = {
             'VERSION',
+            'checksums.md5',
             'metadata.yaml',
             'data/index.html',
             'data/css/style.css',


### PR DESCRIPTION
This commit adds a 'checksums.md5' file to the root of an archive.
The file is formatted with the md5sum format:

\<hex-hash>\<space>\<space or asterisk>\<escaped filename>\<newline>

Filename escaping handles backslash and newline. In the event those are
present, the backslash is doubled and the newline becomes `\n`.
Additionally if escaping is required, then an additional backslash
precedes the \<hex-hash> to indicate the filename is escaped.
See:
https://www.gnu.org/software/coreutils/manual/html_node/md5sum-invocation.html
for more details.

**TODO**:

- [x] Add tests