### PR TITLE
IMP: Invert UsageOutputNames SDK API

### DIFF
--- a/qiime2/plugins.py
+++ b/qiime2/plugins.py
@@ -53,12 +53,10 @@ class ArtifactAPIUsage(usage.Usage):
         action_f, action_sig = action.get_action()
         self._update_imports(action_f)
 
-        new_output_opts = {k: k for k in output_opts.keys()}
-
-        t = self._template_action(action_f, input_opts, new_output_opts)
+        t = self._template_action(action_f, input_opts, output_opts)
         self._recorder.append(t)
 
-        return new_output_opts
+        return output_opts
 
     def _assert_has_line_matching_(self, ref, label, path, expression):
         pass
@@ -72,7 +70,7 @@ class ArtifactAPIUsage(usage.Usage):
         return {r: f() for r, f in self._init_data_refs.items()}
 
     def _template_action(self, action_f, input_opts, output_opts):
-        output_opts = list(output_opts.keys())
+        output_opts = list(output_opts.values())
         if len(output_opts) == 1:
             output_opts.append('')
         output_vars = ', '.join(output_opts)

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -48,7 +48,7 @@ class TestUsage(TestCaseUsage):
         self.assertEqual({'int1': 4, 'int2': 2, 'ints1': 'ints_a',
                           'ints2': 'ints_b', 'ints3': 'ints_c'},
                          obs5['input_opts'])
-        self.assertEqual({'ints_d': 'concatenated_ints'}, obs5['output_opts'])
+        self.assertEqual({'concatenated_ints': 'ints_d'}, obs5['output_opts'])
 
     def test_chained(self):
         action = self.plugin.actions['concatenate_ints']
@@ -74,13 +74,13 @@ class TestUsage(TestCaseUsage):
         self.assertEqual({'int1': 4, 'int2': 2, 'ints1': 'ints_a',
                           'ints2': 'ints_b', 'ints3': 'ints_c'},
                          obs5['input_opts'])
-        self.assertEqual({'ints_d': 'concatenated_ints'}, obs5['output_opts'])
+        self.assertEqual({'concatenated_ints': 'ints_d'}, obs5['output_opts'])
 
         self.assertTrue('chained usage (pt 2)' in obs6['text'])
 
         self.assertEqual('dummy_plugin', obs7['action'].plugin_id)
         self.assertEqual('concatenate_ints', obs7['action'].action_id)
-        self.assertEqual({'int1': 41, 'int2': 0, 'ints1': 'concatenated_ints',
+        self.assertEqual({'int1': 41, 'int2': 0, 'ints1': 'ints_d',
                           'ints2': 'ints_b', 'ints3': 'ints_c'},
                          obs7['input_opts'])
         self.assertEqual({'concatenated_ints': 'concatenated_ints'},
@@ -270,16 +270,16 @@ class TestUsageOutputNames(TestCaseUsage):
     def test_validate_derived_missing_output(self):
         uo = usage.UsageOutputNames(x='goodbye', y='hello')
 
-        with self.assertRaisesRegex(ValueError, 'SDK.*missing output.*hello'):
-            uo.validate_derived({'goodbye': 'val'})
+        with self.assertRaisesRegex(ValueError, 'SDK.*missing output.*y'):
+            uo.validate_computed({'x': 'val'})
 
     def test_validate_derived_extra_output(self):
         uo = usage.UsageOutputNames(x='goodbye', y='hello')
 
         with self.assertRaisesRegex(ValueError, 'SDK.*extra output.*peanut'):
-            uo.validate_derived({'goodbye': 'val',
-                                 'hello': 'val',
-                                 'peanut': 'val'})
+            uo.validate_computed({'x': 'val',
+                                  'y': 'val',
+                                  'peanut': 'val'})
 
 
 class TestUsageBaseClass(TestCaseUsage):

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -123,9 +123,9 @@ class UsageOutputNames:
         if len(extra) > 0:
             raise ValueError('Extra output(s): %r' % (extra, ))
 
-    def validate_derived(self, derived_outputs):
-        provided = set(derived_outputs.keys())
-        exp_outputs = set(self.values.values())
+    def validate_computed(self, computed_outputs):
+        provided = set(computed_outputs.keys())
+        exp_outputs = set(self.values.keys())
 
         missing = exp_outputs - provided
         if len(missing) > 0:
@@ -141,7 +141,7 @@ class UsageOutputNames:
         opts = {}
 
         for output in action_signature.outputs.keys():
-            opts[self.get(output)] = output
+            opts[output] = self.get(output)
 
         return opts
 
@@ -240,11 +240,11 @@ class Usage(metaclass=abc.ABCMeta):
         input_opts = inputs.build_opts(action_signature, self._scope)
         output_opts = outputs.build_opts(action_signature, self._scope)
 
-        derived_outputs = self._action_(action, input_opts, output_opts)
-        self._add_outputs_to_scope(outputs, derived_outputs)
+        computed_outputs = self._action_(action, input_opts, output_opts)
+        self._add_outputs_to_scope(outputs, computed_outputs)
 
     def _action_(self, action: UsageAction,
-                 input_opts: dict, output_opts: list):
+                 input_opts: dict, output_opts: dict):
         raise NotImplementedError
 
     def _assert_has_line_matching_(self, ref, label, path, expression):
@@ -253,9 +253,10 @@ class Usage(metaclass=abc.ABCMeta):
     def get_result(self, ref):
         return self._get_record(ref)
 
-    def _add_outputs_to_scope(self, outputs, derived_outputs):
-        outputs.validate_derived(derived_outputs)
-        for ref, result in derived_outputs.items():
+    def _add_outputs_to_scope(self, outputs, computed_outputs):
+        outputs.validate_computed(computed_outputs)
+        for output, result in computed_outputs.items():
+            ref = outputs.get(output)
             self._push_record(ref, result)
 
     def _push_record(self, ref, value):
@@ -342,7 +343,7 @@ class ExecutionUsage(Usage):
                  input_opts: dict, output_opts: dict):
         action_f, _ = action.get_action()
         results = action_f(**input_opts)
-        return {k: getattr(results, v) for k, v in output_opts.items()}
+        return {k: getattr(results, k) for k in output_opts.keys()}
 
     def _assert_has_line_matching_(self, ref, label, path, expression):
         data = self._get_record(ref).result


### PR DESCRIPTION
@andrewsanchez pointed out to me that there was some clumsy inversion of SDK API in `sdk.usage.UsageOutputNames` - this PR attempts to reconcile that. Now usage drivers can expect to receive a dict of action inputs (parameter name as key, value as, ahem, the value), and a dict of action outputs (parameter name as key, scope ref name as value). I think this makes it a bit simpler to reason about, as an SDK dev.