### PR TITLE
NEW: adds assert_output_type to Usage API

### DIFF
--- a/qiime2/core/testing/examples.py
+++ b/qiime2/core/testing/examples.py
@@ -135,6 +135,12 @@ def typical_pipeline_complex(use):
         expression='1',
     )
 
+    # test that the non-string type works
+    right2.assert_output_type(label='some label', semantic_type=IntSequence1)
+    # test that the string type works
+    out_map = use.get_result('out_map1')
+    out_map.assert_output_type(label='another label', semantic_type='Mapping')
+
 
 def comments_only(use):
     use.comment('comment 1')

--- a/qiime2/plugins.py
+++ b/qiime2/plugins.py
@@ -70,6 +70,9 @@ class ArtifactAPIUsage(usage.Usage):
     def _assert_has_line_matching_(self, ref, label, path, expression):
         pass
 
+    def _assert_output_type_(self, ref, label, semantic_type):
+        pass
+
     def render(self):
         sorted_imps = sorted(self._imports, key=lambda x: x[0])
         imps = ['from %s import %s\n' % i for i in sorted_imps]

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -382,6 +382,11 @@ class TestScopeRecord(TestCaseUsage):
             usage.ScopeRecord('foo', 'value', 'source',
                               assert_has_line_matching='spleen')
 
+    def test_invalid_assert_output_type(self):
+        with self.assertRaisesRegex(TypeError, 'should be a `callable`'):
+            usage.ScopeRecord('foo', 'value', 'source',
+                              assert_output_type='spleen')
+
 
 class TestExecutionUsage(TestCaseUsage):
     def test_init_data(self):

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -940,4 +940,7 @@ class ExecutionUsage(Usage):
 
     def _assert_output_type_(self, ref, label, semantic_type):
         data = self._get_record(ref).result
-        assert str(data.type) == str(semantic_type)
+        if str(data.type) != str(semantic_type):
+            raise AssertionError("Output %r has type %s, which does not match"
+                                 " expected output type of %s"
+                                 % (ref, data.type, semantic_type))


### PR DESCRIPTION
I think this will help with TypeMap usage implementations.