### PR TITLE
BUG: Improve pathspec regex to prevent incorrect filenames

### DIFF
--- a/qiime2/plugin/model/directory_format.py
+++ b/qiime2/plugin/model/directory_format.py
@@ -90,7 +90,7 @@ class BoundFile:
         found_members = False
         root = pathlib.Path(self._directory_format.path)
         for path in collected_paths:
-            if re.match(self.pathspec, str(path.relative_to(root))):
+            if re.fullmatch(self.pathspec, str(path.relative_to(root))):
                 if collected_paths[path]:
                     # Not a ValidationError, this just shouldn't happen.
                     raise ValueError("%r was already validated by another"


### PR DESCRIPTION
close qiime2/q2-types#218 by tightening up the regex used to validate filenames.