### PR TITLE
IMP: Add .view method to _FileFormat

### DIFF
--- a/qiime2/plugin/model/file_format.py
+++ b/qiime2/plugin/model/file_format.py
@@ -8,6 +8,7 @@
 
 import abc
 
+from qiime2.core import transform
 from .base import FormatBase, ValidationError, _check_validation_level
 
 
@@ -38,6 +39,13 @@ class _FileFormat(FormatBase, metaclass=abc.ABCMeta):
         else:
             raise NotImplementedError("%r does not implement validate."
                                       % type(self))
+
+    def view(self, view_type):
+        from_type = transform.ModelType.from_view_type(self.__class__)
+        to_type = transform.ModelType.from_view_type(view_type)
+
+        transformation = from_type.make_transformation(to_type)
+        return transformation(self)
 
 
 class TextFileFormat(_FileFormat):

--- a/qiime2/plugin/model/tests/test_file_format.py
+++ b/qiime2/plugin/model/tests/test_file_format.py
@@ -11,6 +11,7 @@ import unittest
 import tempfile
 
 import qiime2.plugin.model as model
+from qiime2.core.testing.util import get_dummy_plugin
 
 
 class TestTextFileFormat(unittest.TestCase):
@@ -57,6 +58,25 @@ class TestTextFileFormat(unittest.TestCase):
 
         with open(str(ff), mode='rb') as fh:
             self.assertEqual(b'S', fh.read(1))
+
+
+class TestFileFormat(unittest.TestCase):
+    def setUp(self):
+        self.dummy_plugin = get_dummy_plugin()
+        self.test_dir = tempfile.TemporaryDirectory(prefix='qiime2-test-temp-')
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def test_view(self):
+        path = os.path.join(self.test_dir.name, 'int')
+        with open(path, 'w') as fh:
+            fh.write('1')
+
+        format = self.dummy_plugin.formats['SingleIntFormat']
+        test = format.format(path, mode='r')
+        number = test.view(int)
+        self.assertEqual(1, number)
 
 
 if __name__ == '__main__':

--- a/qiime2/plugin/model/tests/test_file_format.py
+++ b/qiime2/plugin/model/tests/test_file_format.py
@@ -12,6 +12,7 @@ import tempfile
 
 import qiime2.plugin.model as model
 from qiime2.core.testing.util import get_dummy_plugin
+from qiime2.core.testing.plugin import SingleIntFormat
 
 
 class TestTextFileFormat(unittest.TestCase):
@@ -65,19 +66,23 @@ class TestFileFormat(unittest.TestCase):
         self.dummy_plugin = get_dummy_plugin()
         self.test_dir = tempfile.TemporaryDirectory(prefix='qiime2-test-temp-')
 
-    def tearDown(self):
-        self.test_dir.cleanup()
-
-    def test_view(self):
         path = os.path.join(self.test_dir.name, 'int')
         with open(path, 'w') as fh:
             fh.write('1')
 
-        format = self.dummy_plugin.formats['SingleIntFormat']
-        test = format.format(path, mode='r')
-        number = test.view(int)
+        self.format = SingleIntFormat(path, mode='r')
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def test_view_expected(self):
+        number = self.format.view(int)
         self.assertEqual(1, number)
 
+    def test_view_invalid_type(self):
+        with self.assertRaisesRegex(
+                Exception, "No transformation.*SingleIntFormat.*float"):
+            self.format.view(float)
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/plugin/model/tests/test_file_format.py
+++ b/qiime2/plugin/model/tests/test_file_format.py
@@ -11,7 +11,6 @@ import unittest
 import tempfile
 
 import qiime2.plugin.model as model
-from qiime2.core.testing.util import get_dummy_plugin
 from qiime2.core.testing.plugin import SingleIntFormat
 
 
@@ -63,7 +62,6 @@ class TestTextFileFormat(unittest.TestCase):
 
 class TestFileFormat(unittest.TestCase):
     def setUp(self):
-        self.dummy_plugin = get_dummy_plugin()
         self.test_dir = tempfile.TemporaryDirectory(prefix='qiime2-test-temp-')
 
         path = os.path.join(self.test_dir.name, 'int')
@@ -83,6 +81,7 @@ class TestFileFormat(unittest.TestCase):
         with self.assertRaisesRegex(
                 Exception, "No transformation.*SingleIntFormat.*float"):
             self.format.view(float)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #482 `_FileFormat` objects now have a `.view` method allowing for easy transformation of `_FileFormat` subclasses without them needing to be turned into `BoundFile` objects. I am unsure of how to test this code. Should `.view` tests be added to the tests for every `_FileFormat` subclass testing each of their transformers? Should the `dummy_plugin` be used to test the transformers of the subclasses of `_FileFormat` in `dummy_plugin`?