### PR TITLE
BUG: semantic validation's transformations

### DIFF
--- a/qiime2/core/tests/test_validate.py
+++ b/qiime2/core/tests/test_validate.py
@@ -133,6 +133,7 @@ class TestValidationObject(unittest.TestCase):
         validator_object = ValidationObject(IntSequence1)
 
         has_run = False
+        has_also_run = False
 
         def test_validator_method(data: list, level):
             nonlocal has_run
@@ -140,15 +141,26 @@ class TestValidationObject(unittest.TestCase):
             self.assertEqual(data, [0, 1, 2])
             self.assertEqual(level, 'max')
 
-        test_record = ValidatorRecord(validator=test_validator_method,
-                                      view=list, plugin='this_plugin',
-                                      context=IntSequence1)
+        def test_another_validator(data: IntSequenceFormat, level):
+            nonlocal has_also_run
+            has_also_run = True
+            self.assertEqual(level, 'max')
 
-        validator_object.add_validator(test_record)
+        test_record1 = ValidatorRecord(validator=test_validator_method,
+                                       view=list, plugin='this_plugin',
+                                       context=IntSequence1 | AscIntSequence)
+        test_record2 = ValidatorRecord(validator=test_another_validator,
+                                       view=IntSequenceFormat,
+                                       plugin='this_plugin',
+                                       context=IntSequence1)
+
+        validator_object.add_validator(test_record1)
+        validator_object.add_validator(test_record2)
 
         validator_object(self.simple_int_seq, level='max')
 
         self.assertTrue(has_run)
+        self.assertTrue(has_also_run)
 
     def test_run_validators_validation_exception(self):
         validator_object = ValidationObject(AscIntSequence)

--- a/qiime2/core/validate.py
+++ b/qiime2/core/validate.py
@@ -148,9 +148,9 @@ class ValidationObject:
         for record in self.validators:
             to_mt = ModelType.from_view_type(record.view)
             transformation = from_mt.make_transformation(to_mt)
-            data = transformation(data)
+            new_data = transformation(data)
             try:
-                record.validator(data=data, level=level)
+                record.validator(data=new_data, level=level)
             except ValidationError:
                 raise
             except Exception as e:
@@ -158,7 +158,7 @@ class ValidationObject:
                                           " from %r attempted to validate %r"
                                           % (record.validator.__name__,
                                              record.plugin,
-                                             data)) from e
+                                             new_data)) from e
 
     def assert_transformation_available(self, data):
         r"""


### PR DESCRIPTION
Discovered in q2-fmt. When multiple validators exist, the "source" `data` was overwritten within a loop, causing the next iteration to fail as `data` would have the wrong type for the next selected transformer.
