### PR TITLE
HACK: Unpin pandas to v0.25.1 to determine plugin issues

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - python {{ python }}
     - pyyaml
     - decorator
-    - pandas 0.25.1
     - tzlocal
     - python-dateutil
     - pyparsing ==2.3.0

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python {{ python }}
     - pyyaml
     - decorator
+    - pandas
     - tzlocal
     - python-dateutil
     - pyparsing ==2.3.0

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pyyaml
     - decorator
     # TODO: unset this pin once pandas 0.25.x is sorted out
-    - pandas 0.24.2
+    - pandas 0.25.1
     - tzlocal
     - python-dateutil
     - pyparsing ==2.3.0

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - python {{ python }}
     - pyyaml
     - decorator
-    # TODO: unset this pin once pandas 0.25.x is sorted out
     - pandas 0.25.1
     - tzlocal
     - python-dateutil


### PR DESCRIPTION
Unpin pandas to determine build issues regarding QIIME 2 plugins and busywork.
