### PR TITLE
HACK: pinning pandas 0.24.2 for 2019.7 release

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,7 +20,8 @@ requirements:
     - python {{ python }}
     - pyyaml
     - decorator
-    - pandas
+    # TODO: unset this pin once pandas 0.25.x is sorted out
+    - pandas 0.24.2
     - tzlocal
     - python-dateutil
     - pyparsing ==2.3.0


### PR DESCRIPTION
0.25.x is out, but let's save that jump for the 2019.10 release cycle...