### PR TITLE
NEW/MISC: allow dict for output registrations and error/sort on sets

### DIFF
--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -160,9 +160,9 @@ dummy_plugin.methods.register_function(
         'int1': Int,
         'int2': Int
     },
-    outputs=[
-        ('concatenated_ints', IntSequence1)
-    ],
+    outputs={
+        'concatenated_ints': IntSequence1
+    },
     name='Concatenate integers',
     description='This method concatenates integers into'
                 ' a single sequence in the order they are provided.',
@@ -182,10 +182,10 @@ dummy_plugin.methods.register_function(
         'ints': T
     },
     parameters={},
-    outputs=[
-        ('left', T),
-        ('right', T)
-    ],
+    outputs={
+        'left': T,
+        'right': T
+    },
     name='Split sequence of integers in half',
     description='This method splits a sequence of integers in half, returning '
                 'the two halves (left and right). If the input sequence\'s '

--- a/qiime2/core/type/primitive.py
+++ b/qiime2/core/type/primitive.py
@@ -211,6 +211,10 @@ class Choices(_PrimitivePredicateBase):
         if len(choices) == 1:
             if not isinstance(choices[0], (bool, str)):
                 choices = choices[0]
+                if type(choices) is set:
+                    # Choices should sort the provided set so interfaces which
+                    # cache the type have a predictable order
+                    choices = sorted(choices)
 
         self.choices = choices = tuple(choices)
         if len(choices) != len(set(choices)):

--- a/qiime2/core/type/tests/test_primitive.py
+++ b/qiime2/core/type/tests/test_primitive.py
@@ -50,6 +50,50 @@ class TestIntersectTwoRanges(unittest.TestCase):
         self.assertIntersectEqual(a, b, grammar.UnionExp())
 
 
+class TestChoices(unittest.TestCase):
+    def test_list_constructor(self):
+        choices = primitive.Choices(['a', 'b', 'c'])
+
+        self.assertEqual(choices.template.choices, ('a', 'b', 'c'))
+        self.assertIn('a', choices)
+        self.assertNotIn('x', choices)
+
+    def test_set_constructor(self):
+        choices = primitive.Choices({'a', 'b', 'c'})
+
+        self.assertEqual(choices.template.choices, ('a', 'b', 'c'))
+        self.assertIn('a', choices)
+        self.assertNotIn('x', choices)
+
+    def test_varargs_constructor(self):
+        choices = primitive.Choices('a', 'b', 'c')
+
+        self.assertEqual(choices.template.choices, ('a', 'b', 'c'))
+        self.assertIn('a', choices)
+        self.assertNotIn('x', choices)
+
+    def test_union(self):
+        a = primitive.Choices('a', 'b', 'c')
+        b = primitive.Choices('x', 'y', 'z')
+
+        r = a | b
+
+        self.assertIn('a', r)
+        self.assertIn('x', r)
+        self.assertNotIn('foo', r)
+
+    def test_intersection(self):
+        a = primitive.Choices('a', 'b', 'c')
+        b = primitive.Choices('a', 'c', 'z')
+
+        r = a & b
+
+        self.assertIn('a', r)
+        self.assertIn('c', r)
+        self.assertNotIn('b', r)
+        self.assertNotIn('z', r)
+
+
 class TestMetadataColumn(unittest.TestCase):
 
     def test_decode_categorical_value(self):


### PR DESCRIPTION
Fixes a long-standing annoyance for output registration.
Also, prevents the plugin author from accidentally creating a `set` of tuples as the output registration.

Sorts `set`s provided to `Choices` so that interfaces which cache the types will maintain a consistent ordering.