### PR TITLE
BUG: Fixes type mismatch exception for primitives

### DIFF
--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -400,7 +400,7 @@ dummy_plugin.visualizers.register_function(
     inputs={},
     parameters={
         'name': Str,
-        'age': Int
+        'age': Int % Range(0, None)
     },
     name='Parameters only viz',
     description='This visualizer only accepts parameters.'

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -310,7 +310,7 @@ class PipelineSignature:
 
                 elif isinstance(parameter, qiime2.Metadata):
                     raise TypeError(
-                        "Parameter %r received a Metadata object as an "
+                        "Parameter %r received Metadata as an "
                         "argument, which is incompatible with parameter "
                         "type: %r" % (name, spec.qiime_type))
 

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -307,10 +307,15 @@ class PipelineSignature:
                         "Parameter %r requires an argument of type %r. An "
                         "argument of type %r was passed." % (
                             name, spec.qiime_type, kwargs[name].type))
+                elif isinstance(kwargs[name], qiime2.Metadata):
+                    raise TypeError(
+                        "Parameter %r received a Metadata file as an argument,"
+                        " which is incompatible with parameter type: %r" % (
+                            name, spec.qiime_type))
                 else:  # kwarg is a primitive type
                     raise TypeError(
                         "Parameter %r received %r as an argument, which is "
-                        "incompatible with parameter type %r"
+                        "incompatible with parameter type: %r"
                         % (name, kwargs[name], spec.qiime_type))
 
     def solve_output(self, **input_types):

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -302,16 +302,18 @@ class PipelineSignature:
                         "argument. Visualizations may not be used as inputs."
                         % name)
 
-                # Check if is Artifact
-                isArtifact = isinstance(kwargs[name], qiime2.sdk.Artifact)
-                # kwargHasTypeAttribute = is_semantic_type(kwargs[name])
-                passed_type = (kwargs[name].type if isArtifact
+                # store parameter type for later use
+                kwargIsArtifact = isinstance(kwargs[name], qiime2.sdk.Artifact)
+                passed_type = (kwargs[name].type if kwargIsArtifact
                                else type(kwargs[name]).__name__)
+
                 raise TypeError(
-                    "Parameter %r received an argument of type %r. An "
-                    "argument of subtype %r is required." % (
-                        name, passed_type,
-                        spec.qiime_type))
+                    "Parameter %r requires an argument of type %r. An "
+                    "argument of type %r was passed." % (
+                        name, spec.qiime_type,
+                        passed_type))
+
+                # handle artifacts with same types, different subtypes:
 
     def solve_output(self, **input_types):
         # TODO implement solving here. The check for concrete output types may

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -302,18 +302,16 @@ class PipelineSignature:
                         "argument. Visualizations may not be used as inputs."
                         % name)
 
-                # store parameter type for later use
-                kwargIsArtifact = isinstance(kwargs[name], qiime2.sdk.Artifact)
-                passed_type = (kwargs[name].type if kwargIsArtifact
-                               else type(kwargs[name]).__name__)
-
-                raise TypeError(
-                    "Parameter %r requires an argument of type %r. An "
-                    "argument of type %r was passed." % (
-                        name, spec.qiime_type,
-                        passed_type))
-
-                # handle artifacts with same types, different subtypes:
+                if isinstance(kwargs[name], qiime2.sdk.Artifact):
+                    raise TypeError(
+                        "Parameter %r requires an argument of type %r. An "
+                        "argument of type %r was passed." % (
+                            name, spec.qiime_type, kwargs[name].type))
+                else:  # kwarg is a primitive type
+                    raise TypeError(
+                        "Parameter %r received %r as an argument, which is "
+                        "incompatible with parameter type %r"
+                        % (name, kwargs[name], spec.qiime_type))
 
     def solve_output(self, **input_types):
         # TODO implement solving here. The check for concrete output types may

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -294,10 +294,24 @@ class PipelineSignature:
             if ((kwargs[name] not in spec.qiime_type) and
                     not (spec.has_default() and spec.default is None
                          and kwargs[name] is None)):
+
+                # handle visualization passed as parameter
+                if isinstance(kwargs[name], qiime2.sdk.Visualization):
+                    raise TypeError(
+                        "Parameter %r received a Visualization (*.qzv) as an "
+                        "argument. Visualizations may not be used as inputs."
+                        % name)
+
+                # Check if is Artifact
+                isArtifact = isinstance(kwargs[name], qiime2.sdk.Artifact)
+                # kwargHasTypeAttribute = is_semantic_type(kwargs[name])
+                passed_type = (kwargs[name].type if isArtifact
+                               else type(kwargs[name]).__name__)
                 raise TypeError(
                     "Parameter %r received an argument of type %r. An "
                     "argument of subtype %r is required." % (
-                        name, kwargs[name].type, spec.qiime_type))
+                        name, passed_type,
+                        spec.qiime_type))
 
     def solve_output(self, **input_types):
         # TODO implement solving here. The check for concrete output types may

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -289,16 +289,15 @@ class PipelineSignature:
 
     def check_types(self, **kwargs):
         for name, spec in self.signature_order.items():
-            if kwargs[name] not in spec.qiime_type:
-                # A type mismatch is unacceptable unless the value is None
-                # and this parameter's default value is None.
-                if not (spec.has_default() and
-                        spec.default is None and
-                        kwargs[name] is None):
-                    raise TypeError(
-                        "Parameter %r received an argument of type %r. An "
-                        "argument of subtype %r is required." % (
-                            name, kwargs[name].type, spec.qiime_type))
+            # A type mismatch is unacceptable unless the value is None
+            # and this parameter's default value is None.
+            if ((kwargs[name] not in spec.qiime_type) and
+                    not (spec.has_default() and spec.default is None
+                         and kwargs[name] is None)):
+                raise TypeError(
+                    "Parameter %r received an argument of type %r. An "
+                    "argument of subtype %r is required." % (
+                        name, kwargs[name].type, spec.qiime_type))
 
     def solve_output(self, **input_types):
         # TODO implement solving here. The check for concrete output types may

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -289,36 +289,36 @@ class PipelineSignature:
 
     def check_types(self, **kwargs):
         for name, spec in self.signature_order.items():
+            parameter = kwargs[name]
             # A type mismatch is unacceptable unless the value is None
             # and this parameter's default value is None.
-            if ((kwargs[name] not in spec.qiime_type) and
+            if ((parameter not in spec.qiime_type) and
                     not (spec.has_default() and spec.default is None
-                         and kwargs[name] is None)):
+                         and parameter is None)):
 
-                # handle visualization passed as parameter
-                if isinstance(kwargs[name], qiime2.sdk.Visualization):
+                if isinstance(parameter, qiime2.sdk.Visualization):
                     raise TypeError(
-                        "Parameter %r received a Visualization (*.qzv) as an "
+                        "Parameter %r received a Visualization as an "
                         "argument. Visualizations may not be used as inputs."
                         % name)
 
-                # handle Artifacts
-                if isinstance(kwargs[name], qiime2.sdk.Artifact):
+                elif isinstance(parameter, qiime2.sdk.Artifact):
                     raise TypeError(
                         "Parameter %r requires an argument of type %r. An "
                         "argument of type %r was passed." % (
-                            name, spec.qiime_type, kwargs[name].type))
-                # handle Metadata without displaying long Metadata repr
-                elif isinstance(kwargs[name], qiime2.Metadata):
+                            name, spec.qiime_type, parameter.type))
+
+                elif isinstance(parameter, qiime2.Metadata):
                     raise TypeError(
-                        "Parameter %r received a Metadata file as an argument,"
-                        " which is incompatible with parameter type: %r" % (
-                            name, spec.qiime_type))
+                        "Parameter %r received a Metadata object as an "
+                        "argument, which is incompatible with parameter "
+                        "type: %r" % (name, spec.qiime_type))
+
                 else:  # handle primitive types
                     raise TypeError(
                         "Parameter %r received %r as an argument, which is "
                         "incompatible with parameter type: %r"
-                        % (name, kwargs[name], spec.qiime_type))
+                        % (name, parameter, spec.qiime_type))
 
     def solve_output(self, **input_types):
         # TODO implement solving here. The check for concrete output types may

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -302,17 +302,19 @@ class PipelineSignature:
                         "argument. Visualizations may not be used as inputs."
                         % name)
 
+                # handle Artifacts
                 if isinstance(kwargs[name], qiime2.sdk.Artifact):
                     raise TypeError(
                         "Parameter %r requires an argument of type %r. An "
                         "argument of type %r was passed." % (
                             name, spec.qiime_type, kwargs[name].type))
+                # handle Metadata without displaying long Metadata repr
                 elif isinstance(kwargs[name], qiime2.Metadata):
                     raise TypeError(
                         "Parameter %r received a Metadata file as an argument,"
                         " which is incompatible with parameter type: %r" % (
                             name, spec.qiime_type))
-                else:  # kwarg is a primitive type
+                else:  # handle primitive types
                     raise TypeError(
                         "Parameter %r received %r as an argument, which is "
                         "incompatible with parameter type: %r"

--- a/qiime2/sdk/tests/test_action.py
+++ b/qiime2/sdk/tests/test_action.py
@@ -21,6 +21,11 @@ from qiime2 import Metadata
 from qiime2.metadata.tests.test_io import get_data_path
 
 
+# NOTE: This test suite exists for tests not easily split into
+# test_method, test_visualizer, test_pipeline
+# TestBadInputs tests type mismatches between Action signatures and passed args
+
+
 class TestBadInputs(TestPluginBase):
 
     def make_provenance_capture(self):

--- a/qiime2/sdk/tests/test_bad_inputs.py
+++ b/qiime2/sdk/tests/test_bad_inputs.py
@@ -128,19 +128,27 @@ class TestBadInputs(TestPluginBase):
             concatenate_ints(ints1, inappropriate_metadata, ints3, int1, int2)
 
     def test_primitive_param_out_of_range(self):
-        # TODO: use params_only_viz
         range_nested_in_list = self.plugin.methods['variadic_input_method']
+        range_not_nested_in_list = self.plugin.visualizers['params_only_viz']
         ints_list = [Artifact.import_data(IntSequence1, [0, 42, 43]),
                      Artifact.import_data(IntSequence2, [4, 5, 6])]
         int_set = {Artifact.import_data(SingleInt, 7),
                    Artifact.import_data(SingleInt, 8)}
         nums = {9, 10}
         bad_range_val = [11, 12, -9999]
+        invalid_age = -99999
 
-        # passes primitive of correct type but outside of Range
+        # Tests primitives of correct type but outside of Range...
+        # ... in a list
         with self.assertRaisesRegex(
                 TypeError, 'opt_nums.*-9999.*incompatible.*List'):
             range_nested_in_list(ints_list, int_set, nums, bad_range_val)
+
+        # ... not in a list
+        with self.assertRaisesRegex(
+                TypeError,
+                '\'age\'.*-99999.*incompatible.*Int % Range\(0, None\)'):
+            range_not_nested_in_list('John Doe', invalid_age)
 
     def test_primitive_param_not_valid_choice(self):
         pipeline = self.plugin.pipelines['failing_pipeline']

--- a/qiime2/sdk/tests/test_bad_inputs.py
+++ b/qiime2/sdk/tests/test_bad_inputs.py
@@ -71,9 +71,27 @@ class TestBadInputs(TestPluginBase):
 
     def test_artifact_passed_as_param(self):
         # TODO: implement
+        # passed as params
+        # passed as metadata
+        # etc?
         pass
 
-    def test_artifact_passed_as_metadata(self):
+    def test_incorrect_artifact_type(self):
+        # method = self.plugin.methods['optional_artifacts_method']
+        # ints1 = Artifact.import_data(IntSequence1, [0, 42, 43])
+        # testDoc = Artifact.import_data
+        #
+        #
+        # with self.assertRaisesRegex(
+        #         TypeError, 'Visualizations may not be used as inputs.'):
+        #     method(saved_viz, 42)
+        pass
+
+    def test_incorrect_artifact_subtype(self):
+        # TODO: implement
+        pass
+
+    def incorrect_primitive_type(self):
         # TODO: implement
         pass
 
@@ -82,8 +100,30 @@ class TestBadInputs(TestPluginBase):
         pass
 
     def test_primitive_passed_as_input(self):
-        # TODO: implement
-        pass
+        # generate params
+        concatenate_ints = self.plugin.methods['concatenate_ints']
+        identity_with_metadata = self.plugin.methods['identity_with_metadata']
+        params_only_method = self.plugin.methods['params_only_method']
+        ints1 = Artifact.import_data(IntSequence1, [0, 42, 43])
+        ints3 = Artifact.import_data(IntSequence1, [99, -22])
+        int1 = 4
+        int2 = 5
+        arbitrary_int = 43
+
+        # tests primitive passed as IntSequence artifact
+        with self.assertRaisesRegex(TypeError,
+                                    'type IntSequence1.*type \'int\''):
+            concatenate_ints(ints1, arbitrary_int, ints3, int1, int2)
+
+        # tests primitive passed as metadata
+        with self.assertRaisesRegex(TypeError,
+                                    'type Metadata.*type \'int\''):
+            identity_with_metadata(ints1, arbitrary_int)
+
+        # tests wrong type of primitive passed
+        with self.assertRaisesRegex(TypeError,
+                                    'type Int.*type \'str\''):
+            params_only_method('key string', 'arbitrary string shuld be int')
 
     def test_primitive_param_out_of_range(self):
         # TODO: implement

--- a/qiime2/sdk/tests/test_bad_inputs.py
+++ b/qiime2/sdk/tests/test_bad_inputs.py
@@ -19,6 +19,8 @@ from qiime2.plugin.testing import TestPluginBase
 from qiime2.sdk import Artifact, Visualization
 from qiime2.core.testing.type import IntSequence1, IntSequence2, SingleInt
 from qiime2.core.testing.visualizer import most_common_viz
+from qiime2 import Metadata
+from qiime2.metadata.tests.test_io import get_data_path
 
 # from qiime2.sdk import Method, Results
 # from qiime2.core.testing.method import (concatenate_ints, merge_mappings,
@@ -98,28 +100,17 @@ class TestBadInputs(TestPluginBase):
                 TypeError, 'ints3.*IntSequence2.*IntSequence1'):
             concatenate_ints(ints1, ints2, inappropriate_Artifact, int1, int2)
 
-    def test_incorrect_artifact_type(self):
-        # method = self.plugin.methods['optional_artifacts_method']
-        # ints1 = Artifact.import_data(IntSequence1, [0, 42, 43])
-        # testDoc = Artifact.import_data
-        #
-        #
-        # with self.assertRaisesRegex(
-        #         TypeError, 'Visualizations may not be used as inputs.'):
-        #     method(saved_viz, 42)
-        pass
-
-    def test_metadata_passed_as_artifact(self):
-        # TODO: implement
-        pass
-
     def test_primitive_passed_incorrectly(self):
         # generate params
         concatenate_ints = self.plugin.methods['concatenate_ints']
         identity_with_metadata = self.plugin.methods['identity_with_metadata']
         params_only_method = self.plugin.methods['params_only_method']
+
+        md_fp = get_data_path('valid/simple.tsv')
+        inappropriate_metadata = Metadata.load(md_fp)
+
         ints1 = Artifact.import_data(IntSequence1, [0, 42, 43])
-        ints3 = Artifact.import_data(IntSequence1, [99, -22])
+        ints3 = Artifact.import_data(IntSequence1, [12, 111])
         int1 = 4
         int2 = 5
         arbitrary_int = 43
@@ -138,6 +129,11 @@ class TestBadInputs(TestPluginBase):
         with self.assertRaisesRegex(TypeError,
                                     'age.*arbitraryString.*incompatible.*Int'):
             params_only_method('key string', 'arbitraryString')
+
+        # tests metadata passed as artifact
+        with self.assertRaisesRegex(TypeError,
+                                    '\'ints2\'.*Metadata.*IntSequence1'):
+            concatenate_ints(ints1, inappropriate_metadata, ints3, int1, int2)
 
     def test_primitive_param_out_of_range(self):
         # TODO: use params_only_viz

--- a/qiime2/sdk/tests/test_bad_inputs.py
+++ b/qiime2/sdk/tests/test_bad_inputs.py
@@ -24,10 +24,8 @@ from qiime2.metadata.tests.test_io import get_data_path
 class TestBadInputs(TestPluginBase):
 
     def make_provenance_capture(self):
-        # Copy-pasted from qiime2.sdk.TestResult.make_provenance_capture.
-        # Comment retained for searchability
-        # You can't actually import a visualization, but I won't tell
-        # visualization if you don't...
+        # importing visualizations is not supported, but we do that here to
+        # simplify testing machinery
         return archive.ImportProvenanceCapture()
 
     def setUp(self):
@@ -44,7 +42,6 @@ class TestBadInputs(TestPluginBase):
         self.test_dir.cleanup()
 
     def test_viz_passed_as_input(self):
-        # generate a sample viz and other params
         saved_viz = Visualization._from_data_dir(
             self.data_dir, self.make_provenance_capture())
         method = self.plugin.methods['optional_artifacts_method']
@@ -67,7 +64,6 @@ class TestBadInputs(TestPluginBase):
             method(ints1, metadata=saved_viz)
 
     def test_artifact_passed_incorrectly(self):
-        # generate params
         concatenate_ints = self.plugin.methods['concatenate_ints']
         identity_with_metadata = self.plugin.methods['identity_with_metadata']
         ints1 = Artifact.import_data(IntSequence1, [0, 42, 43])
@@ -93,7 +89,6 @@ class TestBadInputs(TestPluginBase):
             concatenate_ints(ints1, ints2, inappropriate_Artifact, int1, int2)
 
     def test_primitive_passed_incorrectly(self):
-        # generate params
         concatenate_ints = self.plugin.methods['concatenate_ints']
         identity_with_metadata = self.plugin.methods['identity_with_metadata']
         params_only_method = self.plugin.methods['params_only_method']

--- a/qiime2/sdk/tests/test_bad_inputs.py
+++ b/qiime2/sdk/tests/test_bad_inputs.py
@@ -10,8 +10,6 @@ import os
 import collections
 import tempfile
 import qiime2.core.archive as archive
-# import qiime2.plugin
-# from qiime2.core.type import MethodSignature, Int
 
 from qiime2.core.testing.util import get_dummy_plugin
 from qiime2.plugin.testing import TestPluginBase
@@ -21,12 +19,6 @@ from qiime2.core.testing.type import IntSequence1, IntSequence2, SingleInt
 from qiime2.core.testing.visualizer import most_common_viz
 from qiime2 import Metadata
 from qiime2.metadata.tests.test_io import get_data_path
-
-# from qiime2.sdk import Method, Results
-# from qiime2.core.testing.method import (concatenate_ints, merge_mappings,
-#                                         split_ints, params_only_method,
-#                                         no_input_method)
-# from qiime2.core.testing.type import (Mapping)
 
 
 class TestBadInputs(TestPluginBase):
@@ -115,7 +107,7 @@ class TestBadInputs(TestPluginBase):
         int2 = 5
         arbitrary_int = 43
 
-        # tests primitive passed as IntSequence artifact
+        # tests primitive int passed as IntSequence artifact
         with self.assertRaisesRegex(TypeError,
                                     'ints2.*43.*incompatible.*IntSequence1'):
             concatenate_ints(ints1, arbitrary_int, ints3, int1, int2)
@@ -145,7 +137,7 @@ class TestBadInputs(TestPluginBase):
         nums = {9, 10}
         bad_range_val = [11, 12, -9999]
 
-        # passes primitive of correct type but out of Range
+        # passes primitive of correct type but outside of Range
         with self.assertRaisesRegex(
                 TypeError, 'opt_nums.*-9999.*incompatible.*List'):
             range_nested_in_list(ints_list, int_set, nums, bad_range_val)

--- a/qiime2/sdk/tests/test_bad_inputs.py
+++ b/qiime2/sdk/tests/test_bad_inputs.py
@@ -147,7 +147,7 @@ class TestBadInputs(TestPluginBase):
         # ... not in a list
         with self.assertRaisesRegex(
                 TypeError,
-                '\'age\'.*-99999.*incompatible.*Int % Range\(0, None\)'):
+                r'\'age\'.*-99999.*incompatible.*Int % Range\(0, None\)'):
             range_not_nested_in_list('John Doe', invalid_age)
 
     def test_primitive_param_not_valid_choice(self):

--- a/qiime2/sdk/tests/test_bad_inputs.py
+++ b/qiime2/sdk/tests/test_bad_inputs.py
@@ -1,0 +1,94 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2019, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os
+import collections
+import tempfile
+import qiime2.core.archive as archive
+# import qiime2.plugin
+# from qiime2.core.type import MethodSignature, Int
+
+from qiime2.core.testing.util import get_dummy_plugin
+from qiime2.plugin.testing import TestPluginBase
+
+from qiime2.sdk import Artifact, Visualization
+from qiime2.core.testing.type import IntSequence1
+from qiime2.core.testing.visualizer import most_common_viz
+
+# from qiime2.sdk import Method, Results
+# from qiime2.core.testing.method import (concatenate_ints, merge_mappings,
+#                                         split_ints, params_only_method,
+#                                         no_input_method)
+# from qiime2.core.testing.type import (IntSequence2, SingleInt, Mapping)
+
+
+class TestBadInputs(TestPluginBase):
+    def make_provenance_capture(self):
+        # You can't actually import a visualization, but I won't tell
+        # visualization if you don't...
+        return archive.ImportProvenanceCapture()
+
+    def setUp(self):
+        self.plugin = get_dummy_plugin()
+
+        # TODO standardize temporary directories created by QIIME 2
+        # create a temporary data_dir for sample Visualizations
+        self.test_dir = tempfile.TemporaryDirectory(prefix='qiime2-test-temp-')
+        self.data_dir = os.path.join(self.test_dir.name, 'viz-output')
+        os.mkdir(self.data_dir)
+        most_common_viz(self.data_dir, collections.Counter(range(42)))
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def test_viz_passed_as_input(self):
+        # generate a sample viz and other params
+        saved_viz = Visualization._from_data_dir(
+            self.data_dir, self.make_provenance_capture())
+        method = self.plugin.methods['optional_artifacts_method']
+        ints1 = Artifact.import_data(IntSequence1, [0, 42, 43])
+
+        # tests Viz passed as primitive parameter
+        with self.assertRaisesRegex(
+                TypeError, 'Visualizations may not be used as inputs.'):
+            method(saved_viz, 42)
+
+        # tests Viz passed as Artifact input
+        with self.assertRaisesRegex(
+                TypeError, 'Visualizations may not be used as inputs.'):
+            method(ints1, 42, optional1=saved_viz)
+
+        # tests Viz passed as metadata
+        method = self.plugin.methods['identity_with_optional_metadata']
+        with self.assertRaisesRegex(
+                TypeError, 'Visualizations may not be used as inputs.'):
+            method(ints1, metadata=saved_viz)
+
+    def test_artifact_passed_as_param(self):
+        # TODO: implement
+        pass
+
+    def test_artifact_passed_as_metadata(self):
+        # TODO: implement
+        pass
+
+    def test_metadata_passed_as_artifact(self):
+        # TODO: implement
+        pass
+
+    def test_primitive_passed_as_input(self):
+        # TODO: implement
+        pass
+
+    def test_primitive_param_out_of_range(self):
+        # TODO: implement
+        pass
+
+    def test_primitive_param_not_valid_choice(self):
+        # TODO: implement
+        pass

--- a/qiime2/sdk/tests/test_bad_inputs.py
+++ b/qiime2/sdk/tests/test_bad_inputs.py
@@ -72,12 +72,31 @@ class TestBadInputs(TestPluginBase):
                 TypeError, 'Visualizations may not be used as inputs.'):
             method(ints1, metadata=saved_viz)
 
-    def test_artifact_passed_as_param(self):
-        # TODO: implement
-        # passed as params
-        # passed as metadata
-        # etc?
-        pass
+    def test_artifact_passed_incorrectly(self):
+        # generate params
+        concatenate_ints = self.plugin.methods['concatenate_ints']
+        identity_with_metadata = self.plugin.methods['identity_with_metadata']
+        ints1 = Artifact.import_data(IntSequence1, [0, 42, 43])
+        ints2 = Artifact.import_data(IntSequence1, [99, -22])
+        ints3 = Artifact.import_data(IntSequence2, [12, 111])
+        inappropriate_Artifact = Artifact.import_data(IntSequence1, [-9999999])
+        int1 = 4
+        int2 = 5
+
+        # tests Artifact passed as integer
+        with self.assertRaisesRegex(
+                TypeError, 'int1.*type Int.*IntSequence1'):
+            concatenate_ints(ints1, ints2, ints3, inappropriate_Artifact, int2)
+
+        # tests Artifact passed as metadata
+        with self.assertRaisesRegex(
+                TypeError, '\'metadata\'.*type Metadata.*IntSequence1'):
+            identity_with_metadata(ints1, inappropriate_Artifact)
+
+        # tests wrong type of Artifact passed
+        with self.assertRaisesRegex(
+                TypeError, 'ints3.*IntSequence2.*IntSequence1'):
+            concatenate_ints(ints1, ints2, inappropriate_Artifact, int1, int2)
 
     def test_incorrect_artifact_type(self):
         # method = self.plugin.methods['optional_artifacts_method']
@@ -90,19 +109,11 @@ class TestBadInputs(TestPluginBase):
         #     method(saved_viz, 42)
         pass
 
-    def test_incorrect_artifact_subtype(self):
-        # TODO: implement
-        pass
-
-    def incorrect_primitive_type(self):
-        # TODO: implement
-        pass
-
     def test_metadata_passed_as_artifact(self):
         # TODO: implement
         pass
 
-    def test_primitive_passed_as_input(self):
+    def test_primitive_passed_incorrectly(self):
         # generate params
         concatenate_ints = self.plugin.methods['concatenate_ints']
         identity_with_metadata = self.plugin.methods['identity_with_metadata']

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -399,7 +399,7 @@ class TestMethod(unittest.TestCase):
         # TODO: break this out into section with other "bad input" tests?
         # Invalid type provided as optional artifact.
         with self.assertRaisesRegex(TypeError,
-                                    'type IntSequence2.*subtype IntSequence1'):
+                                    'type IntSequence1.*type IntSequence2'):
             method(ints1, 42, optional1=ints3)
 
     def test_call_with_variadic_inputs(self):

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -396,6 +396,7 @@ class TestMethod(unittest.TestCase):
 
         self.assertEqual(obs.view(list), [0, 42, 43, 42, 99, -22, 43, 43, 111])
 
+        # TODO: break this out into section with other "bad input" tests?
         # Invalid type provided as optional artifact.
         with self.assertRaisesRegex(TypeError,
                                     'type IntSequence2.*subtype IntSequence1'):

--- a/qiime2/sdk/tests/test_method.py
+++ b/qiime2/sdk/tests/test_method.py
@@ -396,7 +396,6 @@ class TestMethod(unittest.TestCase):
 
         self.assertEqual(obs.view(list), [0, 42, 43, 42, 99, -22, 43, 43, 111])
 
-        # TODO: break this out into section with other "bad input" tests?
         # Invalid type provided as optional artifact.
         with self.assertRaisesRegex(TypeError,
                                     'type IntSequence1.*type IntSequence2'):

--- a/qiime2/sdk/tests/test_visualizer.py
+++ b/qiime2/sdk/tests/test_visualizer.py
@@ -15,7 +15,7 @@ import uuid
 
 import qiime2.plugin
 import qiime2.core.type
-from qiime2.core.type import VisualizerSignature, Str
+from qiime2.core.type import VisualizerSignature, Str, Range
 from qiime2.core.type.visualization import Visualization as VisualizationType
 from qiime2.sdk import Artifact, Visualization, Visualizer, Results
 
@@ -95,7 +95,7 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
             inputs={},
             parameters={
                 'name': qiime2.plugin.Str,
-                'age': qiime2.plugin.Int
+                'age': qiime2.plugin.Int % Range(0, None)
             }
         )
         self.assertEqual(visualizer.signature, exp_sig)
@@ -503,7 +503,7 @@ This visualizer only accepts parameters.
 Parameters
 ----------
 name : Str, optional
-age : Int, optional
+age : Int % Range(0, None), optional
 
 Returns
 -------


### PR DESCRIPTION
fixes #437 

- Fixes type mismatch exception for primitives (e.g. when a string is passed where an int is expected)
- Customizes type mismatch error messages to better describe the user error
- Adds tests to support these changes