### PR TITLE
NEW: Expose plugin level importable types set through sdk

### DIFF
--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -63,9 +63,10 @@ dummy_plugin = Plugin(
 import_module('qiime2.core.testing.transformer')
 
 # Register semantic types
-dummy_plugin.register_type_fragments(IntSequence1, IntSequence2, Mapping,
-                                     FourInts, Kennel, Dog, Cat, SingleInt, C1,
-                                     C2, C3, Foo, Bar, Baz)
+dummy_plugin.register_semantic_type_fragments(IntSequence1, IntSequence2,
+                                              Mapping, FourInts, Kennel, Dog,
+                                              Cat, SingleInt, C1, C2, C3, Foo,
+                                              Bar, Baz)
 
 # Register formats
 dummy_plugin.register_formats(

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -63,10 +63,9 @@ dummy_plugin = Plugin(
 import_module('qiime2.core.testing.transformer')
 
 # Register semantic types
-dummy_plugin.register_semantic_type_fragments(IntSequence1, IntSequence2,
-                                              Mapping, FourInts, Kennel, Dog,
-                                              Cat, SingleInt, C1, C2, C3, Foo,
-                                              Bar, Baz)
+dummy_plugin.register_type_fragments(IntSequence1, IntSequence2, Mapping,
+                                     FourInts, Kennel, Dog, Cat, SingleInt, C1,
+                                     C2, C3, Foo, Bar, Baz)
 
 # Register formats
 dummy_plugin.register_formats(

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -63,10 +63,9 @@ dummy_plugin = Plugin(
 import_module('qiime2.core.testing.transformer')
 
 # Register semantic types
-dummy_plugin.register_semantic_type_fragments(IntSequence1, IntSequence2,
-                                              Mapping, FourInts, Kennel, Dog,
-                                              Cat, SingleInt, C1, C2, C3, Foo,
-                                              Bar, Baz)
+dummy_plugin.register_semantic_types(IntSequence1, IntSequence2, Mapping,
+                                     FourInts, Kennel, Dog, Cat, SingleInt, C1,
+                                     C2, C3, Foo, Bar, Baz)
 
 # Register formats
 dummy_plugin.register_formats(

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -63,9 +63,10 @@ dummy_plugin = Plugin(
 import_module('qiime2.core.testing.transformer')
 
 # Register semantic types
-dummy_plugin.register_semantic_types(IntSequence1, IntSequence2, Mapping,
-                                     FourInts, Kennel, Dog, Cat, SingleInt,
-                                     C1, C2, C3, Foo, Bar, Baz)
+dummy_plugin.register_semantic_type_fragments(IntSequence1, IntSequence2,
+                                              Mapping, FourInts, Kennel, Dog,
+                                              Cat, SingleInt, C1, C2, C3, Foo,
+                                              Bar, Baz)
 
 # Register formats
 dummy_plugin.register_formats(

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -64,8 +64,8 @@ import_module('qiime2.core.testing.transformer')
 
 # Register semantic types
 dummy_plugin.register_semantic_types(IntSequence1, IntSequence2, Mapping,
-                                     FourInts, Kennel, Dog, Cat, SingleInt, C1,
-                                     C2, C3, Foo, Bar, Baz)
+                                     FourInts, Kennel, Dog, Cat, SingleInt,
+                                     C1, C2, C3, Foo, Bar, Baz)
 
 # Register formats
 dummy_plugin.register_formats(

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -207,8 +207,8 @@ class Plugin:
             format=artifact_format, plugin=self)
 
         self.type_formats.append(record)
-        for type in record.type_expression:
-            self.importable_types.add(type)
+        for type_ in record.type_expression:
+            self.importable_types.add(type_)
 
 
 class PluginActions(dict):

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -70,6 +70,7 @@ class Plugin:
         self.types = {}
         self.transformers = {}
         self.type_formats = []
+        self.importable_types = set()
 
     @property
     def actions(self):
@@ -201,9 +202,13 @@ class Plugin:
                 raise ValueError("%r has a predicate, differentiating format"
                                  " on predicate is not supported.")
 
-        self.type_formats.append(TypeFormatRecord(
+        record = TypeFormatRecord(
             type_expression=semantic_type,
-            format=artifact_format, plugin=self))
+            format=artifact_format, plugin=self)
+
+        self.type_formats.append(record)
+        for type in record.type_expression:
+            self.importable_types.add(type)
 
 
 class PluginActions(dict):

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -22,7 +22,7 @@ TransformerRecord = collections.namedtuple(
 SemanticTypeRecord = collections.namedtuple(
     'SemanticTypeRecord', ['semantic_type', 'plugin'])
 SemanticTypeFragmentRecord = collections.namedtuple(
-    'SemanticTypeRecord', ['semantic_type', 'plugin'])
+    'SemanticTypeRecord', ['fragment', 'plugin'])
 FormatRecord = collections.namedtuple('FormatRecord', ['format', 'plugin'])
 ViewRecord = collections.namedtuple(
     'ViewRecord', ['name', 'view', 'plugin', 'citations'])
@@ -184,7 +184,7 @@ class Plugin:
                 raise ValueError("%r is not a semantic type symbol."
                                  % type_fragment)
 
-            if type_fragment.name in self.types:
+            if type_fragment.name in self.type_fragments:
                 raise ValueError("Duplicate semantic type symbol %r."
                                  % type_fragment)
 

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -21,6 +21,8 @@ TransformerRecord = collections.namedtuple(
     'TransformerRecord', ['transformer', 'plugin', 'citations'])
 SemanticTypeRecord = collections.namedtuple(
     'SemanticTypeRecord', ['semantic_type', 'plugin'])
+SemanticTypeFragmentRecord = collections.namedtuple(
+    'SemanticTypeRecord', ['semantic_type', 'plugin'])
 FormatRecord = collections.namedtuple('FormatRecord', ['format', 'plugin'])
 ViewRecord = collections.namedtuple(
     'ViewRecord', ['name', 'view', 'plugin', 'citations'])
@@ -67,7 +69,7 @@ class Plugin:
 
         self.formats = {}
         self.views = {}
-        self.types = {}
+        self.type_fragments = {}
         self.transformers = {}
         self.type_formats = []
         self.importable_types = set()
@@ -171,23 +173,24 @@ class Plugin:
             # Apply the decorator as we were applied with a single function
             return decorator(_fn)
 
-    def register_semantic_types(self, *semantic_types):
-        for semantic_type in semantic_types:
-            if not is_semantic_type(semantic_type):
-                raise TypeError("%r is not a semantic type." % semantic_type)
+    def register_semantic_type_fragments(self, *semantic_type_fragments):
+        for type_fragment in semantic_type_fragments:
+            if not is_semantic_type(type_fragment):
+                raise TypeError("%r is not a semantic type." % type_fragment)
 
-            if not (isinstance(semantic_type, grammar.IncompleteExp) or
-                    (semantic_type.is_concrete() and
-                    not semantic_type.fields)):
+            if not (isinstance(type_fragment, grammar.IncompleteExp) or
+                    (type_fragment.is_concrete() and
+                    not type_fragment.fields)):
                 raise ValueError("%r is not a semantic type symbol."
-                                 % semantic_type)
+                                 % type_fragment)
 
-            if semantic_type.name in self.types:
+            if type_fragment.name in self.types:
                 raise ValueError("Duplicate semantic type symbol %r."
-                                 % semantic_type)
+                                 % type_fragment)
 
-            self.types[semantic_type.name] = SemanticTypeRecord(
-                semantic_type=semantic_type, plugin=self)
+            self.type_fragments[type_fragment.name] = \
+                SemanticTypeFragmentRecord(
+                    fragment=type_fragment, plugin=self)
 
     def register_semantic_type_to_format(self, semantic_type, artifact_format):
         if not issubclass(artifact_format, DirectoryFormat):

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -72,7 +72,7 @@ class Plugin:
         self.type_fragments = {}
         self.transformers = {}
         self.type_formats = []
-        self.importable_types = set()
+        self.types = set()
 
     @property
     def actions(self):
@@ -211,7 +211,8 @@ class Plugin:
 
         self.type_formats.append(record)
         for type_ in record.type_expression:
-            self.importable_types.add(type_)
+            self.types.add(SemanticTypeRecord(
+                semantic_type=type_, plugin=self))
 
 
 class PluginActions(dict):

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -173,7 +173,7 @@ class Plugin:
             # Apply the decorator as we were applied with a single function
             return decorator(_fn)
 
-    def register_type_fragments(self, *type_fragments):
+    def register_semantic_type_fragments(self, *type_fragments):
         for type_fragment in type_fragments:
             if not is_semantic_type(type_fragment):
                 raise TypeError("%r is not a semantic type." % type_fragment)

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -173,7 +173,7 @@ class Plugin:
             # Apply the decorator as we were applied with a single function
             return decorator(_fn)
 
-    def register_semantic_type_fragments(self, *type_fragments):
+    def register_semantic_types(self, *type_fragments):
         for type_fragment in type_fragments:
             if not is_semantic_type(type_fragment):
                 raise TypeError("%r is not a semantic type." % type_fragment)

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -173,8 +173,8 @@ class Plugin:
             # Apply the decorator as we were applied with a single function
             return decorator(_fn)
 
-    def register_semantic_type_fragments(self, *semantic_type_fragments):
-        for type_fragment in semantic_type_fragments:
+    def register_type_fragments(self, *type_fragments):
+        for type_fragment in type_fragments:
             if not is_semantic_type(type_fragment):
                 raise TypeError("%r is not a semantic type." % type_fragment)
 

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -151,7 +151,7 @@ class TestPlugin(unittest.TestCase):
     # TODO test registration of directory formats.
 
     def test_types(self):
-        types = self.plugin.types.keys()
+        types = self.plugin.type_fragments.keys()
 
         self.assertEqual(
             set(types),

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -13,8 +13,7 @@ import qiime2.plugin
 import qiime2.sdk
 
 from qiime2.core.testing.type import (IntSequence1, IntSequence2, Mapping,
-                                      FourInts, Kennel, Dog, Cat, SingleInt,
-                                      C1, C2, C3, Foo, Bar, Baz)
+                                      FourInts, Kennel, Dog, Cat, SingleInt)
 from qiime2.core.testing.util import get_dummy_plugin
 
 

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -12,6 +12,9 @@ import unittest
 import qiime2.plugin
 import qiime2.sdk
 
+from qiime2.core.testing.type import (IntSequence1, IntSequence2, Mapping,
+                                      FourInts, Kennel, Dog, Cat, SingleInt,
+                                      C1, C2, C3, Foo, Bar, Baz)
 from qiime2.core.testing.util import get_dummy_plugin
 
 
@@ -150,7 +153,7 @@ class TestPlugin(unittest.TestCase):
 
     # TODO test registration of directory formats.
 
-    def test_types(self):
+    def test_type_fragments(self):
         types = self.plugin.type_fragments.keys()
 
         self.assertEqual(
@@ -158,6 +161,18 @@ class TestPlugin(unittest.TestCase):
             set(['IntSequence1', 'IntSequence2', 'Mapping', 'FourInts',
                  'Kennel', 'Dog', 'Cat', 'SingleInt', 'C1', 'C2', 'C3',
                  'Foo', 'Bar', 'Baz']))
+
+    def test_types(self):
+        types = self.plugin.types
+        # Get just the types out of the SemanticTypeRecord namedtuples
+        types = {type_.semantic_type for type_ in types}
+
+        exp = {IntSequence1, IntSequence2, FourInts, Mapping, Kennel[Dog],
+               Kennel[Cat], SingleInt}
+        self.assertLessEqual(exp, types)
+        self.assertNotIn(Cat, types)
+        self.assertNotIn(Dog, types)
+        self.assertNotIn(Kennel, types)
 
 
 if __name__ == '__main__':

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -47,7 +47,7 @@ class PluginManager:
 
     def _init(self):
         self.plugins = {}
-        self.semantic_type_fragments = {}
+        self.type_fragments = {}
         self.transformers = collections.defaultdict(dict)
         self.formats = {}
         self.views = {}
@@ -65,15 +65,15 @@ class PluginManager:
 
     def _integrate_plugin(self, plugin):
         for type_name, type_record in plugin.type_fragments.items():
-            if type_name in self.semantic_type_fragments:
+            if type_name in self.type_fragments:
                 conflicting_type_record = \
-                    self.semantic_type_fragments[type_name]
+                    self.type_fragments[type_name]
                 raise ValueError("Duplicate semantic type (%r) defined in"
                                  " plugins: %r and %r"
                                  % (type_name, type_record.plugin.name,
                                     conflicting_type_record.plugin.name))
 
-            self.semantic_type_fragments[type_name] = type_record
+            self.type_fragments[type_name] = type_record
 
         for (input, output), transformer_record in plugin.transformers.items():
             if output in self.transformers[input]:

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -52,7 +52,7 @@ class PluginManager:
         self.formats = {}
         self.views = {}
         self.type_formats = []
-        self.importable_types = set()
+        self.types = {}
 
         # These are all dependent loops, each requires the loop above it to
         # be completed.
@@ -101,25 +101,20 @@ class PluginManager:
 
             self.formats[name] = record
         self.type_formats.extend(plugin.type_formats)
-        self.importable_types.update(plugin.importable_types)
+        self.types[plugin.name] = plugin.types
 
     # TODO: Should plugin loading be transactional? i.e. if there's
     # something wrong, the entire plugin fails to load any piece, like a
     # databases rollback/commit
 
-    @property
     def get_semantic_types(self, *, plugin=None):
-        from qiime2.plugin import SemanticTypeRecord
-
         types = set()
 
         plugins = [plugin] if plugin else self.plugins
 
-        for plugin in plugins:
-            for name, record in plugin.type_fragments.items():
-                for _type in record.type_expression:
-                    types.add(SemanticTypeRecord(
-                        semantic_type=_type, plugin=plugin))
+        for plugin in plugins.values():
+            for type_record in plugin.types:
+                types.add(type_record.semantic_type)
 
         return types
 

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -64,7 +64,7 @@ class PluginManager:
             self._integrate_plugin(plugin)
 
     def _integrate_plugin(self, plugin):
-        for type_name, type_record in plugin.types.items():
+        for type_name, type_record in plugin.type_fragments.items():
             if type_name in self.semantic_types:
                 conflicting_type_record = self.semantic_types[type_name]
                 raise ValueError("Duplicate semantic type (%r) defined in"

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -47,7 +47,7 @@ class PluginManager:
 
     def _init(self):
         self.plugins = {}
-        self.semantic_types = {}
+        self.semantic_type_fragments = {}
         self.transformers = collections.defaultdict(dict)
         self.formats = {}
         self.views = {}
@@ -65,14 +65,15 @@ class PluginManager:
 
     def _integrate_plugin(self, plugin):
         for type_name, type_record in plugin.type_fragments.items():
-            if type_name in self.semantic_types:
-                conflicting_type_record = self.semantic_types[type_name]
+            if type_name in self.semantic_type_fragments:
+                conflicting_type_record = \
+                    self.semantic_type_fragments[type_name]
                 raise ValueError("Duplicate semantic type (%r) defined in"
                                  " plugins: %r and %r"
                                  % (type_name, type_record.plugin.name,
                                     conflicting_type_record.plugin.name))
 
-            self.semantic_types[type_name] = type_record
+            self.semantic_type_fragments[type_name] = type_record
 
         for (input, output), transformer_record in plugin.transformers.items():
             if output in self.transformers[input]:

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -52,6 +52,7 @@ class PluginManager:
         self.formats = {}
         self.views = {}
         self.type_formats = []
+        self.importable_types = set()
 
         # These are all dependent loops, each requires the loop above it to
         # be completed.
@@ -100,6 +101,7 @@ class PluginManager:
 
             self.formats[name] = record
         self.type_formats.extend(plugin.type_formats)
+        self.importable_types.update(plugin.importable_types)
 
     # TODO: Should plugin loading be transactional? i.e. if there's
     # something wrong, the entire plugin fails to load any piece, like a
@@ -124,20 +126,6 @@ class PluginManager:
                     importable_formats[name] = record
                     break
         return importable_formats
-
-    @property
-    def importable_types(self):
-        """Return set of concrete semantic types that are importable.
-
-        A concrete semantic type is importable if it has an associated
-        directory format.
-
-        """
-        importable_types = set()
-        for type_format in self.type_formats:
-            for type in type_format.type_expression:
-                importable_types.add(type)
-        return importable_types
 
     def get_directory_format(self, semantic_type):
         if not qiime2.core.type.is_semantic_type(semantic_type):

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -108,6 +108,22 @@ class PluginManager:
     # databases rollback/commit
 
     @property
+    def get_semantic_types(self, *, plugin=None):
+        from qiime2.plugin import SemanticTypeRecord
+
+        types = set()
+
+        plugins = [plugin] if plugin else self.plugins
+
+        for plugin in plugins:
+            for name, record in plugin.type_fragments.items():
+                for _type in record.type_expression:
+                    types.add(SemanticTypeRecord(
+                        semantic_type=_type, plugin=plugin))
+
+        return types
+
+    @property
     def importable_formats(self):
         """Return formats that are importable.
 

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -39,8 +39,8 @@ class TestPluginManager(unittest.TestCase):
         exp = {'dummy-plugin': self.plugin}
         self.assertEqual(plugins, exp)
 
-    def test_semantic_type_fragments(self):
-        types = self.pm.semantic_type_fragments
+    def test_type_fragments(self):
+        types = self.pm.type_fragments
 
         exp = {
             'IntSequence1': SemanticTypeRecord(semantic_type=IntSequence1,

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -76,7 +76,7 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(types, exp)
 
     def test_importable_types(self):
-        types = self.pm.importable_types
+        types = self.pm.get_semantic_types()
 
         exp = {IntSequence1, IntSequence2, FourInts, Mapping, Kennel[Dog],
                Kennel[Cat], SingleInt}

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -39,8 +39,8 @@ class TestPluginManager(unittest.TestCase):
         exp = {'dummy-plugin': self.plugin}
         self.assertEqual(plugins, exp)
 
-    def test_semantic_types(self):
-        types = self.pm.semantic_types
+    def test_semantic_type_fragments(self):
+        types = self.pm.semantic_type_fragments
 
         exp = {
             'IntSequence1': SemanticTypeRecord(semantic_type=IntSequence1,


### PR DESCRIPTION
Exposes plugin level list (set technically) of importable types for easy access in coming changes to docs/cli/artifact API. I can make this happen with formats as well on this or another branch.