### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -50,7 +50,8 @@ def long_description_method(mapping1: dict, name: str, age: int) -> dict:
 
 
 def docstring_order_method(req_input: dict, req_param: str,
-                           opt_input: dict=None, opt_param: int=None) -> dict:
+                           opt_input: dict = None,
+                           opt_param: int = None) -> dict:
     return {req_param: opt_param}
 
 
@@ -81,21 +82,22 @@ def identity_with_numeric_metadata_column(
 
 
 def identity_with_optional_metadata(ints: list,
-                                    metadata: qiime2.Metadata=None) -> list:
+                                    metadata: qiime2.Metadata = None) -> list:
     assert isinstance(metadata, (qiime2.Metadata, type(None)))
     return ints
 
 
 def identity_with_optional_metadata_column(
-        ints: list, metadata: qiime2.MetadataColumn=None) -> list:
+        ints: list, metadata: qiime2.MetadataColumn = None) -> list:
     assert isinstance(metadata, (qiime2.CategoricalMetadataColumn,
                                  qiime2.NumericMetadataColumn,
                                  type(None)))
     return ints
 
 
-def optional_artifacts_method(ints: list, num1: int, optional1: list=None,
-                              optional2: list=None, num2: int=None) -> list:
+def optional_artifacts_method(ints: list, num1: int, optional1: list = None,
+                              optional2: list = None,
+                              num2: int = None) -> list:
     result = ints + [num1]
     if optional1 is not None:
         result += optional1
@@ -107,7 +109,7 @@ def optional_artifacts_method(ints: list, num1: int, optional1: list=None,
 
 
 def variadic_input_method(ints: list, int_set: int, nums: int,
-                          opt_nums: int=None) -> list:
+                          opt_nums: int = None) -> list:
     results = []
 
     for int_list in ints:

--- a/qiime2/core/testing/visualizer.py
+++ b/qiime2/core/testing/visualizer.py
@@ -41,7 +41,7 @@ def multi_html_viz(output_dir: str, ints: list) -> None:
 
 
 # No input artifacts, only parameters.
-def params_only_viz(output_dir: str, name: str='Foo Bar', age: int=42):
+def params_only_viz(output_dir: str, name: str = 'Foo Bar', age: int = 42):
     with open(os.path.join(output_dir, 'index.html'), 'w') as fh:
         fh.write('<html><body>\n')
         fh.write('Name: %s\n' % name)

--- a/qiime2/metadata/tests/test_io.py
+++ b/qiime2/metadata/tests/test_io.py
@@ -245,8 +245,8 @@ class TestLoadErrors(unittest.TestCase):
         # all values that couldn't be converted to numbers, making it possible
         # to test a variety of non-numeric strings in a single test case.
         msg = (r"column 'col2' to numeric.*could not be interpreted as "
-               "numeric: '\$42', '\+inf', '-inf', '0xAF', '1,000', "
-               "'1\.000\.0', '1_000_000', '1e3e4', 'Infinity', 'NA', 'NaN', "
+               r"numeric: '\$42', '\+inf', '-inf', '0xAF', '1,000', "
+               r"'1\.000\.0', '1_000_000', '1e3e4', 'Infinity', 'NA', 'NaN', "
                "'a', 'e3', 'foo', 'inf', 'nan', 'sample-1'")
         with self.assertRaisesRegex(MetadataFileError, msg):
             Metadata.load(fp)

--- a/qiime2/metadata/tests/test_metadata.py
+++ b/qiime2/metadata/tests/test_metadata.py
@@ -37,11 +37,11 @@ class TestInvalidMetadataConstruction(unittest.TestCase):
 
     def test_invalid_id_header(self):
         # default index name
-        with self.assertRaisesRegex(ValueError, 'Index\.name.*None'):
+        with self.assertRaisesRegex(ValueError, r'Index\.name.*None'):
             Metadata(pd.DataFrame(
                 {'col': [1, 2, 3]}, index=pd.Index(['a', 'b', 'c'])))
 
-        with self.assertRaisesRegex(ValueError, 'Index\.name.*my-id-header'):
+        with self.assertRaisesRegex(ValueError, r'Index\.name.*my-id-header'):
             Metadata(pd.DataFrame(
                 {'col': [1, 2, 3]},
                 index=pd.Index(['a', 'b', 'c'], name='my-id-header')))
@@ -142,7 +142,7 @@ class TestInvalidMetadataConstruction(unittest.TestCase):
     def test_categorical_column_unsupported_type(self):
         with self.assertRaisesRegex(
                 TypeError, "CategoricalMetadataColumn.*strings or missing "
-                           "values.*42\.5.*float.*'col2'"):
+                           r"values.*42\.5.*float.*'col2'"):
             Metadata(pd.DataFrame(
                 {'col1': [1, 2, 3],
                  'col2': ['foo', 'bar', 42.5]},

--- a/qiime2/metadata/tests/test_metadata_column.py
+++ b/qiime2/metadata/tests/test_metadata_column.py
@@ -50,11 +50,11 @@ class TestInvalidMetadataColumnConstruction(unittest.TestCase):
 
     def test_invalid_id_header(self):
         # default index name
-        with self.assertRaisesRegex(ValueError, 'Index\.name.*None'):
+        with self.assertRaisesRegex(ValueError, r'Index\.name.*None'):
             DummyMetadataColumn(pd.Series([1, 2, 3], name='col',
                                           index=pd.Index(['a', 'b', 'c'])))
 
-        with self.assertRaisesRegex(ValueError, 'Index\.name.*my-id-header'):
+        with self.assertRaisesRegex(ValueError, r'Index\.name.*my-id-header'):
             DummyMetadataColumn(pd.Series(
                 [1, 2, 3], name='col',
                 index=pd.Index(['a', 'b', 'c'], name='my-id-header')))
@@ -813,7 +813,7 @@ class TestCategoricalMetadataColumn(unittest.TestCase):
     def test_unsupported_type_value(self):
         with self.assertRaisesRegex(
                 TypeError, "CategoricalMetadataColumn.*strings or missing "
-                           "values.*42\.5.*float.*'col1'"):
+                           r"values.*42\.5.*float.*'col1'"):
             CategoricalMetadataColumn(pd.Series(
                 ['foo', 'bar', 42.5], name='col1',
                 index=pd.Index(['a', 'b', 'c'], name='id')))

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -47,7 +47,7 @@ class Action(metaclass=abc.ABCMeta):
     _ProvCaptureCls = archive.ActionProvenanceCapture
 
     __call__ = LateBindingAttribute('_dynamic_call')
-    async = LateBindingAttribute('_dynamic_async')
+    asynchronous = LateBindingAttribute('_dynamic_async')
 
     # Converts a callable's signature into its wrapper's signature (i.e.
     # converts the "view API" signature into the "artifact API" signature).
@@ -256,7 +256,7 @@ class Action(metaclass=abc.ABCMeta):
     def _get_async_wrapper(self):
         def async_wrapper(*args, **kwargs):
             # TODO handle this better in the future, but stop the massive error
-            # caused by MacOSX async runs for now.
+            # caused by MacOSX asynchronous runs for now.
             try:
                 import matplotlib as plt
                 if plt.rcParams['backend'].lower() == 'macosx':
@@ -278,7 +278,7 @@ class Action(metaclass=abc.ABCMeta):
 
         async_wrapper = self._rewrite_wrapper_signature(async_wrapper)
         self._set_wrapper_properties(async_wrapper)
-        self._set_wrapper_name(async_wrapper, 'async')
+        self._set_wrapper_name(async_wrapper, 'asynchronous')
         return async_wrapper
 
     def _rewrite_wrapper_signature(self, wrapper):
@@ -507,7 +507,7 @@ markdown_source_template = """
 
 # TODO add unit test for callables raising this
 backend_error_template = """
-Your current matplotlib backend (MacOSX) does not work with async calls.
+Your current matplotlib backend (MacOSX) does not work with asynchronous calls.
 A recommended backend is Agg, and can be changed by modifying your
 matplotlibrc "backend" parameter, which can be found at: \n\n %s
 """

--- a/qiime2/sdk/results.py
+++ b/qiime2/sdk/results.py
@@ -11,9 +11,9 @@
 # `namedtuple` directly because each `Action` will return a `Results` object
 # with `Action`-specific fields (`Action.signature` determines the fields).
 # Dynamically-defined namedtuple types aren't pickleable, which is necessary
-# for `async`. They aren't pickleable because the namedtuple type must be
-# accessible as a module global, but this global type would be redefined each
-# time an `Action` is instantiated.
+# for `asynchronous`. They aren't pickleable because the namedtuple type must
+# be accessible as a module global, but this global type would be redefined
+# each time an `Action` is instantiated.
 class Results(tuple):
     """Tuple class representing the named results of an ``Action``.
 

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -211,15 +211,15 @@ class TestMethod(unittest.TestCase):
             merge_mappings: merge_exp}
 
         for method, exp in mapper.items():
-            self.assertEqual(method.async.__name__, 'async')
-            self.assertEqual(method.async.__annotations__, exp)
-            self.assertFalse(hasattr(method.async, '__wrapped__'))
+            self.assertEqual(method.asynchronous.__name__, 'asynchronous')
+            self.assertEqual(method.asynchronous.__annotations__, exp)
+            self.assertFalse(hasattr(method.asynchronous, '__wrapped__'))
 
     def test_callable_and_async_signature_with_artifacts_and_parameters(self):
         # Signature with input artifacts and parameters (i.e. primitives).
         concatenate_ints = self.plugin.methods['concatenate_ints']
 
-        for callable_attr in '__call__', 'async':
+        for callable_attr in '__call__', 'asynchronous':
             signature = inspect.Signature.from_callable(
                 getattr(concatenate_ints, callable_attr))
             parameters = list(signature.parameters.items())
@@ -244,7 +244,7 @@ class TestMethod(unittest.TestCase):
         # Signature without parameters (i.e. primitives), only input artifacts.
         method = self.plugin.methods['merge_mappings']
 
-        for callable_attr in '__call__', 'async':
+        for callable_attr in '__call__', 'asynchronous':
             signature = inspect.Signature.from_callable(
                 getattr(method, callable_attr))
             parameters = list(signature.parameters.items())
@@ -415,13 +415,14 @@ class TestMethod(unittest.TestCase):
 
         self.assertEqual(result.view(list), list(range(1, 14)))
 
-    def test_async(self):
+    def test_asynchronous(self):
         concatenate_ints = self.plugin.methods['concatenate_ints']
 
         artifact1 = Artifact.import_data(IntSequence1, [0, 42, 43])
         artifact2 = Artifact.import_data(IntSequence2, [99, -22])
 
-        future = concatenate_ints.async(artifact1, artifact1, artifact2, 55, 1)
+        future = concatenate_ints.asynchronous(
+            artifact1, artifact1, artifact2, 55, 1)
 
         self.assertIsInstance(future, concurrent.futures.Future)
         result = future.result()
@@ -454,7 +455,8 @@ class TestMethod(unittest.TestCase):
 
         # Accepts IntSequence1 | IntSequence2
         artifact3 = Artifact.import_data(IntSequence2, [10, 20])
-        future = concatenate_ints.async(artifact3, artifact1, artifact2, 55, 1)
+        future = concatenate_ints.asynchronous(artifact3, artifact1, artifact2,
+                                               55, 1)
         result, = future.result()
 
         self.assertEqual(result.type, IntSequence1)
@@ -466,7 +468,7 @@ class TestMethod(unittest.TestCase):
 
         artifact = Artifact.import_data(IntSequence1, [0, 42, -2, 43, 6])
 
-        future = split_ints.async(artifact)
+        future = split_ints.asynchronous(artifact)
 
         self.assertIsInstance(future, concurrent.futures.Future)
         result = future.result()

--- a/qiime2/sdk/tests/test_pipeline.py
+++ b/qiime2/sdk/tests/test_pipeline.py
@@ -190,12 +190,12 @@ class TestPipeline(unittest.TestCase):
 
     def test_failing_from_missing_plugin(self):
         for call in self.iter_callables('failing_pipeline'):
-            with self.assertRaisesRegex(ValueError, 'plugin.*not\%a\$plugin'):
+            with self.assertRaisesRegex(ValueError, r'plugin.*not\%a\$plugin'):
                 call(self.int_sequence, break_from='no-plugin')
 
     def test_failing_from_missing_action(self):
         for call in self.iter_callables('failing_pipeline'):
-            with self.assertRaisesRegex(ValueError, 'action.*not\%a\$method'):
+            with self.assertRaisesRegex(ValueError, r'action.*not\%a\$method'):
                 call(self.int_sequence, break_from='no-action')
 
 

--- a/qiime2/sdk/tests/test_pipeline.py
+++ b/qiime2/sdk/tests/test_pipeline.py
@@ -70,7 +70,7 @@ class TestPipeline(unittest.TestCase):
                 'add', kind, default=1, annotation=Int))
         ]
 
-        for callable_attr in '__call__', 'async':
+        for callable_attr in '__call__', 'asynchronous':
             signature = inspect.Signature.from_callable(
                 getattr(typical_pipeline, callable_attr))
             parameters = list(signature.parameters.items())
@@ -82,7 +82,7 @@ class TestPipeline(unittest.TestCase):
         parameter_only_pipeline = self.plugin.pipelines[
             'parameter_only_pipeline']
 
-        for callable_attr in '__call__', 'async':
+        for callable_attr in '__call__', 'asynchronous':
             signature_a = inspect.Signature.from_callable(
                 getattr(typical_pipeline, callable_attr))
 
@@ -94,7 +94,8 @@ class TestPipeline(unittest.TestCase):
     def iter_callables(self, name):
         pipeline = self.plugin.pipelines[name]
         yield pipeline
-        yield lambda *args, **kwargs: pipeline.async(*args, **kwargs).result()
+        yield lambda *args, **kwargs: pipeline.asynchronous(
+            *args, **kwargs).result()
 
     def test_parameter_only_pipeline(self):
         index = pd.Index(['a', 'b', 'c'], name='id', dtype=object)

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -166,14 +166,14 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
             most_common_viz: most_common_exp}
 
         for visualizer, exp in mapper.items():
-            self.assertEqual(visualizer.async.__name__, 'async')
-            self.assertEqual(visualizer.async.__annotations__, exp)
-            self.assertFalse(hasattr(visualizer.async, '__wrapped__'))
+            self.assertEqual(visualizer.asynchronous.__name__, 'asynchronous')
+            self.assertEqual(visualizer.asynchronous.__annotations__, exp)
+            self.assertFalse(hasattr(visualizer.asynchronous, '__wrapped__'))
 
     def test_callable_and_async_signature(self):
         mapping_viz = self.plugin.visualizers['mapping_viz']
 
-        for callable_attr in '__call__', 'async':
+        for callable_attr in '__call__', 'asynchronous':
             signature = inspect.Signature.from_callable(
                 getattr(mapping_viz, callable_attr))
             parameters = list(signature.parameters.items())
@@ -197,7 +197,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         # signature.
         most_common_viz = self.plugin.visualizers['most_common_viz']
 
-        for callable_attr in '__call__', 'async':
+        for callable_attr in '__call__', 'asynchronous':
             signature = inspect.Signature.from_callable(
                 getattr(most_common_viz, callable_attr))
             parameters = list(signature.parameters.items())
@@ -354,14 +354,14 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
 
         self.assertArchiveMembers(filepath, root_dir, expected)
 
-    def test_async(self):
+    def test_asynchronous(self):
         mapping_viz = self.plugin.visualizers['mapping_viz']
 
         artifact1 = Artifact.import_data(Mapping, {'foo': 'abc', 'bar': 'def'})
         artifact2 = Artifact.import_data(
             Mapping, {'baz': 'abc', 'bazz': 'ghi'})
 
-        future = mapping_viz.async(artifact1, artifact2, 'Key', 'Value')
+        future = mapping_viz.asynchronous(artifact1, artifact2, 'Key', 'Value')
 
         self.assertIsInstance(future, concurrent.futures.Future)
         result = future.result()

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -77,7 +77,7 @@ def parse_type(string, expect=None):
         return type_expr
     except NameError as e:
         # http://stackoverflow.com/a/2270822/579416
-        name, = re.findall("name '(\w+)' is not defined", str(e))
+        name, = re.findall(r"name '(\w+)' is not defined", str(e))
         raise UnknownTypeError("Name %r is not a defined QIIME type, a plugin"
                                " may be needed to define it." % name)
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Numerous minor updates for compliance with flake8 v3.6, as discussed in #415.

Note: flake8 has been disabled in versioneer.py. 