### PR TITLE
BUG: Handle primitive unions in provenance

### DIFF
--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -390,7 +390,7 @@ class ActionProvenanceCapture(ProvenanceCapture):
             # TODO: handle collection primitives (not currently used)
         }
 
-        handler = type_map.get(type_expr.to_ast()['name'], lambda x: x)
+        handler = type_map.get(type_expr.to_ast().get('name'), lambda x: x)
         self.parameters[name] = handler(parameter)
 
     def add_input(self, name, input):

--- a/qiime2/core/archive/tests/test_provenance.py
+++ b/qiime2/core/archive/tests/test_provenance.py
@@ -238,6 +238,17 @@ class TestProvenanceIntegration(unittest.TestCase):
         self.assertIn('ints: %s' % ints.uuid, actual_method_yaml)
         self.assertIn('action: split_ints', actual_method_yaml)
 
+    def test_unioned_primitives(self):
+        r = dummy_plugin.actions.unioned_primitives(3, 2)
+
+        prov_dir = r.out._archiver.provenance_dir
+
+        with (prov_dir / 'action' / 'action.yaml').open() as fh:
+            prov_yml = fh.read()
+
+        self.assertIn('foo: 3', prov_yml)
+        self.assertIn('bar: 2', prov_yml)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -40,6 +40,11 @@ def params_only_method(name: str, age: int) -> dict:
     return {name: age}
 
 
+# Unioned primitives
+def unioned_primitives(foo: int, bar: str = 'auto_bar') -> dict:
+    return {'foo': foo, 'bar': bar}
+
+
 # No input artifacts or parameters.
 def no_input_method() -> dict:
     return {'foo': 42}

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -38,7 +38,8 @@ from .method import (concatenate_ints, split_ints, merge_mappings,
                      identity_with_optional_metadata_column,
                      params_only_method, no_input_method,
                      optional_artifacts_method, long_description_method,
-                     docstring_order_method, variadic_input_method)
+                     docstring_order_method, variadic_input_method,
+                     unioned_primitives)
 from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
 from .pipeline import (parameter_only_pipeline, typical_pipeline,
@@ -348,6 +349,19 @@ dummy_plugin.methods.register_function(
     description='This method only accepts parameters.'
 )
 
+dummy_plugin.methods.register_function(
+    function=unioned_primitives,
+    inputs={},
+    parameters={
+        'foo': Int % Range(1, None) | Str % Choices(['auto_foo']),
+        'bar': Int % Range(1, None) | Str % Choices(['auto_bar']),
+    },
+    outputs=[
+        ('out', Mapping)
+    ],
+    name='Unioned primitive parameter',
+    description='This method has a unioned primitive parameter'
+)
 
 dummy_plugin.methods.register_function(
     function=no_input_method,

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -90,7 +90,9 @@ class TestPlugin(unittest.TestCase):
                           'combinatorically_mapped_method',
                           'double_bound_variable_method',
                           'bool_flag_swaps_output_method',
-                          'predicates_preserved_method'})
+                          'predicates_preserved_method',
+                          'unioned_primitives',
+                          })
         for action in actions.values():
             self.assertIsInstance(action, qiime2.sdk.Action)
 
@@ -118,7 +120,9 @@ class TestPlugin(unittest.TestCase):
                           'combinatorically_mapped_method',
                           'double_bound_variable_method',
                           'bool_flag_swaps_output_method',
-                          'predicates_preserved_method'})
+                          'predicates_preserved_method',
+                          'unioned_primitives',
+                          })
         for method in methods.values():
             self.assertIsInstance(method, qiime2.sdk.Method)
 


### PR DESCRIPTION
`UnionExpr` doesn't have a `name`, so this bit of the provenance handler was exploding. By switching to the `.get` accessor, we get to opt into the pre-existing identity fallback behavior.