### PR TITLE
BUG: Fix Metadata repr when ID only MD is passed

### DIFF
--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -408,10 +408,11 @@ class Metadata(_MetadataBase):
         ))
 
         # Column properties
-        max_name_len = max((len(name) for name in self.columns))
-        for name, props in self.columns.items():
-            padding = ' ' * ((max_name_len - len(name)) + 1)
-            lines.append('%s:%s%r' % (name, padding, props))
+        if self.column_count != 0:
+            max_name_len = max((len(name) for name in self.columns))
+            for name, props in self.columns.items():
+                padding = ' ' * ((max_name_len - len(name)) + 1)
+                lines.append('%s:%s%r' % (name, padding, props))
 
         # Epilogue
         lines.append('')


### PR DESCRIPTION
Fixes #419

Metadata.__repr__ errored when a Metadata with no columns was passed. This PR fixes the bug and allows when ID only MD is passed. 
