### PR TITLE
FIX: Added condition for list and set in build opts

### DIFF
--- a/qiime2/core/testing/examples.py
+++ b/qiime2/core/testing/examples.py
@@ -12,7 +12,7 @@ from qiime2 import Artifact, Metadata, CategoricalMetadataColumn
 
 from qiime2.plugin import UsageAction, UsageInputs, UsageOutputNames
 
-from .type import IntSequence1, IntSequence2, Mapping
+from .type import IntSequence1, IntSequence2, Mapping, SingleInt
 
 
 def ints1_factory():
@@ -48,6 +48,26 @@ def mdc1_factory():
                                      name='a',
                                      index=pd.Index(['0', '1', '2'],
                                                     name='id')))
+
+
+def intSequence_list_factory():
+    int1 = ints1_factory()
+    int2 = ints2_factory()
+    return [int1, int2]
+
+
+def singleInt1_factory():
+    return Artifact.import_data(SingleInt, 10)
+
+
+def singleInt2_factory():
+    return Artifact.import_data(SingleInt, 11)
+
+
+def singleInt1_set_factory():
+    singleInt1 = singleInt1_factory()
+    singleInt2 = singleInt2_factory()
+    return {singleInt1, singleInt2}
 
 
 def concatenate_ints_simple(use):
@@ -180,4 +200,16 @@ def identity_with_metadata_column_from_factory(use):
                     action_id='identity_with_metadata_column'),
         UsageInputs(ints=ints, metadata=mdc),
         UsageOutputNames(out='out'),
+    )
+
+
+def feature_table_merge_example(use):
+    ints = use.init_data('int', intSequence_list_factory)
+    int_set = use.init_data('int_set', singleInt1_set_factory)
+
+    use.action(
+        UsageAction(plugin_id='dummy_plugin',
+                    action_id='variadic_input_method'),
+        UsageInputs(ints=ints, int_set=int_set, nums={7, 8, 9}),
+        UsageOutputNames(output='out'),
     )

--- a/qiime2/core/testing/examples.py
+++ b/qiime2/core/testing/examples.py
@@ -50,24 +50,24 @@ def mdc1_factory():
                                                     name='id')))
 
 
-def intSequence_list_factory():
+def int_sequence_list_factory():
     int1 = ints1_factory()
     int2 = ints2_factory()
     return [int1, int2]
 
 
-def singleInt1_factory():
+def single_int1_factory():
     return Artifact.import_data(SingleInt, 10)
 
 
-def singleInt2_factory():
+def single_int2_factory():
     return Artifact.import_data(SingleInt, 11)
 
 
-def singleInt1_set_factory():
-    singleInt1 = singleInt1_factory()
-    singleInt2 = singleInt2_factory()
-    return {singleInt1, singleInt2}
+def single_int_set_factory():
+    single_int1 = single_int1_factory()
+    single_int2 = single_int2_factory()
+    return {single_int1, single_int2}
 
 
 def concatenate_ints_simple(use):
@@ -204,8 +204,8 @@ def identity_with_metadata_column_from_factory(use):
 
 
 def feature_table_merge_example(use):
-    ints = use.init_data('int', intSequence_list_factory)
-    int_set = use.init_data('int_set', singleInt1_set_factory)
+    ints = use.init_data('int', int_sequence_list_factory)
+    int_set = use.init_data('int_set', single_int_set_factory)
 
     use.action(
         UsageAction(plugin_id='dummy_plugin',

--- a/qiime2/core/testing/examples.py
+++ b/qiime2/core/testing/examples.py
@@ -203,7 +203,7 @@ def identity_with_metadata_column_from_factory(use):
     )
 
 
-def feature_table_merge_example(use):
+def variadic_input_simple(use):
     ints = use.init_data('int', int_sequence_list_factory)
     int_set = use.init_data('int_set', single_int_set_factory)
 

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -55,8 +55,7 @@ from .examples import (concatenate_ints_simple, concatenate_ints_complex,
                        identity_with_metadata_merging,
                        identity_with_metadata_column_get_mdc,
                        identity_with_metadata_column_from_factory,
-                       feature_table_merge_example,
-                       optional_inputs,
+                       variadic_input_simple, optional_inputs,
                        )
 
 
@@ -463,7 +462,7 @@ dummy_plugin.methods.register_function(
     output_descriptions={
         'output': 'All of the above mashed together'
     },
-    examples={'feature_table_merge_example': feature_table_merge_example},
+    examples={'variadic_input_simple': variadic_input_simple},
 )
 
 dummy_plugin.visualizers.register_function(

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -55,6 +55,7 @@ from .examples import (concatenate_ints_simple, concatenate_ints_complex,
                        identity_with_metadata_merging,
                        identity_with_metadata_column_get_mdc,
                        identity_with_metadata_column_from_factory,
+                       feature_table_merge_example,
                        )
 
 
@@ -459,7 +460,8 @@ dummy_plugin.methods.register_function(
     },
     output_descriptions={
         'output': 'All of the above mashed together'
-    }
+    },
+    examples={'feature_table_merge_example': feature_table_merge_example},
 )
 
 dummy_plugin.visualizers.register_function(

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -143,6 +143,23 @@ class TestUsage(TestCaseUsage):
         self.assertEqual('init_data', obs2['type'])
         self.assertEqual('action', obs3['type'])
 
+    def test_use_merge_feature_table(self):
+        action = self.plugin.actions['variadic_input_method']
+        use = usage.DiagnosticUsage()
+        action.examples['feature_table_merge_example'](use)
+
+        self.assertEqual(len(use.recorder), 3)
+
+        obs1, obs2, obs3 = use.recorder
+
+        self.assertEqual('init_data', obs1['type'])
+        self.assertEqual('init_data', obs2['type'])
+        self.assertEqual('action', obs3['type'])
+        self.assertEqual(set, type(obs3['input_opts']['nums']))
+
+        self.assertIn('int', obs3['input_opts']['ints'])
+        self.assertIn('int_set', obs3['input_opts']['int_set'])
+
 
 class TestUsageAction(TestCaseUsage):
     def test_successful_init(self):
@@ -230,6 +247,13 @@ class TestUsageInputs(TestCaseUsage):
         ui = usage.UsageInputs(x='hello', z='goodbye')
         ui.validate(self.signature)
         self.assertTrue(True)
+
+    def test_type_of_input(self):
+        test_inputs = usage.UsageInputs(x=[1, 2, 3], z={7, 8, 9})
+        test_inputs.validate(self.signature)
+
+        self.assertEqual(list, type(test_inputs.values['x']))
+        self.assertEqual(set, type(test_inputs.values['z']))
 
 
 class TestUsageOutputNames(TestCaseUsage):

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -252,8 +252,8 @@ class TestUsageInputs(TestCaseUsage):
         test_inputs = usage.UsageInputs(x=[1, 2, 3], z={7, 8, 9})
         test_inputs.validate(self.signature)
 
-        self.assertEqual(list, type(test_inputs.values['x']))
-        self.assertEqual(set, type(test_inputs.values['z']))
+        self.assertIsInstance(test_inputs.values['x'], list)
+        self.assertIsInstance(test_inputs.values['z'], set)
 
 
 class TestUsageOutputNames(TestCaseUsage):

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -146,7 +146,7 @@ class TestUsage(TestCaseUsage):
     def test_use_merge_feature_table(self):
         action = self.plugin.actions['variadic_input_method']
         use = usage.DiagnosticUsage()
-        action.examples['feature_table_merge_example'](use)
+        action.examples['variadic_input_simple'](use)
 
         self.assertEqual(len(use.recorder), 3)
 

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -98,22 +98,15 @@ class UsageInputs:
 
         for name, signature in signature.signature_order.items():
             if name in self.values:
-                if isinstance(self.values[name], ScopeRecord) \
-                        and self.values[name].ref in scope.records:
-                    value = self.values[name].result
-                elif (isinstance(self.values[name], list)
-                      and self.values[name]
-                      and all(isinstance(n, ScopeRecord)
-                      for n in self.values[name])):
-                    value = [item.result for item in self.values[name]]
-                elif (isinstance(self.values[name], set)
-                      and self.values[name]
-                      and all(isinstance(n, ScopeRecord)
-                      for n in self.values[name])):
-                    value = {item.result for item in self.values[name]}
                 v = self.values[name]
                 if isinstance(v, ScopeRecord) and v.ref in scope.records:
-                    value = v.result
+                    value = self.values[name].result
+                elif (isinstance(v, list)
+                      and all(isinstance(n, ScopeRecord) for n in v)):
+                    value = [item.result for item in v]
+                elif (isinstance(v, set)
+                      and all(isinstance(n, ScopeRecord) for n in v)):
+                    value = {item.result for item in v}
                 else:
                     value = v
                 opts[name] = value

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -98,7 +98,6 @@ class UsageInputs:
 
         for name, signature in signature.signature_order.items():
             if name in self.values:
-<<<<<<< HEAD
                 if isinstance(self.values[name], ScopeRecord) \
                         and self.values[name].ref in scope.records:
                     value = self.values[name].result
@@ -112,15 +111,9 @@ class UsageInputs:
                       and all(isinstance(n, ScopeRecord)
                       for n in self.values[name])):
                     value = {item.result for item in self.values[name]}
-||||||| f89eaad
-                if isinstance(self.values[name], ScopeRecord) \
-                        and self.values[name].ref in scope.records:
-                    value = self.values[name].result
-=======
                 v = self.values[name]
                 if isinstance(v, ScopeRecord) and v.ref in scope.records:
                     value = v.result
->>>>>>> master
                 else:
                     value = v
                 opts[name] = value

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -90,11 +90,13 @@ class UsageInputs:
                     value = self.values[name].result
                 elif (isinstance(self.values[name], list)
                       and self.values[name]
-                      and isinstance(self.values[name][0], ScopeRecord)):
+                      and all(isinstance(n, ScopeRecord)
+                      for n in self.values[name])):
                     value = [item.result for item in self.values[name]]
                 elif (isinstance(self.values[name], set)
                       and self.values[name]
-                      and isinstance(self.values[name][0], ScopeRecord)):
+                      and all(isinstance(n, ScopeRecord)
+                      for n in self.values[name])):
                     value = {item.result for item in self.values[name]}
                 else:
                     value = self.values[name]

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -77,8 +77,10 @@ class UsageInputs:
 
         extra = provided - exp_inputs - exp_params
         if len(extra) > 0:
-            raise ValueError('Extra input(s) or parameter(s): %r' %
-                             (extra, ))
+            for provided_value in extra:
+                if provided_value not in signature.parameters:
+                    raise ValueError('Extra input(s) or parameter(s): %r' %
+                                     (extra, ))
 
     def build_opts(self, signature, scope):
         opts = {}

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -88,6 +88,14 @@ class UsageInputs:
                 if isinstance(self.values[name], ScopeRecord) \
                         and self.values[name].ref in scope.records:
                     value = self.values[name].result
+                elif (isinstance(self.values[name], list)
+                      and self.values[name]
+                      and isinstance(self.values[name][0], ScopeRecord)):
+                    value = [item.result for item in self.values[name]]
+                elif (isinstance(self.values[name], set)
+                      and self.values[name]
+                      and isinstance(self.values[name][0], ScopeRecord)):
+                    value = {item.result for item in self.values[name]}
                 else:
                     value = self.values[name]
                 opts[name] = value

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -77,10 +77,8 @@ class UsageInputs:
 
         extra = provided - exp_inputs - exp_params
         if len(extra) > 0:
-            for provided_value in extra:
-                if provided_value not in signature.parameters:
-                    raise ValueError('Extra input(s) or parameter(s): %r' %
-                                     (extra, ))
+            raise ValueError('Extra input(s) or parameter(s): %r' %
+                             (extra, ))
 
     def build_opts(self, signature, scope):
         opts = {}

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -258,7 +258,7 @@ out, = identity_with_metadata_column(
     def test_use_merge_feature_table(self):
         action = self.plugin.actions['variadic_input_method']
         use = ArtifactAPIUsage()
-        action.examples['feature_table_merge_example'](use)
+        action.examples['variadic_input_simple'](use)
 
         exp = """\
 from qiime2.plugins.dummy_plugin.methods import variadic_input_method

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -255,7 +255,6 @@ out, = identity_with_metadata_column(
 """
         self.assertEqual(exp, use.render())
 
-<<<<<<< HEAD
     def test_use_merge_feature_table(self):
         action = self.plugin.actions['variadic_input_method']
         use = ArtifactAPIUsage()
@@ -272,8 +271,6 @@ out, = variadic_input_method(
 """
         self.assertEqual(exp, use.render())
 
-||||||| f89eaad
-=======
     def test_optional_inputs(self):
         action = self.plugin.actions['optional_artifacts_method']
         use = ArtifactAPIUsage()
@@ -308,7 +305,6 @@ output, = optional_artifacts_method(
 
         self.assertEqual(exp, use.render())
 
->>>>>>> master
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -255,6 +255,22 @@ out, = identity_with_metadata_column(
 """
         self.assertEqual(exp, use.render())
 
+    def test_use_merge_feature_table(self):
+        action = self.plugin.actions['variadic_input_method']
+        use = ArtifactAPIUsage()
+        action.examples['feature_table_merge_example'](use)
+
+        exp = """\
+from qiime2.plugins.dummy_plugin.methods import variadic_input_method
+
+out, = variadic_input_method(
+    ints=int,
+    int_set=int_set,
+    nums={8, 9, 7},
+)
+"""
+        self.assertEqual(exp, use.render())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
PR adds checks to ensure that we are able to handle `ScopeRecord` instances within a list or set.

When adding a usage example to `q2-feature-table`, it was discovered that the framework handled lists and `ScopeRecord` types, but could not take in lists or sets with ScopeRecord types as values within that list/set.

This PR adds two conditions that update the `value` variable, using set or list comprehension (depending on the case), to handle such cases.

@thermokarst Is there anything you would recommend for testing these changes moving forward?

Thanks in advance.
