### PR TITLE
BUG: Improve error message for overlong metadata column names

### DIFF
--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -48,7 +48,6 @@ class MetadataReader:
 
         self._filepath = filepath
 
-        # Used by `read()` to store an iterator yielding rows with
         # leading/trailing whitespace stripped from their cells (this is a
         # preprocessing step that should happen with *every* row). The iterator
         # protocol is the only guaranteed API on this object.
@@ -183,7 +182,10 @@ class MetadataReader:
                     "Metadata column name %r conflicts with a name reserved "
                     "for the ID column header. Reserved ID column headers:"
                     "\n\n%s" % (column_name, FORMATTED_ID_HEADERS))
-
+            if len(column_name) > 200:
+                raise MetadataFileError(
+                    f"Metadata column name {column_name} exceeds maximum "
+                    "column name length of 200")
         return header
 
     def _read_directives(self, header):

--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -184,7 +184,7 @@ class MetadataReader:
                     "\n\n%s" % (column_name, FORMATTED_ID_HEADERS))
             if len(column_name) > 200:
                 raise MetadataFileError(
-                    f"Metadata column name {column_name} exceeds maximum "
+                    f"Metadata column name {column_name!r} exceeds maximum "
                     "column name length of 200")
         return header
 

--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -48,6 +48,7 @@ class MetadataReader:
 
         self._filepath = filepath
 
+        # Used by `read()` to store an iterator yielding rows with
         # leading/trailing whitespace stripped from their cells (this is a
         # preprocessing step that should happen with *every* row). The iterator
         # protocol is the only guaranteed API on this object.


### PR DESCRIPTION
Closes #463. Currently all this does is check if any of the metadata column names are >200 characters long and tells the user they're too long if they are. Two potential issues with this approach are:
1. If the directory the file is saving to has a filename length limit of less than 200 (not likely)
2. If whatever we add to the header name before making it a filename makes it longer than acceptable  (example https://github.com/qiime2/q2-diversity/blob/88d3f42b34b2b8e74e79c2a48b3ce794aa596f1d/q2_diversity/_alpha/_visualizer.py#L113), but this is also unlikely because the maximum filename length seems to generally be 255 characters and I doubt we'll ever be adding 56+ characters.
I'll add some tests to this once we've finalized an approach. @ebolyen proposed some potentially more sweeping changes to this sort of system when this issue was initially brought up, so we will see.
