### PR TITLE
IMP: convert MetadataColumn to Metadata

### DIFF
--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -994,6 +994,16 @@ class MetadataColumn(_MetadataBase, metaclass=abc.ABCMeta):
         """
         return self._series.to_frame()
 
+    def to_metadata(self):
+        """Create a metadata object from the metadata column
+
+        Returns
+        -------
+        Metadata
+            Metadata constructed from the metadata column.
+        """
+        return Metadata(self.to_dataframe())
+
     def get_value(self, id):
         """Retrieve metadata column value associated with an ID.
 

--- a/qiime2/metadata/tests/test_metadata_column.py
+++ b/qiime2/metadata/tests/test_metadata_column.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from qiime2 import Artifact
 from qiime2.metadata import (MetadataColumn, CategoricalMetadataColumn,
-                             NumericMetadataColumn)
+                             NumericMetadataColumn, Metadata)
 from qiime2.core.testing.util import get_dummy_plugin, ReallyEqualMixin
 
 
@@ -254,6 +254,26 @@ class TestMetadataColumnConstructionAndProperties(unittest.TestCase):
         mdc = DummyMetadataColumn(series)
 
         self.assertEqual(mdc.ids, ('a', 'b', 'A'))
+
+    def test_to_metadata(self):
+        index = pd.Index(['id1'], name='id')
+        series = pd.Series([42], name='col1', index=index)
+        mdc = DummyMetadataColumn(series)
+        df = pd.DataFrame(series)
+        md = Metadata(df)
+        md2 = mdc.to_metadata()
+
+        self.assertEqual(md, md2)
+
+    def test_to_metadata_artifacts(self):
+        index = pd.Index(['id1'], name='id')
+        series = pd.Series([42], name='col1', index=index)
+        mdc = DummyMetadataColumn(series)
+        df = pd.DataFrame(series)
+        md = Metadata(df)
+        md2 = mdc.to_metadata()
+
+        self.assertEqual(md.artifacts, md2.artifacts)
 
 
 class TestSourceArtifacts(unittest.TestCase):


### PR DESCRIPTION
Closes #487 Adds a method to convert `MetadataColumns` to `Metadata`