### PR TITLE
DOC: clarify intent of test harness machinery

### DIFF
--- a/qiime2/plugin/testing.py
+++ b/qiime2/plugin/testing.py
@@ -104,7 +104,7 @@ class TestPluginBase(unittest.TestCase):
         """Convenience method for getting a registered transformer.
 
         This helper deliberately side-steps the framework's validation machinery,
-        that way it is possible for plugin developers to test failing conditions.
+        so that it is possible for plugin developers to test failing conditions.
 
         Parameters
         ----------
@@ -191,7 +191,7 @@ class TestPluginBase(unittest.TestCase):
         ``data/``, as ``source_format``, then transform to the ``target`` view.
 
         This helper deliberately side-steps the framework's validation machinery,
-        that way it is possible for plugin developers to test failing conditions.
+        so that it is possible for plugin developers to test failing conditions.
 
         Parameters
         ----------

--- a/qiime2/plugin/testing.py
+++ b/qiime2/plugin/testing.py
@@ -103,6 +103,9 @@ class TestPluginBase(unittest.TestCase):
     def get_transformer(self, from_type, to_type):
         """Convenience method for getting a registered transformer.
 
+        This helper deliberately side-steps the framework's validation machinery,
+        that way it is possible for plugin developers to test failing conditions.
+
         Parameters
         ----------
         from_type : A View Type
@@ -186,6 +189,9 @@ class TestPluginBase(unittest.TestCase):
 
         Combines several other utilities in this class, will load files from
         ``data/``, as ``source_format``, then transform to the ``target`` view.
+
+        This helper deliberately side-steps the framework's validation machinery,
+        that way it is possible for plugin developers to test failing conditions.
 
         Parameters
         ----------


### PR DESCRIPTION
Replaces and closes #494 
Fixes #492 by adding documentation.