### PR TITLE
BUG: Fix bug with TypeMatch and Set or List Union

### DIFF
--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -129,3 +129,7 @@ def variadic_input_method(ints: list, int_set: int, nums: int,
         results += opt_nums
 
     return results
+
+
+def type_match_list_and_set(ints: list, strs1: list, strs2: set) -> list:
+    return [0]

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -40,7 +40,7 @@ from .method import (concatenate_ints, split_ints, merge_mappings,
                      params_only_method, no_input_method, deprecated_method,
                      optional_artifacts_method, long_description_method,
                      docstring_order_method, variadic_input_method,
-                     unioned_primitives)
+                     unioned_primitives, type_match_list_and_set)
 from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
 from .pipeline import (parameter_only_pipeline, typical_pipeline,
@@ -460,6 +460,33 @@ dummy_plugin.methods.register_function(
         'output': 'All of the above mashed together'
     },
     examples={'variadic_input_simple': variadic_input_simple},
+)
+
+T = TypeMatch([IntSequence1, IntSequence2])
+dummy_plugin.methods.register_function(
+    function=type_match_list_and_set,
+    inputs={
+        'ints': T
+    },
+    parameters={
+        'strs1': List[Str],
+        'strs2': Set[Str]
+    },
+    outputs=[
+        ('output', T)
+    ],
+    name='TypeMatch with list and set params',
+    description='Just a method with a TypeMatch and list/set params',
+    input_descriptions={
+        'ints': 'An int artifact'
+    },
+    parameter_descriptions={
+        'strs1': 'A list of strings',
+        'strs2': 'A set of strings'
+    },
+    output_descriptions={
+        'output': '[0]'
+    }
 )
 
 dummy_plugin.visualizers.register_function(

--- a/qiime2/core/testing/tests/test_mapped_actions.py
+++ b/qiime2/core/testing/tests/test_mapped_actions.py
@@ -11,6 +11,8 @@ import unittest
 from qiime2 import Artifact
 from qiime2.core.testing.util import get_dummy_plugin
 
+from ..type import IntSequence1, IntSequence2
+
 
 class ActionTester(unittest.TestCase):
     ACTION = 'N/A'
@@ -184,6 +186,22 @@ class TestPredicatesPreservedMethod(ActionTester):
         x, = self.run_action(a=a)
 
         self.assertEqual(repr(x.type), "Foo % Properties('A', 'B')")
+
+
+class TestTypeMatchWithListAndSet(ActionTester):
+    ACTION = 'type_match_list_and_set'
+
+    def test_intsequence1(self):
+        a = Artifact.import_data('IntSequence1', [1])
+
+        x = self.run_action(ints=a, strs1=['a'], strs2={'a'})
+        self.assertEqual(x.output.type, IntSequence1)
+
+    def test_intsequence2(self):
+        a = Artifact.import_data('IntSequence2', [1])
+
+        x = self.run_action(ints=a, strs1=['a'], strs2={'a'})
+        self.assertEqual(x.output.type, IntSequence2)
 
 
 if __name__ == '__main__':

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -393,10 +393,10 @@ class PipelineSignature:
             # Shouldn't happen:
             raise ValueError("Parameter passed not consistent with signature.")
         if type(value) is list:
-            inner = UnionExp((self._infer_type(v) for v in value))
+            inner = UnionExp((self._infer_type(key, v) for v in value))
             return List[inner.normalize()]
         if type(value) is set:
-            inner = UnionExp((self._infer_type(v) for v in value))
+            inner = UnionExp((self._infer_type(key, v) for v in value))
             return Set[inner.normalize()]
         if isinstance(value, qiime2.sdk.Artifact):
             return value.type

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -95,6 +95,7 @@ class TestPlugin(unittest.TestCase):
                           'predicates_preserved_method',
                           'deprecated_method',
                           'unioned_primitives',
+                          'type_match_list_and_set',
                           })
         for action in actions.values():
             self.assertIsInstance(action, qiime2.sdk.Action)
@@ -126,6 +127,7 @@ class TestPlugin(unittest.TestCase):
                           'predicates_preserved_method',
                           'deprecated_method',
                           'unioned_primitives',
+                          'type_match_list_and_set',
                           })
         for method in methods.values():
             self.assertIsInstance(method, qiime2.sdk.Method)

--- a/qiime2/sdk/tests/test_util.py
+++ b/qiime2/sdk/tests/test_util.py
@@ -40,7 +40,8 @@ class TestUtil(unittest.TestCase):
             'Visualize most common integers',
             'Split sequence of integers in half',
             'Test different ways of failing', 'Optional artifacts method',
-            'Do stuff normally, but override this one step sometimes'])]
+            'Do stuff normally, but override this one step sometimes',
+            'TypeMatch with list and set params'])]
         self.assertEqual(len(obs), 1)
         self.assertEqual(obs[0][0], exp[0][0])
         self.assertCountEqual(obs[0][1], exp[0][1])


### PR DESCRIPTION
Evan and I discovered a bug while working on caporaso-lab/genome-sampler#49 that prevents the use of TypeMatch with a List[Union] or Set[Union]. This fixes that bug.

Next step, add a test.