### PR TITLE
BUG: fix behavior of parse_primitive with TypeMap

### DIFF
--- a/qiime2/core/type/util.py
+++ b/qiime2/core/type/util.py
@@ -17,7 +17,7 @@ from qiime2.core.type.parse import ast_to_type
 
 def _strip_predicates(expr):
     if isinstance(expr, UnionExp):
-        return UnionExp(_strip_predicates(m) for m in expr.members)
+        return UnionExp(_strip_predicates(m) for m in expr.members).normalize()
 
     if hasattr(expr, 'fields'):
         new_fields = tuple(_strip_predicates(f) for f in expr.fields)


### PR DESCRIPTION
When a TypeMap generates a type such as Bool % Choices(False) | Bool,
parse_primitive will will attempt to strip the predicates to recieve a
base type. However this resulted in Bool | Bool which caused the logic
within parse_primitive to fail to recognize the coercion priority giving
us a floating point 0.0 type instead of False.

Normalizing the UnionExp after stripping predicates corrects this issue,
giving us a single Bool type that is recognized by the internal logic.