### PR TITLE
MAINT: Remove outdated contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,0 @@
-Contributing to QIIME 2
------------------------
-
-QIIME 2 is an open-source project, and we are very interested in contributions from the community. Please get in touch through the [QIIME 2 Forum](https://forum.qiime2.org) if you'd like to get involved.


### PR DESCRIPTION
This guide is not up to date, and is causing more confusion than it is worth right now. The "main" contributing guide can be found in the `.github` dir, anyway.