### PR TITLE
BUG: column type now informed by Metadata.load's `default_missing_scheme`

### DIFF
--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -113,7 +113,8 @@ class MetadataReader:
         if column_missing_schemes is None:
             column_missing_schemes = {}
 
-        resolved_missing = directives.get('missing', {})
+        resolved_missing = {c: default_missing_scheme for c in df.columns}
+        resolved_missing.update(directives.get('missing', {}))
         resolved_missing.update(column_missing_schemes)
 
         try:

--- a/qiime2/metadata/tests/data/valid/missing-insdc-no-directive.tsv
+++ b/qiime2/metadata/tests/data/valid/missing-insdc-no-directive.tsv
@@ -1,0 +1,7 @@
+id	col1	col2	col3
+id1	1	a	foo
+id2	2	b	bar
+id3	3	c	42
+id4	not applicable	missing	anything
+id5	not collected	not provided	whatever
+id6	restricted access	restricted access	10

--- a/qiime2/metadata/tests/test_io.py
+++ b/qiime2/metadata/tests/test_io.py
@@ -620,6 +620,33 @@ class TestLoadSuccess(unittest.TestCase):
         ]
         self.assertEqual(obs_columns, exp_columns)
 
+    def test_insdc_no_directives(self):
+        fp = get_data_path('valid/missing-insdc-no-directive.tsv')
+
+        obs_md = Metadata.load(fp, default_missing_scheme='INSDC:missing')
+
+        exp_index = pd.Index(['id1', 'id2', 'id3', 'id4', 'id5', 'id6'],
+                             name='id')
+        exp_df = pd.DataFrame({'col1': [1, 2, 3] + ([float('nan')] * 3),
+                               'col2': ['a', 'b', 'c'] + ([float('nan')] * 3),
+                               'col3': ['foo', 'bar', '42', 'anything',
+                                        'whatever', '10']}, index=exp_index)
+
+        # not testing column_missing_schemes here on purpose, externally the
+        # nan's shouldn't be meaningfully different
+        exp_md = Metadata(exp_df)
+        pd.testing.assert_frame_equal(obs_md.to_dataframe(),
+                                      exp_md.to_dataframe())
+
+        obs_columns = [(name, props.type, props.missing_scheme)
+                       for name, props in obs_md.columns.items()]
+        exp_columns = [
+            ('col1', 'numeric', 'INSDC:missing'),
+            ('col2', 'categorical', 'INSDC:missing'),
+            ('col3', 'categorical', 'INSDC:missing')
+        ]
+        self.assertEqual(obs_columns, exp_columns)
+
     def test_insdc_override(self):
         fp = get_data_path('valid/override-insdc.tsv')
 


### PR DESCRIPTION
There was a bug in `Metadata.load()` where a set `default_missing_scheme` would not inform the column type detection/validation which would result in numeric columns being falsely attributed to categorical (or raise an error if the type was specifically noted in a directive without a corresponding missing directive).

Noticed by @antgonza in [this forum post](https://forum.qiime2.org/t/q2-metadata-how-to-use-default-missing-scheme-and-column-missing-schemes/24255/5).