### PR TITLE
bug: networked filesystem race conditions

### DIFF
--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -317,7 +317,12 @@ class ProvenanceCapture:
         self.write_action_yaml()
         self.write_citations_bib()
 
-        self.path.rename(final_path)
+        # Certain networked filesystems will experience a race
+        # condition on `rename`, so fall back to copying.
+        try:
+            self.path.rename(final_path)
+        except FileExistsError:
+            distutils.dir_util.copy_tree(str(self.path), str(final_path))
 
     def fork(self):
         forked = copy.copy(self)

--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -324,8 +324,6 @@ class ProvenanceCapture:
         except FileExistsError:
             distutils.dir_util.copy_tree(str(self.path), str(final_path))
             distutils.dir_util.remove_tree(str(self.path))
-            # TODO: update self.path? This doesn't seem to work as hoped
-            # self.path = qiime2.core.path.ProvenancePath(str(final_path))
 
     def fork(self):
         forked = copy.copy(self)

--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -323,6 +323,9 @@ class ProvenanceCapture:
             self.path.rename(final_path)
         except FileExistsError:
             distutils.dir_util.copy_tree(str(self.path), str(final_path))
+            distutils.dir_util.remove_tree(str(self.path))
+            # TODO: update self.path? This doesn't seem to work as hoped
+            # self.path = qiime2.core.path.ProvenancePath(str(final_path))
 
     def fork(self):
         forked = copy.copy(self)

--- a/qiime2/core/archive/tests/test_provenance.py
+++ b/qiime2/core/archive/tests/test_provenance.py
@@ -262,6 +262,20 @@ class TestProvenanceIntegration(unittest.TestCase):
         self.assertEqual(obs, exp)
         self.assertTrue(mocked_tzlocal.called)
 
+    def test_prov_rename(self):
+        viz, = dummy_plugin.actions.no_input_viz()
+
+        viz_p_dir = viz._archiver.provenance_dir
+        self.assertTrue(viz_p_dir.exists())
+
+    @mock.patch('qiime2.core.path.ProvenancePath.rename',
+                side_effect=FileExistsError)
+    def test_prov_rename_file_exists(self, _):
+        viz, = dummy_plugin.actions.no_input_viz()
+
+        viz_p_dir = viz._archiver.provenance_dir
+        self.assertTrue(viz_p_dir.exists())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/core/archive/tests/test_provenance.py
+++ b/qiime2/core/archive/tests/test_provenance.py
@@ -274,7 +274,9 @@ class TestProvenanceIntegration(unittest.TestCase):
         viz, = dummy_plugin.actions.no_input_viz()
 
         viz_p_dir = viz._archiver.provenance_dir
-        self.assertTrue(viz_p_dir.exists())
+
+        with (viz_p_dir / 'action' / 'action.yaml').open() as fh:
+            self.assertIn('output-name: visualization', fh.read())
 
 
 if __name__ == '__main__':

--- a/qiime2/core/path.py
+++ b/qiime2/core/path.py
@@ -33,6 +33,12 @@ class OwnedPath(_ConcretePath):
         else:
             return shutil.copy(str(self), str(other))
 
+    def _destruct(self):
+        if self.is_dir():
+            distutils.dir_util.remove_tree(str(self))
+        else:
+            self.unlink()
+
     def _move_or_copy(self, other):
         if self._user_owned:
             return self._copy_dir_or_file(other)
@@ -42,7 +48,9 @@ class OwnedPath(_ConcretePath):
             try:
                 return _ConcretePath.rename(self, other)
             except FileExistsError:
-                return self._copy_dir_or_file(other)
+                copied = self._copy_dir_or_file(other)
+                self._destruct()
+                return copied
 
 
 class InPath(OwnedPath):

--- a/qiime2/core/tests/test_path.py
+++ b/qiime2/core/tests/test_path.py
@@ -62,11 +62,14 @@ class TestOwnedPath(unittest.TestCase):
         d._move_or_copy(self.to_dir)
 
         # since from_dir is not owned, but the network fs race condition crops
-        # up, _move_or_copy should copy, not move
-        self.assertTrue(os.path.exists(os.path.join(self.from_dir, 'foo.txt')))
+        # up, _move_or_copy should copy, not move, but then we still ensure
+        # that the original path has been cleaned up
+        self.assertFalse(os.path.exists(os.path.join(self.from_dir,
+                                                     'foo.txt')))
         self.assertTrue(os.path.exists(os.path.join(self.to_dir, 'foo.txt')))
 
-        shutil.rmtree(self.from_dir)
+        with self.assertRaises(FileNotFoundError):
+            shutil.rmtree(self.from_dir)
         shutil.rmtree(self.to_dir)
 
 

--- a/qiime2/core/tests/test_path.py
+++ b/qiime2/core/tests/test_path.py
@@ -7,9 +7,67 @@
 # ----------------------------------------------------------------------------
 
 import os
+import pathlib
+import shutil
+import tempfile
 import unittest
 
-from qiime2.core.path import OutPath
+from qiime2.core.path import OwnedPath, OutPath
+
+
+class TestOwnedPath(unittest.TestCase):
+    def setUp(self):
+        self.from_dir = tempfile.mkdtemp()
+        (pathlib.Path(self.from_dir) / 'foo.txt').touch()
+
+        self.to_dir = tempfile.mkdtemp()
+        # assume to_dir is empty for all tests
+
+    def test_move_or_copy_owned(self):
+        d = OwnedPath(self.from_dir)
+        # ensure that we are owned
+        d._user_owned = True
+
+        d._move_or_copy(self.to_dir)
+
+        # since from_dir is owned, _move_or_copy should copy, not move
+        self.assertTrue(os.path.exists(os.path.join(self.from_dir, 'foo.txt')))
+        self.assertTrue(os.path.exists(os.path.join(self.to_dir, 'foo.txt')))
+
+        shutil.rmtree(self.from_dir)
+        shutil.rmtree(self.to_dir)
+
+    def test_move_or_copy_not_owned_rename(self):
+        d = OwnedPath(self.from_dir)
+        # ensure that we are not owned
+        d._user_owned = False
+
+        d._move_or_copy(self.to_dir)
+
+        # since from_dir is not owned, _move_or_copy should move, not copy
+        self.assertFalse(os.path.exists(os.path.join(self.from_dir,
+                                                     'foo.txt')))
+        self.assertTrue(os.path.exists(os.path.join(self.to_dir, 'foo.txt')))
+
+        with self.assertRaises(FileNotFoundError):
+            shutil.rmtree(self.from_dir)
+        shutil.rmtree(self.to_dir)
+
+    @unittest.mock.patch('pathlib.Path.rename', side_effect=FileExistsError)
+    def test_move_or_copy_not_owned_copy(self, _):
+        d = OwnedPath(self.from_dir)
+        # ensure that we are not owned
+        d._user_owned = False
+
+        d._move_or_copy(self.to_dir)
+
+        # since from_dir is not owned, but the network fs race condition crops
+        # up, _move_or_copy should copy, not move
+        self.assertTrue(os.path.exists(os.path.join(self.from_dir, 'foo.txt')))
+        self.assertTrue(os.path.exists(os.path.join(self.to_dir, 'foo.txt')))
+
+        shutil.rmtree(self.from_dir)
+        shutil.rmtree(self.to_dir)
 
 
 class TestOutPath(unittest.TestCase):


### PR DESCRIPTION
This changeset attempts to address some longstanding issues we've seen crop up on the forum from time to time:

- https://forum.qiime2.org/t/qiime-tools-import-on-cluster/17531
- https://forum.qiime2.org/t/error-while-runing-dada2/16600
- https://forum.qiime2.org/t/qiime2-installation-and-run-error/4766
- https://forum.qiime2.org/t/out-of-disk-space-error/5736

This has been a tricky one to debug though, since it seems to be specifically tied to the [BeeGFS filesystem](https://en.wikipedia.org/wiki/BeeGFS). I finally figured out how to reproduce this error though, using the following repo (plus patch; I also had to manually rebuild the beegfs client and launch the system service):

https://github.com/jeremysj/beegfs-sandbox/

```patch
diff --git a/roles/beegfs_client/tasks/main.yml b/roles/beegfs_client/tasks/main.yml
index 5ea86fa..6ed0ec9 100644
--- a/roles/beegfs_client/tasks/main.yml
+++ b/roles/beegfs_client/tasks/main.yml
@@ -6,7 +6,8 @@
 - name: "BeeGFS client packages"
   yum: name="{{ item }}" state=present
   with_items:
-  - "kernel-devel-{{ ansible_kernel }}"
+  - kernel
+  - kernel-devel
   - gcc
   - beegfs-client
   - beegfs-helperd

```

So, after poking around a bit, I can't find anything obviously wrong with the framework's handling of these temp paths - no double-creation of dirs/files, etc. It really only seems to be an issue when setting your machine's `TMPDIR` to a beegfs mount. One thing I learned while poking around at things is that [`pathlib.Path.rename`](https://docs.python.org/3.6/library/pathlib.html#pathlib.Path.rename) is a thin wrapper around [`os.rename`](https://docs.python.org/3.6/library/os.html#os.rename). Check out this `os.rename` note in the docs:

> The operation may fail on some Unix flavors if src and dst are on different filesystems.

I suppose we have been warned. Anyway, other solutions I looked at included replacing `rename` with `replace`, but I saw identical failures.

I haven't written any tests for this yet, I wanted to put this out there into the world (cc @ebolyen) to see what folks think. This changeset takes the approach of attempting to perform the lower-cost rename operations, and if it fails due to this `FileExistsError`, falls back to a slightly more expensive copy operation. I am open to other suggestions, just let me know. PS - thought about trying to use `qiime2.util.duplicate` in here, but steered clear for now.