### PR TITLE
IMP: Max validate FileFormat on construction

### DIFF
--- a/qiime2/core/format.py
+++ b/qiime2/core/format.py
@@ -19,6 +19,8 @@ class FormatBase:
             if mode != 'r':
                 raise ValueError("A path must be omitted when writing.")
 
+        self._mode = mode
+
         if mode == 'w':
             self.path = qpath.OutPath(
                 # TODO: parents shouldn't know about their children
@@ -26,8 +28,10 @@ class FormatBase:
                 prefix='q2-%s-' % self.__class__.__name__)
         else:
             self.path = qpath.InPath(path)
-
-        self._mode = mode
+            # Check for _validate_ because some classes have a dummy
+            # implementation of validate to raise NotImplemented errors
+            if hasattr(self, '_validate_'):
+                self.validate()
 
     def __str__(self):
         return str(self.path)

--- a/qiime2/core/format.py
+++ b/qiime2/core/format.py
@@ -19,6 +19,8 @@ class FormatBase:
             if mode != 'r':
                 raise ValueError("A path must be omitted when writing.")
 
+        # Mode has to be set here so objects don't fail validation for not
+        # having a `.mode` attribute
         self._mode = mode
 
         if mode == 'w':

--- a/qiime2/sdk/tests/test_artifact.py
+++ b/qiime2/sdk/tests/test_artifact.py
@@ -501,17 +501,17 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
         self.assertTrue(True)  # Checkpoint assertion
         A.validate(level='max')
         self.assertTrue(True)  # Checkpoint assertion
-        A = Artifact.import_data('IntSequence1', [1, 2, 3, 4, 5, 6, 7, 10])
         with self.assertRaisesRegex(ValidationError, '3 more'):
-            A.validate(level='max')
+            Artifact.import_data('IntSequence1', [1, 2, 3, 4, 5, 6, 7, 10])
 
     def test_artifact_validate_max_on_import(self):
         fp = get_data_path('intsequence-fail-max-validation.txt')
-        fmt = IntSequenceFormat(fp, mode='r')
-        fmt.validate(level='min')
+        # This has become impossible to test because max validate is run on
+        # creation
+        # fmt.validate(level='min')
         self.assertTrue(True)  # Checkpoint assertion
         with self.assertRaisesRegex(ValidationError, '3 more'):
-            Artifact.import_data('IntSequence1', fp)
+            IntSequenceFormat(fp, mode='r')
 
     def test_artifact_validate_min(self):
         A = Artifact.import_data('IntSequence1', [1, 2, 3, 4])


### PR DESCRIPTION
Closes #490 

This PR should get the ball rolling on validating  `_FileFormat` on construction, it should also serve to expose some of the issues currently facing this idea. This current PR works by max validating all objects created in 'r' mode using the `FormatBase` constructor
1. First of all as @ebolyen said here https://github.com/qiime2/qiime2/issues/490#issuecomment-530002158 we may not want to max validate every `FormatBase` that comes out of a transformer, we already min validate all of them by default when using the transformation API. I'm not sure why we chose min over max though. I suppose time efficiency.
2. We can no longer create invalid test data of any `FormatBase` derivative. This is only problematic when we are intentionally creating invalid objects, and usually all it means is putting the object creation inside of the `assertRaisesRegex` instead of an explicit `object.validate`, but it does prevent us from actually doing anything with these intentionally broken `FormatBase` objects. For example, one of the tests I changed created an object, asserted that it passed min validation, and then that it failed max validation. This cannot be done anymore as max validation is called on creation.
3. As a result of point 2, all tests using intentionally broken `FormatBase` objects in all repos (no idea how many of these there are) will fail and then have to be changed. Fortunately, all tests using unintentionally broken `FormatBase` objects will also fail.
4. This only works to validate objects created in 'r' mode because those created in 'w' mode have nothing to validate and will always fail until after initialization as they have yet to be set up in any meaningful way.