### PR TITLE
Updates TypeError Message to improve readability for naive users

### DIFF
--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -297,7 +297,7 @@ class PipelineSignature:
                         kwargs[name] is None):
                     raise TypeError(
                         "Parameter %r received an argument of type %r. An "
-                        "argument of type(s) %r is required." % (
+                        "argument of subtype %r is required." % (
                             name, kwargs[name].type, spec.qiime_type))
 
     def solve_output(self, **input_types):

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -295,8 +295,10 @@ class PipelineSignature:
                 if not (spec.has_default() and
                         spec.default is None and
                         kwargs[name] is None):
-                    raise TypeError("Argument to parameter %r is not a "
-                                    "subtype of %r." % (name, spec.qiime_type))
+                    raise TypeError(
+                        "Parameter %r received an argument of type %r. An "
+                        "argument of type(s) %r is required." % (
+                            name, kwargs[name].type, spec.qiime_type))
 
     def solve_output(self, **input_types):
         # TODO implement solving here. The check for concrete output types may

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -398,7 +398,7 @@ class TestMethod(unittest.TestCase):
 
         # Invalid type provided as optional artifact.
         with self.assertRaisesRegex(TypeError,
-                                    'not a subtype of IntSequence1'):
+                                    'type IntSequence2.*subtype IntSequence1'):
             method(ints1, 42, optional1=ints3)
 
     def test_call_with_variadic_inputs(self):


### PR DESCRIPTION
closes #252 

Is this readable enough in cases like below, where there are multiple subtypes? We could probably parse "type [x | y | z]" into "type[x] or type[y] or type[z]".

![errormsg](https://user-images.githubusercontent.com/39198770/48167946-af68d180-e2aa-11e8-8b61-d380a54d0c4f.png)
