### PR TITLE
IMP: Metadata constructor now strips whitespace

### DIFF
--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -357,14 +357,14 @@ class Metadata(_MetadataBase):
         super().__init__(dataframe.index)
 
         self._validate_index(dataframe.columns, axis='column')
-        dataframe.index = dataframe.index.str.strip()
-        # Do not attempt to strip empty columns
-        if not dataframe.columns.empty:
-            dataframe.columns = dataframe.columns.str.strip()
+        dataframe.index = dataframe.index.copy().str.strip()
 
         self._dataframe, self._columns = self._normalize_dataframe(dataframe)
 
     def _normalize_dataframe(self, dataframe):
+        # Do not attempt to strip empty columns
+        if not dataframe.columns.empty:
+            dataframe.columns = dataframe.columns.str.strip()
         norm_df = dataframe.copy()
         columns = collections.OrderedDict()
         for column_name, series in dataframe.items():
@@ -876,11 +876,9 @@ class MetadataColumn(_MetadataBase, metaclass=abc.ABCMeta):
                 "%s %r does not support a pandas.Series object with dtype %s" %
                 (self.__class__.__name__, series.name, series.dtype))
 
-        series.index = series.index.str.strip()
-        series.name = series.name.strip()
+        series.index = series.index.copy().str.strip()
+        series.name = series.copy().name.strip()
         self._series = self._normalize_(series)
-        if isinstance(self, CategoricalMetadataColumn):
-            self._series = self._series.str.strip()
 
     def __repr__(self):
         """String summary of the metadata column."""
@@ -1145,7 +1143,9 @@ class CategoricalMetadataColumn(MetadataColumn):
                     "%r of type %r in column %r." %
                     (cls.__name__, value, type(value), series.name))
 
-        return series.apply(normalize, convert_dtype=False)
+        series = series.apply(normalize, convert_dtype=False)
+        series = series.str.strip()
+        return series
 
 
 class NumericMetadataColumn(MetadataColumn):

--- a/qiime2/metadata/tests/test_metadata.py
+++ b/qiime2/metadata/tests/test_metadata.py
@@ -76,22 +76,6 @@ class TestInvalidMetadataConstruction(unittest.TestCase):
                 {'col': [1, 2, 3],
                  '': [4, 5, 6]}, index=pd.Index(['a', 'b', 'c'], name='id')))
 
-    def test_leading_trailing_whitespace_id(self):
-        with self.assertRaisesRegex(ValueError, "metadata ID.*leading or "
-                                                "trailing whitespace.*' b '"):
-            Metadata(pd.DataFrame(
-                {'col': [1, 2, 3]},
-                index=pd.Index(['a', ' b ', 'c'], name='id')))
-
-    def test_leading_trailing_whitespace_column_name(self):
-        with self.assertRaisesRegex(
-                ValueError, "metadata column name.*leading or trailing "
-                            "whitespace.*' col2 '"):
-            Metadata(pd.DataFrame(
-                {'col1': [1, 2, 3],
-                 ' col2 ': [4, 5, 6]},
-                index=pd.Index(['a', 'b', 'c'], name='id')))
-
     def test_pound_sign_id(self):
         with self.assertRaisesRegex(
                 ValueError, "metadata ID.*begins with a pound sign.*'#b'"):
@@ -155,15 +139,6 @@ class TestInvalidMetadataConstruction(unittest.TestCase):
             Metadata(pd.DataFrame(
                 {'col1': [1, 2, 3],
                  'col2': ['foo', '', 'bar']},
-                index=pd.Index(['a', 'b', 'c'], name='id')))
-
-    def test_categorical_column_leading_trailing_whitespace_value(self):
-        with self.assertRaisesRegex(
-                ValueError, "CategoricalMetadataColumn.*leading or trailing "
-                            "whitespace characters.*Column 'col2'.*' bar '"):
-            Metadata(pd.DataFrame(
-                {'col1': [1, 2, 3],
-                 'col2': ['foo', ' bar ', 'baz']},
                 index=pd.Index(['a', 'b', 'c'], name='id')))
 
     def test_numeric_column_infinity(self):
@@ -401,6 +376,38 @@ class TestMetadataConstructionAndProperties(unittest.TestCase):
         metadata = Metadata(df)
 
         self.assertEqual(set(metadata.columns), {'column', 'Column'})
+
+    def test_categorical_column_leading_trailing_whitespace_value(self):
+        md1 = Metadata(pd.DataFrame(
+            {'col1': [1, 2, 3],
+             'col2': ['foo', ' bar ', 'baz']},
+            index=pd.Index(['a', 'b', 'c'], name='id')))
+        md2 = Metadata(pd.DataFrame(
+            {'col1': [1, 2, 3],
+             'col2': ['foo', 'bar', 'baz']},
+            index=pd.Index(['a', 'b', 'c'], name='id')))
+
+        self.assertEqual(md1, md2)
+
+    def test_leading_trailing_whitespace_id(self):
+        md1 = Metadata(pd.DataFrame(
+            {'col1': [1, 2, 3], 'col2': [4, 5, 6]},
+            index=pd.Index(['a', ' b ', 'c'], name='id')))
+        md2 = Metadata(pd.DataFrame(
+            {'col1': [1, 2, 3], 'col2': [4, 5, 6]},
+            index=pd.Index(['a', 'b', 'c'], name='id')))
+
+        self.assertEqual(md1, md2)
+
+    def test_leading_trailing_whitespace_column_name(self):
+        md1 = Metadata(pd.DataFrame(
+            {'col1': [1, 2, 3], ' col2 ': [4, 5, 6]},
+            index=pd.Index(['a', 'b', 'c'], name='id')))
+        md2 = Metadata(pd.DataFrame(
+            {'col1': [1, 2, 3], 'col2': [4, 5, 6]},
+            index=pd.Index(['a', 'b', 'c'], name='id')))
+
+        self.assertEqual(md1, md2)
 
 
 class TestSourceArtifacts(unittest.TestCase):

--- a/qiime2/metadata/tests/test_metadata_column.py
+++ b/qiime2/metadata/tests/test_metadata_column.py
@@ -96,21 +96,6 @@ class TestInvalidMetadataColumnConstruction(unittest.TestCase):
                 [1, 2, 3], name='',
                 index=pd.Index(['a', 'b', 'c'], name='id')))
 
-    def test_leading_trailing_whitespace_id(self):
-        with self.assertRaisesRegex(ValueError, "metadata ID.*leading or "
-                                                "trailing whitespace.*' b '"):
-            DummyMetadataColumn(pd.Series(
-                [1, 2, 3], name='col',
-                index=pd.Index(['a', ' b ', 'c'], name='id')))
-
-    def test_leading_trailing_whitespace_column_name(self):
-        with self.assertRaisesRegex(
-                ValueError, "metadata column name.*leading or trailing "
-                            "whitespace.*' col2 '"):
-            DummyMetadataColumn(pd.Series(
-                [1, 2, 3], name=' col2 ',
-                index=pd.Index(['a', 'b', 'c'], name='id')))
-
     def test_pound_sign_id(self):
         with self.assertRaisesRegex(
                 ValueError, "metadata ID.*begins with a pound sign.*'#b'"):
@@ -254,6 +239,36 @@ class TestMetadataColumnConstructionAndProperties(unittest.TestCase):
         mdc = DummyMetadataColumn(series)
 
         self.assertEqual(mdc.ids, ('a', 'b', 'A'))
+
+    def test_leading_trailing_whitespace_value(self):
+        col1 = CategoricalMetadataColumn(pd.Series(
+            ['foo', ' bar ', 'baz'], name='col1',
+            index=pd.Index(['a', 'b', 'c'], name='id')))
+        col2 = CategoricalMetadataColumn(pd.Series(
+            ['foo', 'bar', 'baz'], name='col1',
+            index=pd.Index(['a', 'b', 'c'], name='id')))
+
+        self.assertEqual(col1, col2)
+
+    def test_leading_trailing_whitespace_id(self):
+        col1 = DummyMetadataColumn(pd.Series(
+                [1, 2, 3], name='col',
+                index=pd.Index(['a', ' b ', 'c'], name='id')))
+        col2 = DummyMetadataColumn(pd.Series(
+                [1, 2, 3], name='col',
+                index=pd.Index(['a', 'b', 'c'], name='id')))
+
+        self.assertEqual(col1, col2)
+
+    def test_leading_trailing_whitespace_column_name(self):
+        col1 = DummyMetadataColumn(pd.Series(
+                [1, 2, 3], name=' col2 ',
+                index=pd.Index(['a', 'b', 'c'], name='id')))
+        col2 = DummyMetadataColumn(pd.Series(
+                [1, 2, 3], name='col2',
+                index=pd.Index(['a', 'b', 'c'], name='id')))
+
+        self.assertEqual(col1, col2)
 
 
 class TestSourceArtifacts(unittest.TestCase):
@@ -824,14 +839,6 @@ class TestCategoricalMetadataColumn(unittest.TestCase):
                             "column 'col1'"):
             CategoricalMetadataColumn(pd.Series(
                 ['foo', '', 'bar'], name='col1',
-                index=pd.Index(['a', 'b', 'c'], name='id')))
-
-    def test_leading_trailing_whitespace_value(self):
-        with self.assertRaisesRegex(
-                ValueError, "CategoricalMetadataColumn.*leading or trailing "
-                            "whitespace characters.*Column 'col1'.*' bar '"):
-            CategoricalMetadataColumn(pd.Series(
-                ['foo', ' bar ', 'baz'], name='col1',
                 index=pd.Index(['a', 'b', 'c'], name='id')))
 
     def test_type_property(self):

--- a/qiime2/metadata/tests/test_metadata_column.py
+++ b/qiime2/metadata/tests/test_metadata_column.py
@@ -240,36 +240,6 @@ class TestMetadataColumnConstructionAndProperties(unittest.TestCase):
 
         self.assertEqual(mdc.ids, ('a', 'b', 'A'))
 
-    def test_leading_trailing_whitespace_value(self):
-        col1 = CategoricalMetadataColumn(pd.Series(
-            ['foo', ' bar ', 'baz'], name='col1',
-            index=pd.Index(['a', 'b', 'c'], name='id')))
-        col2 = CategoricalMetadataColumn(pd.Series(
-            ['foo', 'bar', 'baz'], name='col1',
-            index=pd.Index(['a', 'b', 'c'], name='id')))
-
-        self.assertEqual(col1, col2)
-
-    def test_leading_trailing_whitespace_id(self):
-        col1 = DummyMetadataColumn(pd.Series(
-                [1, 2, 3], name='col',
-                index=pd.Index(['a', ' b ', 'c'], name='id')))
-        col2 = DummyMetadataColumn(pd.Series(
-                [1, 2, 3], name='col',
-                index=pd.Index(['a', 'b', 'c'], name='id')))
-
-        self.assertEqual(col1, col2)
-
-    def test_leading_trailing_whitespace_column_name(self):
-        col1 = DummyMetadataColumn(pd.Series(
-                [1, 2, 3], name=' col2 ',
-                index=pd.Index(['a', 'b', 'c'], name='id')))
-        col2 = DummyMetadataColumn(pd.Series(
-                [1, 2, 3], name='col2',
-                index=pd.Index(['a', 'b', 'c'], name='id')))
-
-        self.assertEqual(col1, col2)
-
 
 class TestSourceArtifacts(unittest.TestCase):
     def setUp(self):
@@ -905,6 +875,36 @@ class TestCategoricalMetadataColumn(unittest.TestCase):
 
         pdt.assert_series_equal(obs, exp)
         self.assertEqual(obs.dtype, object)
+
+    def test_leading_trailing_whitespace_value(self):
+        col1 = CategoricalMetadataColumn(pd.Series(
+            ['foo', ' bar ', 'baz'], name='col1',
+            index=pd.Index(['a', 'b', 'c'], name='id')))
+        col2 = CategoricalMetadataColumn(pd.Series(
+            ['foo', 'bar', 'baz'], name='col1',
+            index=pd.Index(['a', 'b', 'c'], name='id')))
+
+        self.assertEqual(col1, col2)
+
+    def test_leading_trailing_whitespace_id(self):
+        col1 = CategoricalMetadataColumn(pd.Series(
+                ['foo', ' bar ', 'baz'], name='col',
+                index=pd.Index(['a', ' b ', 'c'], name='id')))
+        col2 = CategoricalMetadataColumn(pd.Series(
+                ['foo', ' bar ', 'baz'], name='col',
+                index=pd.Index(['a', 'b', 'c'], name='id')))
+
+        self.assertEqual(col1, col2)
+
+    def test_leading_trailing_whitespace_column_name(self):
+        col1 = CategoricalMetadataColumn(pd.Series(
+                ['foo', ' bar ', 'baz'], name=' col ',
+                index=pd.Index(['a', 'b', 'c'], name='id')))
+        col2 = CategoricalMetadataColumn(pd.Series(
+                ['foo', ' bar ', 'baz'], name='col',
+                index=pd.Index(['a', 'b', 'c'], name='id')))
+
+        self.assertEqual(col1, col2)
 
 
 class TestNumericMetadataColumn(unittest.TestCase):


### PR DESCRIPTION
Closes #478. Strips all white space from all pieces of the Metadata