### PR TITLE
BUG: class view_type in Usage.import_from_format

### DIFF
--- a/qiime2/plugins.py
+++ b/qiime2/plugins.py
@@ -205,7 +205,7 @@ class ArtifactAPIUsage(usage.Usage):
             if type(view_type) is not str:
                 # Show users where these formats come from when used in the
                 # Python API to make things less "magical".
-                import_path = _cannonical_module(view_type)
+                import_path = _canonical_module(view_type)
                 view_type = view_type.__name__
                 if import_path is not None:
                     self._update_imports(from_=import_path,
@@ -378,7 +378,7 @@ class ArtifactAPIUsage(usage.Usage):
             self.global_imports.add(rendered)
 
 
-def _cannonical_module(obj):
+def _canonical_module(obj):
     last_module = None
     module_str = obj.__module__
     parts = module_str.split('.')


### PR DESCRIPTION
This may be overkill, but I really like how the output ended up.

With `str` view_type:
![image](https://user-images.githubusercontent.com/3976804/150028078-56e136e3-150e-4a80-b9c6-6d1329f663b9.png)

With `class` view_type:
![image](https://user-images.githubusercontent.com/3976804/150028185-44506c98-8a77-4a78-bf5c-443e9b81a01e.png)
