### PR TITLE
Write collision

### DIFF
--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -369,7 +369,7 @@ class Archiver:
             ref = cls(data_path, process_alias, Format(rec), cache)
             return ref
         # We really just want to kill this path if anything at all goes wrong
-        # Exceptions including keyboard interrupts are reraised
+        # Exceptions including keyboard interrupts are re-raised
         except:  # noqa: E722
             # cls._destroy_temp_path(process_alias)
             raise

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -7,7 +7,6 @@
 # ----------------------------------------------------------------------------
 
 import collections
-from time import process_time
 import uuid as _uuid
 import pathlib
 import weakref

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import collections
+from time import process_time
 import uuid as _uuid
 import pathlib
 import weakref
@@ -363,15 +364,18 @@ class Archiver:
                 cls._futuristic_archive_error(filepath, archive)
 
             archive.mount(path)
-            process_alias, data_path = cache._alias(archive.uuid, path)
-            rec = ArchiveRecord(data_path, data_path / archive.VERSION_FILE,
-                                archive.uuid, archive.version, archive.framework_version)
+            process_alias, data_path = cache._rename(archive.uuid, path)
+            rec = ArchiveRecord(
+                data_path, data_path / archive.VERSION_FILE, archive.uuid,
+                archive.version, archive.framework_version)
             ref = cls(data_path, process_alias, Format(rec), cache)
             return ref
-        # We really just want to kill this path if anything at all goes wrong
+        # We really just want to kill these paths if anything at all goes wrong
         # Exceptions including keyboard interrupts are re-raised
         except:  # noqa: E722
-            # cls._destroy_temp_path(process_alias)
+            cls._destroy_temp_path(archive.uuid)
+            if 'process_alias' in vars():
+                cls._destroy_temp_path(process_alias)
             raise
 
     @classmethod
@@ -403,14 +407,19 @@ class Archiver:
             Format = cls.get_format_class(cls.CURRENT_FORMAT_VERSION)
             Format.write(rec, type, format, data_initializer,
                          provenance_capture)
-            format = Format(rec)
-            ref = cls(path, process_alias, format, cache)
-            set_permissions(path, READ_ONLY_FILE, READ_ONLY_DIR)
+
+            process_alias, data_path = cache._rename(uuid, path)
+            rec = ArchiveRecord(data_path, data_path / _Archive.VERSION_FILE,
+                                uuid, cls.CURRENT_FORMAT_VERSION,
+                                qiime2.__version__)
+            ref = cls(data_path, process_alias, Format(rec), cache)
             return ref
-        # We really just want to kill this path if anything at all goes wrong
-        # Exceptions including keyboard interrupts are reraised
+        # We really just want to kill these paths if anything at all goes wrong
+        # Exceptions including keyboard interrupts are re-raised
         except:  # noqa: E722
-            cls._destroy_temp_path(process_alias)
+            cls._destroy_temp_path(uuid)
+            if 'process_alias' in vars():
+                cls._destroy_temp_path(process_alias)
             raise
 
     def __init__(self, path, process_alias, fmt, cache):

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -18,9 +18,7 @@ import io
 import qiime2
 import qiime2.core.cite as cite
 
-from qiime2.core.util import (md5sum_directory, from_checksum_format,
-                              is_uuid4, set_permissions, READ_ONLY_FILE,
-                              READ_ONLY_DIR)
+from qiime2.core.util import md5sum_directory, from_checksum_format, is_uuid4
 
 _VERSION_TEMPLATE = """\
 QIIME 2
@@ -394,7 +392,6 @@ class Archiver:
         rec = archive.mount(path)
         ref = cls(path, process_alias, Format(rec), cache)
 
-        set_permissions(path, READ_ONLY_FILE, READ_ONLY_DIR)
         return ref
 
     @classmethod

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -285,6 +285,9 @@ class Archiver:
 
     @classmethod
     def _make_temp_path(cls, uuid):
+        """Allocates a place in the cache for the file to be temporarily
+        written. Returns this location and the cache in use.
+        """
         from qiime2.core.cache import get_cache
 
         cache = get_cache()

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -692,11 +692,11 @@ class Pool:
                         break
                 else:
                     raise ValueError(f'Too many collisions ({MAX_RETRIES}) '
-                                        'occured while trying to save artifact '
-                                        f'<{uuid}> to process pool {self.path}.'
-                                        'It is likely you have attempted to load '
-                                        'the same artifact a very large number '
-                                        'of times.')
+                                     'occured while trying to save artifact '
+                                     f'<{uuid}> to process pool {self.path}.'
+                                     'It is likely you have attempted to load '
+                                     'the same artifact a very large number '
+                                     'of times.')
         return dest
 
     def _guarded_symlink(self, src, dest):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -763,8 +763,9 @@ class Pool:
         # Symlink will error if the location we are creating the link at
         # already exists. This could happen legitimately from trying to save
         # the same thing to a named pool several times.
-        if not os.path.exists(dest):
-            os.symlink(src, dest)
+        with self.cache.lock:
+            if not os.path.exists(dest):
+                os.symlink(src, dest)
 
     def load(self, ref):
         """Load a reference to an element in the pool

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -749,14 +749,12 @@ class Pool:
 
         return False
 
-    def _allocate(self, uuid):
+    def _allocate(self, dirname):
         """Allocate an empty directory under the process pool to extract to.
         The actual uuid of an artifact is always reserved for this directory.
         All symlinks will be uuid.random_number.
         """
-        uuid = str(uuid)
-
-        path = self.path / uuid
+        path = self.path / dirname
         # If we try to load the same artifact twice in one process, this will
         # already exist.
         if not os.path.exists(path):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -588,6 +588,7 @@ class Cache:
             if self.named_pool is not None:
                 self.named_pool._make_symlink(uuid)
 
+        # If we did not rename we need to manually remove our mount point
         if not renamed:
             shutil.rmtree(src)
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -536,6 +536,17 @@ class Cache:
         archiver = Archiver.load_raw(path, self)
         return Result._from_archiver(archiver)
 
+    def _load_uuid(self, uuid):
+        """Load raw from the cache if the uuid is in the cache. Return None if
+        it isn't.
+        """
+        path = self.data / str(uuid)
+
+        if os.path.exists(path):
+            return Archiver.load_raw(path, self)
+        else:
+            return None
+
     def remove(self, key):
         """Remove a key from the cache then run garbage collection to remove
         anything it was referencing and any other loose data

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -538,7 +538,9 @@ class Cache:
 
     def _load_uuid(self, uuid):
         """Load raw from the cache if the uuid is in the cache. Return None if
-        it isn't.
+        it isn't. This is done so if someone already has an artifact in the
+        cache then tries to use their qza for the artifact we can use the
+        already cached version instead.
         """
         path = self.data / str(uuid)
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -521,19 +521,21 @@ class Cache:
         """Load the data pointed to by a key. Only works on a key that refers
         to a data item will error on a key that points to a pool
         """
-        try:
-            with open(self.keys / key) as fh:
-                path = self.data / yaml.safe_load(fh)['data']
-        except TypeError as e:
-            raise ValueError(f"The key file '{key}' does not point to any "
-                             "data. This most likely occured because you "
-                             "tried to load a pool which is not supported.") \
-                from e
-        except FileNotFoundError as e:
-            raise ValueError(f"The cache '{self.path}' does not contain the "
-                             f"key '{key}'") from e
+        with self.lock:
+            try:
+                with open(self.keys / key) as fh:
+                    path = self.data / yaml.safe_load(fh)['data']
+            except TypeError as e:
+                raise ValueError(f"The key file '{key}' does not point to any "
+                                 "data. This most likely occured because you "
+                                 "tried to load a pool which is not "
+                                 "supported.") from e
+            except FileNotFoundError as e:
+                raise ValueError(f"The cache '{self.path}' does not contain "
+                                 f"the key '{key}'") from e
 
-        archiver = Archiver.load_raw(path, self)
+            archiver = Archiver.load_raw(path, self)
+
         return Result._from_archiver(archiver)
 
     def _load_uuid(self, uuid):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -544,10 +544,11 @@ class Cache:
         """
         path = self.data / str(uuid)
 
-        if os.path.exists(path):
-            return Archiver.load_raw(path, self)
-        else:
-            return None
+        with self.lock:
+            if os.path.exists(path):
+                return Archiver.load_raw(path, self)
+            else:
+                return None
 
     def remove(self, key):
         """Remove a key from the cache then run garbage collection to remove

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -579,6 +579,9 @@ class Cache:
                 os.rename(src, dest)
                 set_permissions(dest, READ_ONLY_FILE, READ_ONLY_DIR)
 
+            # Create a new alias whether we renamed or not because this is
+            # still loading a new reference to the data even if the data is
+            # already there
             process_alias = self._alias(uuid)
 
         # Remove the aliased directory above the one we renamed. We need to do

--- a/qiime2/core/testing/util.py
+++ b/qiime2/core/testing/util.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import qiime2
 import os
 import os.path
 import zipfile

--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -207,13 +207,13 @@ class TestCache(unittest.TestCase):
     def test_remove_locks(self):
         """Create some locks then see if we can remove them
         """
-        self.cache.lock.lock.lock()
+        self.cache.lock.flufl_lock.lock()
 
-        self.assertEqual(self.cache.lock.lock.state, LockState.ours)
+        self.assertEqual(self.cache.lock.flufl_lock.state, LockState.ours)
 
         self.cache.clear_lock()
 
-        self.assertEqual(self.cache.lock.lock.state, LockState.unlocked)
+        self.assertEqual(self.cache.lock.flufl_lock.state, LockState.unlocked)
 
     # Might create another class for garbage collection tests to test more
     # cases with shared boilerplate

--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -207,13 +207,13 @@ class TestCache(unittest.TestCase):
     def test_remove_locks(self):
         """Create some locks then see if we can remove them
         """
-        self.cache.lock.lock()
+        self.cache.lock.lock.lock()
 
-        self.assertEqual(self.cache.lock.state, LockState.ours)
+        self.assertEqual(self.cache.lock.lock.state, LockState.ours)
 
         self.cache.clear_lock()
 
-        self.assertEqual(self.cache.lock.state, LockState.unlocked)
+        self.assertEqual(self.cache.lock.lock.state, LockState.unlocked)
 
     # Might create another class for garbage collection tests to test more
     # cases with shared boilerplate

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -64,7 +64,17 @@ class Result:
     @classmethod
     def load(cls, filepath):
         """Factory for loading Artifacts and Visualizations."""
-        archiver = archive.Archiver.load(filepath)
+        from qiime2.core.cache import get_cache
+
+        # Check if the data is already in the cache (if the uuid is in
+        # cache.data) and load it from the cache if it is. Avoids unzipping the
+        # qza again if we already have it.
+        cache = get_cache()
+        peek = cls.peek(filepath)
+        archiver = cache._load_uuid(peek.uuid)
+
+        if not archiver:
+            archiver = archive.Archiver.load(filepath)
 
         if Artifact._is_valid_type(archiver.type):
             result = Artifact.__new__(Artifact)


### PR DESCRIPTION
Get rid of race collision that can happen when you try to load the same artifact in several different processes at once by ensuring no process thinks the data is in the cache until the data is fully in cache/data.