### PR TITLE
MAINT: Update error message to point out common mistake

### DIFF
--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -144,7 +144,9 @@ class MetadataReader:
                 raise MetadataFileError(
                     "Found unrecognized ID column name %r while searching for "
                     "header. The first column name in the header defines the "
-                    "ID column, and must be one of these values:\n\n%s" %
+                    "ID column, and must be one of these values:\n\n%s\n\n"
+                    "NOTE: Metadata files must be tab separated not comma "
+                    "separated." %
                     (row[0], FORMATTED_ID_HEADERS))
 
         if header is None:

--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -145,8 +145,7 @@ class MetadataReader:
                     "Found unrecognized ID column name %r while searching for "
                     "header. The first column name in the header defines the "
                     "ID column, and must be one of these values:\n\n%s\n\n"
-                    "NOTE: Metadata files must be tab separated not comma "
-                    "separated." %
+                    "NOTE: Metadata files must contain tab-separated values." %
                     (row[0], FORMATTED_ID_HEADERS))
 
         if header is None:


### PR DESCRIPTION
Closes #537. It seemed to me like the simplest way to resolve this issue would be adding a short note that metadata files must be tab and not comma separated. Hopefully people will be able to see this note and quickly realize what the issue is if they attempt to use a csv as metadata.