### PR TITLE
Compatibility with 32-bits CPU architectures

### DIFF
--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -1162,7 +1162,7 @@ class NumericMetadataColumn(MetadataColumn):
 
     @classmethod
     def _is_supported_dtype(cls, dtype):
-        return dtype == 'float' or dtype == 'int'
+        return dtype == 'float' or dtype == 'int' or dtype == 'int64'
 
     @classmethod
     def _normalize_(cls, series):

--- a/qiime2/metadata/tests/test_metadata_column.py
+++ b/qiime2/metadata/tests/test_metadata_column.py
@@ -26,7 +26,7 @@ class DummyMetadataColumn(MetadataColumn):
 
     @classmethod
     def _is_supported_dtype(cls, dtype):
-        return dtype == 'float' or dtype == 'int'
+        return dtype == 'float' or dtype == 'int' or dtype == 'int64'
 
     @classmethod
     def _normalize_(cls, series):


### PR DESCRIPTION
Greetings,

While working on issue #520 related to migration to python 3.9 in the Debian project, I caught an issue specific to 32-bits CPU architectures.  On 64-bits CPUs, the _pandas.dtype_ returned for integers is a plain _int_ 64 bits wide.  However, on 32 bits machines, the type is returned as _int64_ to differenciate from plain _int_, which I suppose would be 32 bits wide in such context.

Due to this, when running the test suite on 32-bits CPU architectures, the error output includes several instances of errors such as the following:

```
======================================================================
ERROR: test_decode_numeric_value (qiime2.core.type.tests.test_primitive.TestMetadataColumn)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/autopkgtest-lxc.shmdvuw3/downtmp/autopkgtest_tmp/qiime2/core/type/tests/test_primitive.py", line 66, in test_decode_numeric_value
    num_md = metadata.NumericMetadataColumn(value)
  File "/tmp/autopkgtest-lxc.shmdvuw3/downtmp/autopkgtest_tmp/qiime2/metadata/metadata.py", line 875, in __init__
    raise TypeError(
TypeError: NumericMetadataColumn 'foo' does not support a pandas.Series object with dtype int64
```
---

Please note I did not know whether 32 bits support was under your radar or not, so in doubt I just leave that merge request for your convenience.  I understand these limited architectures are usually a concern in bioinformatics, but I also heard of cases where architectures like _armhf_ (which is 32 bits) were in use in various educational contexts.

Have a nice day,  :)
Étienne.
