### PR TITLE
IMP: Make path to BoundFile easily accessible through path attribute

### DIFF
--- a/qiime2/plugin/model/directory_format.py
+++ b/qiime2/plugin/model/directory_format.py
@@ -118,6 +118,10 @@ class BoundFile:
             return path
         return bound_path_maker
 
+    @property
+    def path(self):
+        return str(self._directory_format.path)
+
 
 class BoundFileCollection(BoundFile):
     def __init__(self, name, pathspec, format, directory_format, path_maker):

--- a/qiime2/plugin/model/directory_format.py
+++ b/qiime2/plugin/model/directory_format.py
@@ -8,6 +8,7 @@
 
 import re
 import pathlib
+from pathlib import Path
 
 from qiime2.core import transform
 from .base import FormatBase, ValidationError, _check_validation_level
@@ -120,7 +121,7 @@ class BoundFile:
 
     @property
     def path(self):
-        return str(self._directory_format.path)
+        return Path(self._directory_format.path)
 
 
 class BoundFileCollection(BoundFile):

--- a/qiime2/plugin/model/tests/test_dir_format.py
+++ b/qiime2/plugin/model/tests/test_dir_format.py
@@ -1,0 +1,27 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2019, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os
+import unittest
+import tempfile
+
+from qiime2.core.testing.util import get_dummy_plugin
+from qiime2.core.testing.plugin import IntSequenceDirectoryFormat
+
+
+class TestBoundFile(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory(prefix='qiime2-test-temp')
+        self.dummy_plugin = get_dummy_plugin()
+
+    def test_filepath_expected(self):
+        path = os.path.join(self.test_dir.name, 'file')
+        with open(path, 'w') as fh:
+            fh.write('1\n10')
+        format = IntSequenceDirectoryFormat(path, mode='r')
+        self.assertEqual(path, format.file.path)

--- a/qiime2/plugin/model/tests/test_dir_format.py
+++ b/qiime2/plugin/model/tests/test_dir_format.py
@@ -9,6 +9,7 @@
 import os
 import unittest
 import tempfile
+from pathlib import Path
 
 from qiime2.core.testing.plugin import IntSequenceDirectoryFormat
 
@@ -16,7 +17,7 @@ from qiime2.core.testing.plugin import IntSequenceDirectoryFormat
 class TestBoundFile(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.TemporaryDirectory(prefix='qiime2-test-temp')
-        self.path = os.path.join(self.test_dir.name, 'file')
+        self.path = Path(os.path.join(self.test_dir.name, 'file'))
         with open(self.path, 'w') as fh:
             fh.write('1\n10')
         self.format = IntSequenceDirectoryFormat(self.path, mode='r')

--- a/qiime2/plugin/model/tests/test_dir_format.py
+++ b/qiime2/plugin/model/tests/test_dir_format.py
@@ -10,18 +10,19 @@ import os
 import unittest
 import tempfile
 
-from qiime2.core.testing.util import get_dummy_plugin
 from qiime2.core.testing.plugin import IntSequenceDirectoryFormat
 
 
 class TestBoundFile(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.TemporaryDirectory(prefix='qiime2-test-temp')
-        self.dummy_plugin = get_dummy_plugin()
+        self.path = os.path.join(self.test_dir.name, 'file')
+        with open(self.path, 'w') as fh:
+            fh.write('1\n10')
+        self.format = IntSequenceDirectoryFormat(self.path, mode='r')
+
+    def tearDown(self):
+        self.test_dir.cleanup()
 
     def test_filepath_expected(self):
-        path = os.path.join(self.test_dir.name, 'file')
-        with open(path, 'w') as fh:
-            fh.write('1\n10')
-        format = IntSequenceDirectoryFormat(path, mode='r')
-        self.assertEqual(path, format.file.path)
+        self.assertEqual(self.path, self.format.file.path)


### PR DESCRIPTION
Closes #481 by exposing a new `path` parameter on `BoundFile` objects that makes the filepath directly accessible without having to do any digging.
