### PR TITLE
bug: minor typos in ArtifactAPIUsage

### DIFF
--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -730,6 +730,44 @@ class Usage(metaclass=abc.ABCMeta):
     def _get_records(self):
         return self._scope.records
 
+    def _destructure_signature(self, action_sig):
+        # In the future this could return a more robust spec subset,
+        # if necessary.
+        def distill_spec(spec):
+            return str(spec.qiime_type)
+
+        inputs = {k: distill_spec(v) for k, v in action_sig.inputs.items()}
+        outputs = {k: distill_spec(v) for k, v in action_sig.outputs.items()}
+        params, mds = {}, {}
+
+        for param_name, spec in action_sig.inputs.items():
+            inputs[param_name] = distill_spec(spec)
+
+        for param_name, spec in action_sig.parameters.items():
+            if sdk.util.is_metadata_type(spec.qiime_type):
+                mds[param_name] = distill_spec(spec)
+            else:
+                params[param_name] = distill_spec(spec)
+
+        return {'inputs': inputs, 'params': params,
+                'mds': mds, 'outputs': outputs}
+
+    def _destructure_opts(self, signature, input_opts, output_opts):
+        inputs, params, mds, outputs = {}, {}, {}, {}
+
+        for opt_name, val in input_opts.items():
+            if opt_name in signature['inputs'].keys():
+                inputs[opt_name] = (val, signature['inputs'][opt_name])
+            elif opt_name in signature['params'].keys():
+                params[opt_name] = (val, signature['params'][opt_name])
+            elif opt_name in signature['mds'].keys():
+                mds[opt_name] = (val, signature['mds'][opt_name])
+
+        for opt_name, val in output_opts.items():
+            outputs[opt_name] = (val, signature['outputs'][opt_name])
+
+        return inputs, params, mds, outputs
+
 
 class DiagnosticUsage(Usage):
     """


### PR DESCRIPTION
gee whiz, thanks q2-mystery-stew! also, this PR merges some stuff from q2cli into the base Usage driver.

tested locally with:

```python
from q2_mystery_stew.plugin_setup import create_plugin
from qiime2 import sdk, plugins
from qiime2.sdk import usage


pm = sdk.PluginManager(add_plugins=False)
test_plugin = create_plugin()
pm.add_plugin(test_plugin)

for action in test_plugin.actions.values():
    for example in action.examples.values():
        exc_use = usage.ExecutionUsage()
        dia_use = usage.DiagnosticUsage()
        art_use = plugins.ArtifactAPIUsage()
        
        example(exc_use)
        example(dia_use)
        example(art_use)

        rendered = art_use.render()
        # gross, but this gets example data in scope
        locals().update(art_use.get_example_data())
        try:
            exec(rendered)
        except:
            print(exc_use._get_records())
            print(dia_use._get_records())
            print(rendered)
            raise
```