### PR TITLE
Fall back for tzlocal failure

### DIFF
--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -14,7 +14,7 @@ import copy
 import importlib
 import shutil
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 import distutils
 import yaml
@@ -27,7 +27,7 @@ from qiime2.core.cite import Citations
 
 
 def _ts_to_date(ts):
-    time_zone = None
+    time_zone = timezone.utc
     try:
         time_zone = tzlocal.get_localzone()
     except ValueError:

--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -26,6 +26,15 @@ import qiime2.core.util as util
 from qiime2.core.cite import Citations
 
 
+def _ts_to_date(ts):
+    time_zone = None
+    try:
+        time_zone = tzlocal.get_localzone()
+    except ValueError:
+        pass
+    return datetime.fromtimestamp(ts, tz=time_zone)
+
+
 # Used to give PyYAML something to recognize for custom tags
 ForwardRef = collections.namedtuple('ForwardRef', ['reference'])
 NoProvenance = collections.namedtuple('NoProvenance', ['uuid'])
@@ -245,15 +254,12 @@ class ProvenanceCapture:
 
         return recorder
 
-    def _ts_to_date(self, ts):
-        return datetime.fromtimestamp(ts, tzlocal.get_localzone())
-
     def make_execution_section(self):
         execution = collections.OrderedDict()
         execution['uuid'] = str(self.uuid)
         execution['runtime'] = runtime = collections.OrderedDict()
-        runtime['start'] = start = self._ts_to_date(self.start)
-        runtime['end'] = end = self._ts_to_date(self.end)
+        runtime['start'] = start = _ts_to_date(self.start)
+        runtime['end'] = end = _ts_to_date(self.end)
         runtime['duration'] = \
             util.duration_time(relativedelta.relativedelta(end, start))
 

--- a/qiime2/core/archive/tests/test_provenance.py
+++ b/qiime2/core/archive/tests/test_provenance.py
@@ -8,6 +8,7 @@
 
 import unittest
 import re
+import unittest.mock as mock
 
 import pandas as pd
 import pandas.util.testing as pdt
@@ -15,6 +16,7 @@ import pandas.util.testing as pdt
 import qiime2
 from qiime2.plugins import dummy_plugin
 from qiime2.core.testing.type import IntSequence1, Mapping
+import qiime2.core.archive.provenance as provenance
 
 
 class TestProvenanceIntegration(unittest.TestCase):
@@ -248,6 +250,17 @@ class TestProvenanceIntegration(unittest.TestCase):
 
         self.assertIn('foo: 3', prov_yml)
         self.assertIn('bar: 2', prov_yml)
+
+    @mock.patch('qiime2.core.archive.provenance.tzlocal.get_localzone',
+                side_effect=ValueError())
+    def test_ts_to_date(self, mocked_link):
+        q2_paper_date = 1563984000
+
+        obs = str(provenance._ts_to_date(q2_paper_date))
+        exp = "2019-07-24 09:00:00"
+
+        self.assertEqual(obs, exp)
+        assert mocked_link.called
 
 
 if __name__ == '__main__':

--- a/qiime2/core/archive/tests/test_provenance.py
+++ b/qiime2/core/archive/tests/test_provenance.py
@@ -253,14 +253,14 @@ class TestProvenanceIntegration(unittest.TestCase):
 
     @mock.patch('qiime2.core.archive.provenance.tzlocal.get_localzone',
                 side_effect=ValueError())
-    def test_ts_to_date(self, mocked_link):
+    def test_ts_to_date(self, mocked_tzlocal):
         q2_paper_date = 1563984000
 
         obs = str(provenance._ts_to_date(q2_paper_date))
         exp = "2019-07-24 16:00:00+00:00"
 
         self.assertEqual(obs, exp)
-        assert mocked_link.called
+        self.assertTrue(mocked_tzlocal.called)
 
 
 if __name__ == '__main__':

--- a/qiime2/core/archive/tests/test_provenance.py
+++ b/qiime2/core/archive/tests/test_provenance.py
@@ -257,7 +257,7 @@ class TestProvenanceIntegration(unittest.TestCase):
         q2_paper_date = 1563984000
 
         obs = str(provenance._ts_to_date(q2_paper_date))
-        exp = "2019-07-24 09:00:00"
+        exp = "2019-07-24 16:00:00+00:00"
 
         self.assertEqual(obs, exp)
         assert mocked_link.called


### PR DESCRIPTION
This PR addresses the issues that some users encounter regarding timezone information. This fix bypasses the `ValueError` that is shown and simply sets the timezone to none, which produces date & time, without any timezone information.

See issue #510 for more details.
