### PR TITLE
IMP: save() updates: adding optional file extension argument

### DIFF
--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -338,7 +338,17 @@ class MetadataWriter:
     def __init__(self, metadata):
         self._metadata = metadata
 
-    def write(self, filepath):
+    def write(self, filepath, ext=None):
+        if ext is None:
+            ext = ''
+        else:
+            ext = '.' + ext.lstrip('.')
+
+        filepath = filepath.rstrip('.')
+
+        if not filepath.endswith(ext):
+            filepath += ext
+
         # Newline settings based on recommendation from csv docs:
         #     https://docs.python.org/3/library/csv.html#id3
 
@@ -367,6 +377,8 @@ class MetadataWriter:
             df.fillna('', inplace=True)
             df = df.applymap(self._format)
             tsv_writer.writerows(df.itertuples(index=True))
+
+        return filepath
 
     def _format(self, value):
         if isinstance(value, str):

--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -338,17 +338,7 @@ class MetadataWriter:
     def __init__(self, metadata):
         self._metadata = metadata
 
-    def write(self, filepath, ext=None):
-        if ext is None:
-            ext = ''
-        else:
-            ext = '.' + ext.lstrip('.')
-
-        filepath = filepath.rstrip('.')
-
-        if not filepath.endswith(ext):
-            filepath += ext
-
+    def write(self, filepath):
         # Newline settings based on recommendation from csv docs:
         #     https://docs.python.org/3/library/csv.html#id3
 
@@ -377,8 +367,6 @@ class MetadataWriter:
             df.fillna('', inplace=True)
             df = df.applymap(self._format)
             tsv_writer.writerows(df.itertuples(index=True))
-
-        return filepath
 
     def _format(self, value):
         if isinstance(value, str):

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -473,7 +473,7 @@ class Metadata(_MetadataBase):
         """
         return not (self == other)
 
-    def save(self, filepath):
+    def save(self, filepath, extension=None):
         """Save a TSV metadata file.
 
         The TSV metadata file format is described at https://docs.qiime2.org in
@@ -493,7 +493,12 @@ class Metadata(_MetadataBase):
 
         """
         from .io import MetadataWriter
+        
+        if extension is not None and not filepath.endswith(extension):
+            filepath += extension
+
         MetadataWriter(self).write(filepath)
+        return filepath
 
     def to_dataframe(self):
         """Create a pandas dataframe from the metadata.

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -487,13 +487,19 @@ class Metadata(_MetadataBase):
         filepath : str
             Path to save TSV metadata file at.
 
-        extension : str
+        ext : str
             Preferred file extension (.tsv, .txt, etc).
             Will be left blank if no extension is included.
             Including a period in the extension is
             optional, and any additional periods delimiting
             the filepath and the extension will be reduced
             to a single period.
+
+        Returns
+        -------
+        str
+            Filepath and extension (if provided) that the
+            file was saved to.
 
         See Also
         --------
@@ -502,18 +508,7 @@ class Metadata(_MetadataBase):
         """
         from .io import MetadataWriter
 
-        if ext is None:
-            ext = ''
-        else:
-            ext = '.' + ext.lstrip('.')
-
-        filepath = filepath.rstrip('.')
-
-        if not filepath.endswith(ext):
-            filepath += ext
-
-        MetadataWriter(self).write(filepath)
-        return filepath
+        return MetadataWriter(self).write(filepath, ext)
 
     def to_dataframe(self):
         """Create a pandas dataframe from the metadata.
@@ -958,7 +953,7 @@ class MetadataColumn(_MetadataBase, metaclass=abc.ABCMeta):
         """
         return not (self == other)
 
-    def save(self, filepath):
+    def save(self, filepath, ext=None):
         """Save a TSV metadata file containing this metadata column.
 
         The TSV metadata file format is described at https://docs.qiime2.org in
@@ -972,9 +967,24 @@ class MetadataColumn(_MetadataBase, metaclass=abc.ABCMeta):
         filepath : str
             Path to save TSV metadata file at.
 
+        ext : str
+            Preferred file extension (.tsv, .txt, etc).
+            Will be left blank if no extension is included.
+            Including a period in the extension is
+            optional, and any additional periods delimiting
+            the filepath and the extension will be reduced
+            to a single period.
+
+        Returns
+        -------
+        str
+            Filepath and extension (if provided) that the
+            file was saved to.
+
         """
         from .io import MetadataWriter
-        MetadataWriter(self).write(filepath)
+
+        return MetadataWriter(self).write(filepath, ext)
 
     def to_series(self):
         """Create a pandas series from the metadata column.

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -237,7 +237,7 @@ class _MetadataBase:
 
         """
         from .io import MetadataWriter
-        
+
         if ext is None:
             ext = ''
         else:
@@ -250,6 +250,7 @@ class _MetadataBase:
 
         MetadataWriter(self).write(filepath)
         return filepath
+
 
 # Other properties such as units can be included here in the future!
 ColumnProperties = collections.namedtuple('ColumnProperties', ['type'])

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -494,12 +494,23 @@ class Metadata(_MetadataBase):
         extension : str
             Preferred file extension (.tsv, .txt, etc).
             Will be left blank if no extension is included.
+            Note that including a period in the extension is
+            optional, and if either none or multiple periods
+            are included, they will be replaced with a single
+            period at the beginning of the extension.
 
         """
         from .io import MetadataWriter
 
-        if ext is not None and not filepath.endswith(ext):
-            filepath += ext
+        if ext is None:
+            ext = ''
+
+        if filepath.endswith('.') or ext.startswith('.'):
+            filepath = filepath.rstrip('.')
+            ext = ext.lstrip('.')
+
+        if not filepath.endswith(ext):
+            filepath += '.' + ext
 
         MetadataWriter(self).write(filepath)
         return filepath

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -504,13 +504,13 @@ class Metadata(_MetadataBase):
 
         if ext is None:
             ext = ''
+        else:
+            ext = '.' + ext.lstrip('.')
 
-        if filepath.endswith('.') or ext.startswith('.'):
-            filepath = filepath.rstrip('.')
-            ext = ext.lstrip('.')
+        filepath = filepath.rstrip('.')
 
         if not filepath.endswith(ext):
-            filepath += '.' + ext
+            filepath += ext
 
         MetadataWriter(self).write(filepath)
         return filepath

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -474,9 +474,9 @@ class Metadata(_MetadataBase):
         return not (self == other)
 
     def save(self, filepath, ext=None):
-        """Save a metadata file.
+        """Save a TSV metadata file.
 
-        The metadata file format is described at https://docs.qiime2.org in
+        The TSV metadata file format is described at https://docs.qiime2.org in
         the Metadata Tutorial.
 
         The file will always include the ``#q2:types`` directive in order to
@@ -485,19 +485,19 @@ class Metadata(_MetadataBase):
         Parameters
         ----------
         filepath : str
-            Path to save metadata file at.
-
-        See Also
-        --------
-        load
+            Path to save TSV metadata file at.
 
         extension : str
             Preferred file extension (.tsv, .txt, etc).
             Will be left blank if no extension is included.
-            Note that including a period in the extension is
-            optional, and if either none or multiple periods
-            are included, they will be replaced with a single
-            period at the beginning of the extension.
+            Including a period in the extension is
+            optional, and any additional periods delimiting
+            the filepath and the extension will be reduced
+            to a single period.
+
+        See Also
+        --------
+        load
 
         """
         from .io import MetadataWriter

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -492,7 +492,8 @@ class Metadata(_MetadataBase):
         load
 
         extension : str
-            Preferred file extension (.tsv, .txt, etc). Will be left blank if no extension is included.
+            Preferred file extension (.tsv, .txt, etc).
+            Will be left blank if no extension is included.
 
         """
         from .io import MetadataWriter

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -492,7 +492,7 @@ class Metadata(_MetadataBase):
         load
 
         extension : str
-            Preferred file extension (.tsv, etc). Will be left blank if no extension is included.
+            Preferred file extension (.tsv, .txt, etc). Will be left blank if no extension is included.
 
         """
         from .io import MetadataWriter

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -203,6 +203,53 @@ class _MetadataBase:
         return df_or_series.drop(labels=ids_to_discard, axis='index',
                                  inplace=False, errors='raise')
 
+    def save(self, filepath, ext=None):
+        """Save a TSV metadata file.
+
+        The TSV metadata file format is described at https://docs.qiime2.org in
+        the Metadata Tutorial.
+
+        The file will always include the ``#q2:types`` directive in order to
+        make the file roundtrippable without relying on column type inference.
+
+        Parameters
+        ----------
+        filepath : str
+            Path to save TSV metadata file at.
+
+        ext : str
+            Preferred file extension (.tsv, .txt, etc).
+            Will be left blank if no extension is included.
+            Including a period in the extension is
+            optional, and any additional periods delimiting
+            the filepath and the extension will be reduced
+            to a single period.
+
+        Returns
+        -------
+        str
+            Filepath and extension (if provided) that the
+            file was saved to.
+
+        See Also
+        --------
+        load
+
+        """
+        from .io import MetadataWriter
+        
+        if ext is None:
+            ext = ''
+        else:
+            ext = '.' + ext.lstrip('.')
+
+        filepath = filepath.rstrip('.')
+
+        if not filepath.endswith(ext):
+            filepath += ext
+
+        MetadataWriter(self).write(filepath)
+        return filepath
 
 # Other properties such as units can be included here in the future!
 ColumnProperties = collections.namedtuple('ColumnProperties', ['type'])
@@ -472,43 +519,6 @@ class Metadata(_MetadataBase):
 
         """
         return not (self == other)
-
-    def save(self, filepath, ext=None):
-        """Save a TSV metadata file.
-
-        The TSV metadata file format is described at https://docs.qiime2.org in
-        the Metadata Tutorial.
-
-        The file will always include the ``#q2:types`` directive in order to
-        make the file roundtrippable without relying on column type inference.
-
-        Parameters
-        ----------
-        filepath : str
-            Path to save TSV metadata file at.
-
-        ext : str
-            Preferred file extension (.tsv, .txt, etc).
-            Will be left blank if no extension is included.
-            Including a period in the extension is
-            optional, and any additional periods delimiting
-            the filepath and the extension will be reduced
-            to a single period.
-
-        Returns
-        -------
-        str
-            Filepath and extension (if provided) that the
-            file was saved to.
-
-        See Also
-        --------
-        load
-
-        """
-        from .io import MetadataWriter
-
-        return MetadataWriter(self).write(filepath, ext)
 
     def to_dataframe(self):
         """Create a pandas dataframe from the metadata.
@@ -952,39 +962,6 @@ class MetadataColumn(_MetadataBase, metaclass=abc.ABCMeta):
 
         """
         return not (self == other)
-
-    def save(self, filepath, ext=None):
-        """Save a TSV metadata file containing this metadata column.
-
-        The TSV metadata file format is described at https://docs.qiime2.org in
-        the Metadata Tutorial.
-
-        The file will always include the ``#q2:types`` directive in order to
-        make the file roundtrippable without relying on column type inference.
-
-        Parameters
-        ----------
-        filepath : str
-            Path to save TSV metadata file at.
-
-        ext : str
-            Preferred file extension (.tsv, .txt, etc).
-            Will be left blank if no extension is included.
-            Including a period in the extension is
-            optional, and any additional periods delimiting
-            the filepath and the extension will be reduced
-            to a single period.
-
-        Returns
-        -------
-        str
-            Filepath and extension (if provided) that the
-            file was saved to.
-
-        """
-        from .io import MetadataWriter
-
-        return MetadataWriter(self).write(filepath, ext)
 
     def to_series(self):
         """Create a pandas series from the metadata column.

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -233,7 +233,7 @@ class _MetadataBase:
 
         See Also
         --------
-        load
+        Metadata.load
 
         """
         from .io import MetadataWriter

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -474,9 +474,9 @@ class Metadata(_MetadataBase):
         return not (self == other)
 
     def save(self, filepath, extension=None):
-        """Save a TSV metadata file.
+        """Save a metadata file.
 
-        The TSV metadata file format is described at https://docs.qiime2.org in
+        The metadata file format is described at https://docs.qiime2.org in
         the Metadata Tutorial.
 
         The file will always include the ``#q2:types`` directive in order to
@@ -485,15 +485,18 @@ class Metadata(_MetadataBase):
         Parameters
         ----------
         filepath : str
-            Path to save TSV metadata file at.
+            Path to save metadata file at.
 
         See Also
         --------
         load
 
+        extension : str
+            Preferred file extension (.tsv, etc). Will be left blank if no extension is included.
+
         """
         from .io import MetadataWriter
-        
+
         if extension is not None and not filepath.endswith(extension):
             filepath += extension
 

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -473,7 +473,7 @@ class Metadata(_MetadataBase):
         """
         return not (self == other)
 
-    def save(self, filepath, extension=None):
+    def save(self, filepath, ext=None):
         """Save a metadata file.
 
         The metadata file format is described at https://docs.qiime2.org in
@@ -498,8 +498,8 @@ class Metadata(_MetadataBase):
         """
         from .io import MetadataWriter
 
-        if extension is not None and not filepath.endswith(extension):
-            filepath += extension
+        if ext is not None and not filepath.endswith(ext):
+            filepath += ext
 
         MetadataWriter(self).write(filepath)
         return filepath

--- a/qiime2/metadata/tests/test_io.py
+++ b/qiime2/metadata/tests/test_io.py
@@ -841,6 +841,13 @@ class TestSave(unittest.TestCase):
              'col3': ['foo', 'bar', '42']},
             index=pd.Index(['id1', 'id2', 'id3'], name='id')))
 
+        # Filename & extension endswith is matching (non-default).
+        fp = os.path.join(self.temp_dir, 'metadatatsv')
+        obs_md = md.save(fp, '.tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadatatsv.tsv')
+
         # No period in filename; no extension included.
         fp = os.path.join(self.temp_dir, 'metadata')
         obs_md = md.save(fp)

--- a/qiime2/metadata/tests/test_io.py
+++ b/qiime2/metadata/tests/test_io.py
@@ -853,7 +853,7 @@ class TestSave(unittest.TestCase):
         obs_md = md.save(fp, '.tsv')
         obs_filename = os.path.basename(obs_md)
 
-        self.assertEqual(obs_filename, 'metadata.tsv')        
+        self.assertEqual(obs_filename, 'metadata.tsv')
 
         # Extension in filename; no extension input.
         fp = os.path.join(self.temp_dir, 'metadata.tsv')
@@ -874,7 +874,7 @@ class TestSave(unittest.TestCase):
         obs_md = md.save(fp, '.tsv')
         obs_filename = os.path.basename(obs_md)
 
-        self.assertEqual(obs_filename, 'metadata.tsv')        
+        self.assertEqual(obs_filename, 'metadata.tsv')
 
     def test_no_bom(self):
         md = Metadata(pd.DataFrame(

--- a/qiime2/metadata/tests/test_io.py
+++ b/qiime2/metadata/tests/test_io.py
@@ -834,6 +834,48 @@ class TestSave(unittest.TestCase):
 
         self.assertEqual(obs, exp)
 
+    def test_save_metadata_auto_extension(self):
+        md = Metadata(pd.DataFrame(
+            {'col1': [1.0, 2.0, 3.0],
+             'col2': ['a', 'b', 'c'],
+             'col3': ['foo', 'bar', '42']},
+            index=pd.Index(['id1', 'id2', 'id3'], name='id')))
+
+        # No extension in filename; no extension input.
+        fp = os.path.join(self.temp_dir, 'metadata')
+        obs_md = md.save(fp)
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata')
+
+        # No extension in filename; extension input.
+        fp = os.path.join(self.temp_dir, 'metadata')
+        obs_md = md.save(fp, '.tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')        
+
+        # Extension in filename; no extension input.
+        fp = os.path.join(self.temp_dir, 'metadata.tsv')
+        obs_md = md.save(fp)
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')
+
+        # Extension in filename; extension input (non-matching).
+        fp = os.path.join(self.temp_dir, 'metadata.tsv')
+        obs_md = md.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv.txt')
+
+        # Extension in filename; extension input (matching).
+        fp = os.path.join(self.temp_dir, 'metadata.tsv')
+        obs_md = md.save(fp, '.tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')        
+
     def test_no_bom(self):
         md = Metadata(pd.DataFrame(
             {'col1': [1.0, 2.0, 3.0],

--- a/qiime2/metadata/tests/test_io.py
+++ b/qiime2/metadata/tests/test_io.py
@@ -841,6 +841,62 @@ class TestSave(unittest.TestCase):
              'col3': ['foo', 'bar', '42']},
             index=pd.Index(['id1', 'id2', 'id3'], name='id')))
 
+        # No period in filename; no extension included.
+        fp = os.path.join(self.temp_dir, 'metadata')
+        obs_md = md.save(fp)
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata')
+
+        # No period in filename; no period in extension.
+        fp = os.path.join(self.temp_dir, 'metadata')
+        obs_md = md.save(fp, 'tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')
+
+        # No period in filename; multiple periods in extension.
+        fp = os.path.join(self.temp_dir, 'metadata')
+        obs_md = md.save(fp, '..tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')
+
+        # Single period in filename; no period in extension.
+        fp = os.path.join(self.temp_dir, 'metadata.')
+        obs_md = md.save(fp, 'tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')
+
+        # Single period in filename; single period in extension.
+        fp = os.path.join(self.temp_dir, 'metadata.')
+        obs_md = md.save(fp, '.tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')
+
+        # Single period in filename; multiple periods in extension.
+        fp = os.path.join(self.temp_dir, 'metadata.')
+        obs_md = md.save(fp, '..tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')
+
+        # Multiple periods in filename; single period in extension.
+        fp = os.path.join(self.temp_dir, 'metadata..')
+        obs_md = md.save(fp, '.tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')
+
+        # Multiple periods in filename; multiple periods in extension.
+        fp = os.path.join(self.temp_dir, 'metadata..')
+        obs_md = md.save(fp, '..tsv')
+        obs_filename = os.path.basename(obs_md)
+
+        self.assertEqual(obs_filename, 'metadata.tsv')
+
         # No extension in filename; no extension input.
         fp = os.path.join(self.temp_dir, 'metadata')
         obs_md = md.save(fp)

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -326,7 +326,7 @@ class Artifact(Result):
 
 
 class Visualization(Result):
-    # extension = '.qzv'
+    extension = '.qzv'
 
     @classmethod
     def _is_valid_type(cls, type_):
@@ -366,9 +366,3 @@ class Visualization(Result):
     def _repr_html_(self):
         from qiime2.jupyter import make_html
         return make_html(str(self._archiver.path))
-
-    def save(self, filepath, extension='.qzv'):
-        if not filepath.endswith(self.extension):
-            filepath += self.extension
-        self._archiver.save(filepath)
-        return filepath

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -160,14 +160,24 @@ class Result:
             If no preferred extension input is included,
             Artifact extension will default to .qza and
             Visualization extension will default to .qzv.
+            Note that including a period in the extension is
+            optional, and if either none or multiple periods
+            are included, they will be replaced with a single
+            period at the beginning of the extension.
 
 
         """
         if ext is None:
             ext = self.extension
+    
+        # This accounts for edge cases in the filename extension
+        # and ensures that there is only a single period in the ext.
+        if filepath.endswith('.') or ext.startswith('.'):
+            filepath = filepath.rstrip('.')
+            ext = ext.lstrip('.')
 
         if not filepath.endswith(ext):
-            filepath += ext
+            filepath += '.' + ext
 
         self._archiver.save(filepath)
         return filepath
@@ -208,7 +218,7 @@ class Result:
 
 
 class Artifact(Result):
-    extension = '.qza'
+    extension = 'qza'
 
     @classmethod
     def _is_valid_type(cls, type_):
@@ -345,7 +355,7 @@ class Artifact(Result):
 
 
 class Visualization(Result):
-    extension = '.qzv'
+    extension = 'qzv'
 
     @classmethod
     def _is_valid_type(cls, type_):

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -157,7 +157,7 @@ class Result:
 
         extension : str
             Preferred file extension (.qza, .qzv, .txt, etc). If no preferred extension input is included,
-            Artifact extensions will default to .qza and Visualization extensions will default to .qzv.
+            Artifact extension will default to .qza and Visualization extension will default to .qzv.
 
 
         """

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -164,7 +164,7 @@ class Result:
 
         """
         if ext is None:
-            ext = self.ext
+            ext = self.extension
 
         if not filepath.endswith(ext):
             filepath += ext

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -144,6 +144,23 @@ class Result:
         return self._archiver._destructor
 
     def save(self, filepath, extension=None):
+        """Save an artifact (.qza) or visualization (.qzv) file.
+
+        Parameters
+        ----------
+        filepath : str
+            Path to save artifact or visualization file at.
+
+        See Also
+        --------
+        load
+
+        extension : str
+            Preferred file extension (.qza, .qzv, .txt, etc). If no preferred extension input is included,
+            Artifact extensions will default to .qza and Visualization extensions will default to .qzv.
+
+
+        """
         if extension is None:
             extension = self.extension
         

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -156,14 +156,16 @@ class Result:
         load
 
         extension : str
-            Preferred file extension (.qza, .qzv, .txt, etc). If no preferred extension input is included,
-            Artifact extension will default to .qza and Visualization extension will default to .qzv.
+            Preferred file extension (.qza, .qzv, .txt, etc).
+            If no preferred extension input is included,
+            Artifact extension will default to .qza and
+            Visualization extension will default to .qzv.
 
 
         """
         if extension is None:
             extension = self.extension
-        
+
         if not filepath.endswith(extension):
             filepath += extension
 

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -143,7 +143,7 @@ class Result:
     def _destructor(self):
         return self._archiver._destructor
 
-    def save(self, filepath, extension=None):
+    def save(self, filepath, ext=None):
         """Save an artifact (.qza) or visualization (.qzv) file.
 
         Parameters
@@ -163,11 +163,11 @@ class Result:
 
 
         """
-        if extension is None:
-            extension = self.extension
+        if ext is None:
+            ext = self.ext
 
-        if not filepath.endswith(extension):
-            filepath += extension
+        if not filepath.endswith(ext):
+            filepath += ext
 
         self._archiver.save(filepath)
         return filepath

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -144,27 +144,26 @@ class Result:
         return self._archiver._destructor
 
     def save(self, filepath, ext=None):
-        """Save an artifact (.qza) or visualization (.qzv) file.
+        """Save to a file.
 
         Parameters
         ----------
         filepath : str
-            Path to save artifact or visualization file at.
-
-        See Also
-        --------
-        load
+            Path to save file at.
 
         extension : str
             Preferred file extension (.qza, .qzv, .txt, etc).
             If no preferred extension input is included,
             Artifact extension will default to .qza and
             Visualization extension will default to .qzv.
-            Note that including a period in the extension is
-            optional, and if either none or multiple periods
-            are included, they will be replaced with a single
-            period at the beginning of the extension.
+            Including a period in the extension is
+            optional, and any additional periods delimiting
+            the filepath and the extension will be reduced
+            to a single period.
 
+        See Also
+        --------
+        load
 
         """
         if ext is None:
@@ -217,7 +216,7 @@ class Result:
 
 
 class Artifact(Result):
-    extension = 'qza'
+    extension = '.qza'
 
     @classmethod
     def _is_valid_type(cls, type_):
@@ -354,7 +353,7 @@ class Artifact(Result):
 
 
 class Visualization(Result):
-    extension = 'qzv'
+    extension = '.qzv'
 
     @classmethod
     def _is_valid_type(cls, type_):

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -324,12 +324,6 @@ class Artifact(Result):
 
         self.format.validate(self.view(self.format), level)
 
-    # def save(self, filepath, extension='.qza'):
-    #     if not filepath.endswith(self.extension):
-    #         filepath += self.extension
-    #     self._archiver.save(filepath)
-    #     return filepath
-
 
 class Visualization(Result):
     # extension = '.qzv'

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -169,7 +169,7 @@ class Result:
         """
         if ext is None:
             ext = self.extension
-    
+
         # This accounts for edge cases in the filename extension
         # and ensures that there is only a single period in the ext.
         if filepath.endswith('.') or ext.startswith('.'):

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -161,6 +161,11 @@ class Result:
             the filepath and the extension will be reduced
             to a single period.
 
+        Returns
+        -------
+        str
+            Filepath and extension (if provided) that the
+            file was saved to.
         See Also
         --------
         load

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -143,9 +143,13 @@ class Result:
     def _destructor(self):
         return self._archiver._destructor
 
-    def save(self, filepath):
-        if not filepath.endswith(self.extension):
-            filepath += self.extension
+    def save(self, filepath, extension=None):
+        if extension is None:
+            extension = self.extension
+        
+        if not filepath.endswith(extension):
+            filepath += extension
+
         self._archiver.save(filepath)
         return filepath
 
@@ -320,9 +324,15 @@ class Artifact(Result):
 
         self.format.validate(self.view(self.format), level)
 
+    # def save(self, filepath, extension='.qza'):
+    #     if not filepath.endswith(self.extension):
+    #         filepath += self.extension
+    #     self._archiver.save(filepath)
+    #     return filepath
+
 
 class Visualization(Result):
-    extension = '.qzv'
+    # extension = '.qzv'
 
     @classmethod
     def _is_valid_type(cls, type_):
@@ -362,3 +372,9 @@ class Visualization(Result):
     def _repr_html_(self):
         from qiime2.jupyter import make_html
         return make_html(str(self._archiver.path))
+
+    def save(self, filepath, extension='.qzv'):
+        if not filepath.endswith(self.extension):
+            filepath += self.extension
+        self._archiver.save(filepath)
+        return filepath

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -166,6 +166,7 @@ class Result:
         str
             Filepath and extension (if provided) that the
             file was saved to.
+
         See Also
         --------
         load

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -172,12 +172,11 @@ class Result:
 
         # This accounts for edge cases in the filename extension
         # and ensures that there is only a single period in the ext.
-        if filepath.endswith('.') or ext.startswith('.'):
-            filepath = filepath.rstrip('.')
-            ext = ext.lstrip('.')
+        filepath = filepath.rstrip('.')
+        ext = '.' + ext.lstrip('.')
 
         if not filepath.endswith(ext):
-            filepath += '.' + ext
+            filepath += ext
 
         self._archiver.save(filepath)
         return filepath

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -157,21 +157,37 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
     def test_save_artifact_auto_extension(self):
         artifact = Artifact.import_data(FourInts, [0, 0, 42, 1000])
 
-        # No extension.
+        # No extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'artifact')
         obs_fp = artifact.save(fp)
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'artifact.qza')
 
-        # Wrong extension.
+#######################################################################
+        # No extension in filename; different extension input.
+        fp = os.path.join(self.test_dir.name, 'artifact','.txt')
+        obs_fp = artifact.save(fp)
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.txt')
+
+        # No extension in filename; default extension input.
+        fp = os.path.join(self.test_dir.name, 'artifact','.qza')
+        obs_fp = artifact.save(fp)
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.qza')
+
+######################################################################
+        # Different extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'artifact.zip')
         obs_fp = artifact.save(fp)
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'artifact.zip.qza')
 
-        # Correct extension.
+        # Default extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'artifact.qza')
         obs_fp = artifact.save(fp)
         obs_filename = os.path.basename(obs_fp)

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -166,15 +166,15 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
 
 #######################################################################
         # No extension in filename; different extension input.
-        fp = os.path.join(self.test_dir.name, 'artifact','.txt')
-        obs_fp = artifact.save(fp)
+        fp = os.path.join(self.test_dir.name, 'artifact')
+        obs_fp = artifact.save(fp, '.txt')
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'artifact.txt')
 
         # No extension in filename; default extension input.
-        fp = os.path.join(self.test_dir.name, 'artifact','.qza')
-        obs_fp = artifact.save(fp)
+        fp = os.path.join(self.test_dir.name, 'artifact')
+        obs_fp = artifact.save(fp, '.qza')
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'artifact.qza')

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -197,7 +197,7 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
         obs_fp = artifact.save(fp, '.zip')
         obs_filename = os.path.basename(obs_fp)
 
-        self.assertEqual(obs_filename, 'artifact.zip')        
+        self.assertEqual(obs_filename, 'artifact.zip')
 
         # Different extension in filename; default extension input.
         fp = os.path.join(self.test_dir.name, 'artifact.zip')
@@ -271,7 +271,7 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
         obs_fp = visualization.save(fp, '.zip')
         obs_filename = os.path.basename(obs_fp)
 
-        self.assertEqual(obs_filename, 'visualization.zip')        
+        self.assertEqual(obs_filename, 'visualization.zip')
 
         # Different extension in filename; default extension input.
         fp = os.path.join(self.test_dir.name, 'visualization.zip')

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -157,6 +157,20 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
     def test_save_artifact_auto_extension(self):
         artifact = Artifact.import_data(FourInts, [0, 0, 42, 1000])
 
+        # Filename & extension endswith is matching (default).
+        fp = os.path.join(self.test_dir.name, 'artifactqza')
+        obs_fp = artifact.save(fp)
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifactqza.qza')
+
+        # Filename & extension endswith is matching (non-default).
+        fp = os.path.join(self.test_dir.name, 'artifacttxt')
+        obs_fp = artifact.save(fp, 'txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifacttxt.txt')
+
         # No period in filename; no period in extension.
         fp = os.path.join(self.test_dir.name, 'artifact')
         obs_fp = artifact.save(fp, 'txt')
@@ -281,6 +295,20 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
     def test_save_visualization_auto_extension(self):
         visualization = Visualization._from_data_dir(
              self.data_dir, self.make_provenance_capture())
+
+        # Filename & extension endswith is matching (default).
+        fp = os.path.join(self.test_dir.name, 'visualizationqzv')
+        obs_fp = visualization.save(fp)
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualizationqzv.qzv')
+
+        # Filename & extension endswith is matching (non-default).
+        fp = os.path.join(self.test_dir.name, 'visualizationtxt')
+        obs_fp = visualization.save(fp, 'txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualizationtxt.txt')
 
         # No period in filename; no period in extension.
         fp = os.path.join(self.test_dir.name, 'visualization')

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -185,9 +185,26 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
 
         self.assertEqual(obs_filename, 'artifact.zip.qza')
 
-        # Different extension in filename; different extension input.
+        # Different extension in filename; different extension input (non-matching).
+        fp = os.path.join(self.test_dir.name, 'artifact.zip')
+        obs_fp = artifact.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.zip.txt')
+
+        # Different extension in filename; different extension input (matching).
+        fp = os.path.join(self.test_dir.name, 'artifact.zip')
+        obs_fp = artifact.save(fp, '.zip')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.zip')        
 
         # Different extension in filename; default extension input.
+        fp = os.path.join(self.test_dir.name, 'artifact.zip')
+        obs_fp = artifact.save(fp, '.qza')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.zip.qza')
 
         # Default extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'artifact.qza')
@@ -197,8 +214,18 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
         self.assertEqual(obs_filename, 'artifact.qza')
 
         # Default extension in filename; different extension input.
+        fp = os.path.join(self.test_dir.name, 'artifact.qza')
+        obs_fp = artifact.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.qza.txt')
 
         # Default extension in filename; default extension input.
+        fp = os.path.join(self.test_dir.name, 'artifact.qza')
+        obs_fp = artifact.save(fp, '.qza')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.qza')
 
     def test_save_visualization_auto_extension(self):
         visualization = Visualization._from_data_dir(
@@ -232,9 +259,26 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
 
         self.assertEqual(obs_filename, 'visualization.zip.qzv')
 
-        # Different extension in filename; different extension input.
+        # Different extension in filename; different extension input (non-matching).
+        fp = os.path.join(self.test_dir.name, 'visualization.zip')
+        obs_fp = visualization.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.zip.txt')
+
+        # Different extension in filename; different extension input (matching).
+        fp = os.path.join(self.test_dir.name, 'visualization.zip')
+        obs_fp = visualization.save(fp, '.zip')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.zip')        
 
         # Different extension in filename; default extension input.
+        fp = os.path.join(self.test_dir.name, 'visualization.zip')
+        obs_fp = visualization.save(fp, '.qzv')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.zip.qzv')
 
         # Default extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'visualization.qzv')
@@ -244,8 +288,18 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
         self.assertEqual(obs_filename, 'visualization.qzv')
 
         # Default extension in filename; different extension input.
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
+        obs_fp = visualization.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.qzv.txt')
 
         # Default extension in filename; default extension input.
+        fp = os.path.join(self.test_dir.name, 'visualization.qzv')
+        obs_fp = visualization.save(fp, '.qzv')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.qzv')
 
     def test_import_data_single_dirfmt_to_single_dirfmt(self):
         temp_data_dir = os.path.join(self.test_dir.name, 'import')

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -185,14 +185,16 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
 
         self.assertEqual(obs_filename, 'artifact.zip.qza')
 
-        # Different extension in filename; different extension input (non-matching).
+        # Different extension in filename;
+        # Different extension input (non-matching).
         fp = os.path.join(self.test_dir.name, 'artifact.zip')
         obs_fp = artifact.save(fp, '.txt')
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'artifact.zip.txt')
 
-        # Different extension in filename; different extension input (matching).
+        # Different extension in filename;
+        # Different extension input (matching).
         fp = os.path.join(self.test_dir.name, 'artifact.zip')
         obs_fp = artifact.save(fp, '.zip')
         obs_filename = os.path.basename(obs_fp)
@@ -259,14 +261,16 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
 
         self.assertEqual(obs_filename, 'visualization.zip.qzv')
 
-        # Different extension in filename; different extension input (non-matching).
+        # Different extension in filename;
+        # Different extension input (non-matching).
         fp = os.path.join(self.test_dir.name, 'visualization.zip')
         obs_fp = visualization.save(fp, '.txt')
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'visualization.zip.txt')
 
-        # Different extension in filename; different extension input (matching).
+        # Different extension in filename;
+        # Different extension input (matching).
         fp = os.path.join(self.test_dir.name, 'visualization.zip')
         obs_fp = visualization.save(fp, '.zip')
         obs_filename = os.path.basename(obs_fp)

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -157,6 +157,55 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
     def test_save_artifact_auto_extension(self):
         artifact = Artifact.import_data(FourInts, [0, 0, 42, 1000])
 
+        # No period in filename; no period in extension.
+        fp = os.path.join(self.test_dir.name, 'artifact')
+        obs_fp = artifact.save(fp, 'txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.txt')
+
+        # No period in filename; multiple periods in extension.
+        fp = os.path.join(self.test_dir.name, 'artifact')
+        obs_fp = artifact.save(fp, '..txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.txt')
+
+        # Single period in filename; no period in extension.
+        fp = os.path.join(self.test_dir.name, 'artifact.')
+        obs_fp = artifact.save(fp, 'txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.txt')
+
+        # Single period in filename; single period in extension.
+        fp = os.path.join(self.test_dir.name, 'artifact.')
+        obs_fp = artifact.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.txt')
+
+        # Single period in filename; multiple periods in extension.
+        fp = os.path.join(self.test_dir.name, 'artifact.')
+        obs_fp = artifact.save(fp, '..txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.txt')
+
+        # Multiple periods in filename; single period in extension.
+        fp = os.path.join(self.test_dir.name, 'artifact..')
+        obs_fp = artifact.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.txt')
+
+        # Multiple periods in filename; multiple periods in extension.
+        fp = os.path.join(self.test_dir.name, 'artifact..')
+        obs_fp = artifact.save(fp, '..txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'artifact.txt')
+
         # No extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'artifact')
         obs_fp = artifact.save(fp)
@@ -232,6 +281,55 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
     def test_save_visualization_auto_extension(self):
         visualization = Visualization._from_data_dir(
              self.data_dir, self.make_provenance_capture())
+
+        # No period in filename; no period in extension.
+        fp = os.path.join(self.test_dir.name, 'visualization')
+        obs_fp = visualization.save(fp, 'txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.txt')
+
+        # No period in filename; multiple periods in extension.
+        fp = os.path.join(self.test_dir.name, 'visualization')
+        obs_fp = visualization.save(fp, '..txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.txt')
+
+        # Single period in filename; no period in extension.
+        fp = os.path.join(self.test_dir.name, 'visualization.')
+        obs_fp = visualization.save(fp, 'txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.txt')
+
+        # Single period in filename; single period in extension.
+        fp = os.path.join(self.test_dir.name, 'visualization.')
+        obs_fp = visualization.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.txt')
+
+        # Single period in filename; multiple periods in extension.
+        fp = os.path.join(self.test_dir.name, 'visualization.')
+        obs_fp = visualization.save(fp, '..txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.txt')
+
+        # Multiple periods in filename; single period in extension.
+        fp = os.path.join(self.test_dir.name, 'visualization..')
+        obs_fp = visualization.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.txt')
+
+        # Multiple periods in filename; multiple periods in extension.
+        fp = os.path.join(self.test_dir.name, 'visualization..')
+        obs_fp = visualization.save(fp, '..txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.txt')
 
         # No extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'visualization')

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -164,7 +164,6 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
 
         self.assertEqual(obs_filename, 'artifact.qza')
 
-#######################################################################
         # No extension in filename; different extension input.
         fp = os.path.join(self.test_dir.name, 'artifact')
         obs_fp = artifact.save(fp, '.txt')
@@ -179,13 +178,16 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
 
         self.assertEqual(obs_filename, 'artifact.qza')
 
-######################################################################
         # Different extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'artifact.zip')
         obs_fp = artifact.save(fp)
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'artifact.zip.qza')
+
+        # Different extension in filename; different extension input.
+
+        # Different extension in filename; default extension input.
 
         # Default extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'artifact.qza')
@@ -194,30 +196,56 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
 
         self.assertEqual(obs_filename, 'artifact.qza')
 
+        # Default extension in filename; different extension input.
+
+        # Default extension in filename; default extension input.
+
     def test_save_visualization_auto_extension(self):
         visualization = Visualization._from_data_dir(
              self.data_dir, self.make_provenance_capture())
 
-        # No extension.
+        # No extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'visualization')
         obs_fp = visualization.save(fp)
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'visualization.qzv')
 
-        # Wrong extension.
+        # No extension in filename; different extension input.
+        fp = os.path.join(self.test_dir.name, 'visualization')
+        obs_fp = visualization.save(fp, '.txt')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.txt')
+
+        # No extension in filename; default extension input.
+        fp = os.path.join(self.test_dir.name, 'visualization')
+        obs_fp = visualization.save(fp, '.qzv')
+        obs_filename = os.path.basename(obs_fp)
+
+        self.assertEqual(obs_filename, 'visualization.qzv')
+
+        # Different extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'visualization.zip')
         obs_fp = visualization.save(fp)
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'visualization.zip.qzv')
 
-        # Correct extension.
+        # Different extension in filename; different extension input.
+
+        # Different extension in filename; default extension input.
+
+        # Default extension in filename; no extension input.
         fp = os.path.join(self.test_dir.name, 'visualization.qzv')
         obs_fp = visualization.save(fp)
         obs_filename = os.path.basename(obs_fp)
 
         self.assertEqual(obs_filename, 'visualization.qzv')
+
+        # Default extension in filename; different extension input.
+
+        # Default extension in filename; default extension input.
 
     def test_import_data_single_dirfmt_to_single_dirfmt(self):
         temp_data_dir = os.path.join(self.test_dir.name, 'import')


### PR DESCRIPTION
.save() method now includes the extension argument, which takes string values as input.
This argument has been added for Metadata, Artifact, and Visualization classes.
Default values (if left blank) for each class are as follows:

Metadata: blank
Artifact: .qza
Visualization: .qzv

Additionally, Metadata.save() will now return the filepath (including optional extension), just as Artifact and Visualization currently do.

Unit tests have been implemented for the above changes, as well as docstring additions.