### PR TITLE
adds support for registering descriptions and example imports for artifact classes

### DIFF
--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -100,13 +100,17 @@ dummy_plugin.register_views(
     SingleIntFormat, RedundantSingleIntDirectoryFormat,
     citations=[citations['mayer2012walking']])
 
-dummy_plugin.register_semantic_type_to_format(
+dummy_plugin.register_artifact_class(
     IntSequence1,
-    artifact_format=IntSequenceDirectoryFormat
+    artifact_format=IntSequenceDirectoryFormat,
+    description="The first IntSequence",
+    examples=None
 )
-dummy_plugin.register_semantic_type_to_format(
+dummy_plugin.register_artifact_class(
     IntSequence2,
-    artifact_format=IntSequenceV2DirectoryFormat
+    artifact_format=IntSequenceV2DirectoryFormat,
+    description="The second IntSequence",
+    examples=None
 )
 dummy_plugin.register_semantic_type_to_format(
     IntSequence3,

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -100,17 +100,56 @@ dummy_plugin.register_views(
     SingleIntFormat, RedundantSingleIntDirectoryFormat,
     citations=[citations['mayer2012walking']])
 
+
+# Create IntSequence1 import example usage example
+def is1_use(use):
+    def factory():
+        from qiime2.core.testing.format import IntSequenceFormat
+        from qiime2.plugin.util import transform
+        ff = transform([1, 2, 3], to_type=IntSequenceFormat)
+
+        ff.validate()
+        return ff
+
+    to_import = use.init_format('to_import', factory, ext='.hello')
+
+    ints = use.import_from_format('ints',
+                                  semantic_type='IntSequence1',
+                                  variable=to_import,
+                                  view_type='IntSequenceFormat')
+
+
 dummy_plugin.register_artifact_class(
     IntSequence1,
     directory_format=IntSequenceDirectoryFormat,
     description="The first IntSequence",
-    examples=None
+    examples={'IntSequence1 import example': is1_use}
 )
+
+
+# Create IntSequence2 import example usage example
+def is2_use(use):
+    def factory():
+        from qiime2.core.testing.format import IntSequenceFormatV2
+        from qiime2.plugin.util import transform
+        ff = transform([1, 2, 3], to_type=IntSequenceFormatV2)
+
+        ff.validate()
+        return ff
+
+    to_import = use.init_format('to_import', factory, ext='.hello')
+
+    ints = use.import_from_format('ints',
+                                  semantic_type='IntSequence2',
+                                  variable=to_import,
+                                  view_type='IntSequenceFormatV2')
+
+
 dummy_plugin.register_artifact_class(
     IntSequence2,
     directory_format=IntSequenceV2DirectoryFormat,
     description="The second IntSequence",
-    examples=None
+    examples={'IntSequence2 import example': is2_use}
 )
 dummy_plugin.register_semantic_type_to_format(
     IntSequence3,

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -102,35 +102,35 @@ dummy_plugin.register_views(
 
 dummy_plugin.register_artifact_class(
     IntSequence1,
-    artifact_format=IntSequenceDirectoryFormat,
+    directory_format=IntSequenceDirectoryFormat,
     description="The first IntSequence",
     examples=None
 )
 dummy_plugin.register_artifact_class(
     IntSequence2,
-    artifact_format=IntSequenceV2DirectoryFormat,
+    directory_format=IntSequenceV2DirectoryFormat,
     description="The second IntSequence",
     examples=None
 )
 dummy_plugin.register_semantic_type_to_format(
     IntSequence3,
-    artifact_format=IntSequenceMultiFileDirectoryFormat
+    directory_format=IntSequenceMultiFileDirectoryFormat
 )
 dummy_plugin.register_semantic_type_to_format(
     Mapping,
-    artifact_format=MappingDirectoryFormat
+    directory_format=MappingDirectoryFormat
 )
 dummy_plugin.register_semantic_type_to_format(
     FourInts,
-    artifact_format=FourIntsDirectoryFormat
+    directory_format=FourIntsDirectoryFormat
 )
 dummy_plugin.register_semantic_type_to_format(
     SingleInt,
-    artifact_format=RedundantSingleIntDirectoryFormat
+    directory_format=RedundantSingleIntDirectoryFormat
 )
 dummy_plugin.register_semantic_type_to_format(
     Kennel[Dog | Cat],
-    artifact_format=MappingDirectoryFormat
+    directory_format=MappingDirectoryFormat
 )
 
 dummy_plugin.register_semantic_type_to_format(
@@ -142,15 +142,15 @@ dummy_plugin.register_semantic_type_to_format(
     | Foo
     | Bar
     | Baz,
-    artifact_format=EchoDirectoryFormat)
+    directory_format=EchoDirectoryFormat)
 
 dummy_plugin.register_semantic_type_to_format(
     AscIntSequence,
-    artifact_format=IntSequenceDirectoryFormat)
+    directory_format=IntSequenceDirectoryFormat)
 
 dummy_plugin.register_semantic_type_to_format(
     Squid | Octopus | Cuttlefish,
-    artifact_format=CephalapodDirectoryFormat)
+    directory_format=CephalapodDirectoryFormat)
 
 # TODO add an optional parameter to this method when they are supported
 dummy_plugin.methods.register_function(

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -113,10 +113,10 @@ def is1_use(use):
 
     to_import = use.init_format('to_import', factory, ext='.hello')
 
-    ints = use.import_from_format('ints',
-                                  semantic_type='IntSequence1',
-                                  variable=to_import,
-                                  view_type='IntSequenceFormat')
+    use.import_from_format('ints',
+                           semantic_type='IntSequence1',
+                           variable=to_import,
+                           view_type='IntSequenceFormat')
 
 
 dummy_plugin.register_artifact_class(
@@ -139,10 +139,10 @@ def is2_use(use):
 
     to_import = use.init_format('to_import', factory, ext='.hello')
 
-    ints = use.import_from_format('ints',
-                                  semantic_type='IntSequence2',
-                                  variable=to_import,
-                                  view_type='IntSequenceFormatV2')
+    use.import_from_format('ints',
+                           semantic_type='IntSequence2',
+                           variable=to_import,
+                           view_type='IntSequenceFormatV2')
 
 
 dummy_plugin.register_artifact_class(

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -29,7 +29,8 @@ FormatRecord = collections.namedtuple('FormatRecord', ['format', 'plugin'])
 ViewRecord = collections.namedtuple(
     'ViewRecord', ['name', 'view', 'plugin', 'citations'])
 TypeFormatRecord = collections.namedtuple(
-    'TypeFormatRecord', ['type_expression', 'format', 'plugin'])
+    'TypeFormatRecord', ['type_expression', 'format', 'plugin', 'description',
+                         'examples'])
 ValidatorRecord = collections.namedtuple(
     'ValidatorRecord', ['validator', 'view', 'plugin', 'context'])
 
@@ -249,21 +250,36 @@ class Plugin:
                     fragment=type_fragment, plugin=self)
 
     def register_semantic_type_to_format(self, semantic_type, artifact_format):
+        self.register_artifact_class(semantic_type=semantic_type,
+                                     artifact_format=artifact_format,
+                                     description=None, examples= None)
+
+    def register_artifact_class(self, semantic_type, artifact_format,
+                                description=None, examples=None):
         if not issubclass(artifact_format, DirectoryFormat):
             raise TypeError("%r is not a directory format." % artifact_format)
         if not is_semantic_type(semantic_type):
             raise TypeError("%r is not a semantic type." % semantic_type)
         if not is_semantic_type(semantic_type):
+            # Evan: this was coptied from register_semantic_type_to_format
+            # but is unreachable, right?
             raise ValueError("%r is not a semantic type expression."
                              % semantic_type)
+
         for t in semantic_type:
             if t.predicate is not None:
                 raise ValueError("%r has a predicate, differentiating format"
                                  " on predicate is not supported.")
 
+        if description is None:
+            description = ""
+        if examples is None:
+            examples = {}
+
         self.type_formats.append(TypeFormatRecord(
             type_expression=semantic_type, format=artifact_format,
-            plugin=self))
+            plugin=self, description=description, examples=examples))
+
 
 
 class PluginActions(dict):

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -249,10 +249,10 @@ class Plugin:
                 SemanticTypeFragmentRecord(
                     fragment=type_fragment, plugin=self)
 
-    def _register_artifact_class(self, semantic_type, artifact_format,
+    def _register_artifact_class(self, semantic_type, directory_format,
                                  description, examples):
-        if not issubclass(artifact_format, DirectoryFormat):
-            raise TypeError("%r is not a directory format." % artifact_format)
+        if not issubclass(directory_format, DirectoryFormat):
+            raise TypeError("%r is not a directory format." % directory_format)
         if not is_semantic_type(semantic_type):
             raise TypeError("%r is not a semantic type." % semantic_type)
         if not is_semantic_type(semantic_type):
@@ -272,15 +272,34 @@ class Plugin:
             examples = {}
 
         self.type_formats.append(TypeFormatRecord(
-            type_expression=semantic_type, format=artifact_format,
+            type_expression=semantic_type, format=directory_format,
             plugin=self, description=description, examples=examples))
 
-    def register_semantic_type_to_format(self, semantic_type, artifact_format):
+    def register_semantic_type_to_format(self, semantic_type,
+                                         artifact_format=None,
+                                         directory_format=None):
+        # Handle the deprecated parameter name, artifact_format. This is being
+        # replaced with directory_format for clarity.
+        if artifact_format is not None and directory_format is not None:
+            raise ValueError('directory_format and artifact_format were both'
+                             'provided when registering artifact class %s.'
+                             'Please provide directory_format only as '
+                             'artifact_format is deprecated.'
+                             % str(semantic_type))
+        elif artifact_format is None and directory_format is None:
+            raise ValueError('directory_format or artifact_format must be '
+                             'provided when registering artifact class %s.'
+                             'Please provide directory_format only as '
+                             'artifact_format is deprecated.'
+                             % str(semantic_type))
+        else:
+            directory_format = directory_format or artifact_format
+
         self._register_artifact_class(semantic_type=semantic_type,
-                                      artifact_format=artifact_format,
+                                      directory_format=directory_format,
                                       description=None, examples= None)
 
-    def register_artifact_class(self, semantic_type, artifact_format,
+    def register_artifact_class(self, semantic_type, directory_format,
                                 description=None, examples=None):
         # Evan, better way to determine number of types in the type expression?
         if len(list(semantic_type)) > 1:
@@ -288,7 +307,7 @@ class Plugin:
                             "with register_artifact_class. Registration "
                             "attempted for %s." % str(semantic_type))
         self._register_artifact_class(
-            semantic_type, artifact_format, description, examples)
+            semantic_type, directory_format, description, examples)
 
 
 

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -266,10 +266,14 @@ class Plugin:
         if examples is None:
             examples = {}
 
-        self.type_formats.append(TypeFormatRecord(
-            type_expression=semantic_type, format=directory_format,
-            plugin=self, description=description,
-            examples=types.MappingProxyType(examples)))
+        # register_semantic_type_to_format can accept type expressions such as
+        # Kennel[Dog | Cat]. By iterating, we will register the concrete types
+        # (e.g., Kennel[Dog] and Kennel[Cat], not the type expression)
+        for e in list(semantic_type):
+            self.type_formats.append(TypeFormatRecord(
+                type_expression=e, format=directory_format,
+                plugin=self, description=description,
+                examples=types.MappingProxyType(examples)))
 
     def register_semantic_type_to_format(self, semantic_type,
                                          artifact_format=None,

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -268,7 +268,8 @@ class Plugin:
 
         self.type_formats.append(TypeFormatRecord(
             type_expression=semantic_type, format=directory_format,
-            plugin=self, description=description, examples=examples))
+            plugin=self, description=description,
+            examples=types.MappingProxyType(examples)))
 
     def register_semantic_type_to_format(self, semantic_type,
                                          artifact_format=None,

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -249,20 +249,15 @@ class Plugin:
                 SemanticTypeFragmentRecord(
                     fragment=type_fragment, plugin=self)
 
-    def register_semantic_type_to_format(self, semantic_type, artifact_format):
-        self.register_artifact_class(semantic_type=semantic_type,
-                                     artifact_format=artifact_format,
-                                     description=None, examples= None)
-
-    def register_artifact_class(self, semantic_type, artifact_format,
-                                description=None, examples=None):
+    def _register_artifact_class(self, semantic_type, artifact_format,
+                                 description, examples):
         if not issubclass(artifact_format, DirectoryFormat):
             raise TypeError("%r is not a directory format." % artifact_format)
         if not is_semantic_type(semantic_type):
             raise TypeError("%r is not a semantic type." % semantic_type)
         if not is_semantic_type(semantic_type):
-            # Evan: this was coptied from register_semantic_type_to_format
-            # but is unreachable, right?
+            # Evan: this was copied from register_semantic_type_to_format
+            # but is unreachable so should be deleted, right?
             raise ValueError("%r is not a semantic type expression."
                              % semantic_type)
 
@@ -279,6 +274,21 @@ class Plugin:
         self.type_formats.append(TypeFormatRecord(
             type_expression=semantic_type, format=artifact_format,
             plugin=self, description=description, examples=examples))
+
+    def register_semantic_type_to_format(self, semantic_type, artifact_format):
+        self._register_artifact_class(semantic_type=semantic_type,
+                                      artifact_format=artifact_format,
+                                      description=None, examples= None)
+
+    def register_artifact_class(self, semantic_type, artifact_format,
+                                description=None, examples=None):
+        # Evan, better way to determine number of types in the type expression?
+        if len(list(semantic_type)) > 1:
+            raise TypeError("Only a single type can be registered at a time "
+                            "with register_artifact_class. Registration "
+                            "attempted for %s." % str(semantic_type))
+        self._register_artifact_class(
+            semantic_type, artifact_format, description, examples)
 
 
 

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -28,9 +28,12 @@ SemanticTypeFragmentRecord = collections.namedtuple(
 FormatRecord = collections.namedtuple('FormatRecord', ['format', 'plugin'])
 ViewRecord = collections.namedtuple(
     'ViewRecord', ['name', 'view', 'plugin', 'citations'])
-TypeFormatRecord = collections.namedtuple(
-    'TypeFormatRecord', ['type_expression', 'format', 'plugin', 'description',
-                         'examples'])
+# semantic_type and type_expression will point to the same value in
+# ArtifactClassRecords as type_expression is deprecated in favor of
+# semantic_type
+ArtifactClassRecord = collections.namedtuple(
+    'ArtifactClassRecord', ['semantic_type', 'format', 'plugin', 'description',
+                            'examples', 'type_expression'])
 ValidatorRecord = collections.namedtuple(
     'ValidatorRecord', ['validator', 'view', 'plugin', 'context'])
 
@@ -279,10 +282,11 @@ class Plugin:
                                 "once. Artifact classes can only be "
                                 "registered once." % semantic_type_str)
 
-            self.type_formats.append(TypeFormatRecord(
-                type_expression=e, format=directory_format,
+            self.type_formats.append(ArtifactClassRecord(
+                semantic_type=e, format=directory_format,
                 plugin=self, description=description,
-                examples=types.MappingProxyType(examples)))
+                examples=types.MappingProxyType(examples),
+                type_expression=e))
 
             registered_artifact_classes.add(semantic_type_str)
 

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -103,14 +103,7 @@ class Plugin:
 
     @property
     def types(self):
-        types = {}
-
-        for record in self.type_formats:
-            for type_ in record.type_expression:
-                types[str(type_)] = \
-                    SemanticTypeRecord(semantic_type=type_, plugin=self)
-
-        return types
+        return {str(e.semantic_type): e for e in self.type_formats}
 
     def register_formats(self, *formats, citations=None):
         for format in formats:

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -266,14 +266,26 @@ class Plugin:
         if examples is None:
             examples = {}
 
+        registered_artifact_classes = \
+            set(str(e.type_expression) for e in self.type_formats)
+
         # register_semantic_type_to_format can accept type expressions such as
         # Kennel[Dog | Cat]. By iterating, we will register the concrete types
         # (e.g., Kennel[Dog] and Kennel[Cat], not the type expression)
         for e in list(semantic_type):
+            semantic_type_str = str(e)
+            if semantic_type_str in registered_artifact_classes:
+                raise NameError("Artifact class %s was registered more than "
+                                "once. Artifact classes can only be "
+                                "registered once." % semantic_type_str)
+
             self.type_formats.append(TypeFormatRecord(
                 type_expression=e, format=directory_format,
                 plugin=self, description=description,
                 examples=types.MappingProxyType(examples)))
+
+            registered_artifact_classes.add(semantic_type_str)
+
 
     def register_semantic_type_to_format(self, semantic_type,
                                          artifact_format=None,

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -289,7 +289,6 @@ class Plugin:
 
             registered_artifact_classes.add(semantic_type_str)
 
-
     def register_semantic_type_to_format(self, semantic_type,
                                          artifact_format=None,
                                          directory_format=None):
@@ -312,7 +311,8 @@ class Plugin:
 
         self._register_artifact_class(semantic_type=semantic_type,
                                       directory_format=directory_format,
-                                      description=None, examples= None)
+                                      description=None,
+                                      examples=None)
 
     def register_artifact_class(self, semantic_type, directory_format,
                                 description=None, examples=None):
@@ -322,7 +322,6 @@ class Plugin:
                             "attempted for %s." % str(semantic_type))
         self._register_artifact_class(
             semantic_type, directory_format, description, examples)
-
 
 
 class PluginActions(dict):

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -83,7 +83,7 @@ class Plugin:
         self.views = {}
         self.type_fragments = {}
         self.transformers = {}
-        self.type_formats = []
+        self.artifact_classes = []
         self.validators = {}
 
     def freeze(self):
@@ -103,7 +103,13 @@ class Plugin:
 
     @property
     def types(self):
-        return {str(e.semantic_type): e for e in self.type_formats}
+        return {str(e.semantic_type): e for e in self.artifact_classes}
+
+    @property
+    def type_formats(self):
+        # self.type_formats was replaced with self.artifact_classes - this
+        # property provides backward compatibility
+        return self.artifact_classes
 
     def register_formats(self, *formats, citations=None):
         for format in formats:
@@ -263,7 +269,7 @@ class Plugin:
             examples = {}
 
         registered_artifact_classes = \
-            set(str(e.type_expression) for e in self.type_formats)
+            set(str(e.type_expression) for e in self.artifact_classes)
 
         # register_semantic_type_to_format can accept type expressions such as
         # Kennel[Dog | Cat]. By iterating, we will register the concrete types
@@ -275,7 +281,7 @@ class Plugin:
                                 "once. Artifact classes can only be "
                                 "registered once." % semantic_type_str)
 
-            self.type_formats.append(ArtifactClassRecord(
+            self.artifact_classes.append(ArtifactClassRecord(
                 semantic_type=e, format=directory_format,
                 plugin=self, description=description,
                 examples=types.MappingProxyType(examples),

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -255,11 +255,6 @@ class Plugin:
             raise TypeError("%r is not a directory format." % directory_format)
         if not is_semantic_type(semantic_type):
             raise TypeError("%r is not a semantic type." % semantic_type)
-        if not is_semantic_type(semantic_type):
-            # Evan: this was copied from register_semantic_type_to_format
-            # but is unreachable so should be deleted, right?
-            raise ValueError("%r is not a semantic type expression."
-                             % semantic_type)
 
         for t in semantic_type:
             if t.predicate is not None:

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -297,8 +297,7 @@ class Plugin:
 
     def register_artifact_class(self, semantic_type, directory_format,
                                 description=None, examples=None):
-        # Evan, better way to determine number of types in the type expression?
-        if len(list(semantic_type)) > 1:
+        if not semantic_type.is_concrete():
             raise TypeError("Only a single type can be registered at a time "
                             "with register_artifact_class. Registration "
                             "attempted for %s." % str(semantic_type))

--- a/qiime2/plugin/testing.py
+++ b/qiime2/plugin/testing.py
@@ -169,21 +169,21 @@ class TestPluginBase(unittest.TestCase):
             The :term:`Format` to check that the Semantic Type is registed on.
 
         """
+        # For backward compatibility, support type expressions as input here
+        for t in semantic_type:
+            obs_format = None
 
-        obs_format = None
-        for artifact_class_record in self.plugin.artifact_classes:
-            if artifact_class_record.semantic_type == semantic_type:
-                obs_format = artifact_class_record.format
-                break
+            try:
+                obs_format = self.plugin.artifact_classes[str(t)].format
+            except KeyError:
+                self.assertIsNotNone(
+                    obs_format,
+                    "Semantic type %r is not registered to a format." % t)
 
-        self.assertIsNotNone(
-            obs_format,
-            "Semantic type %r is not registered to a format." % semantic_type)
-
-        self.assertEqual(
-            obs_format, exp_format,
-            "Expected semantic type %r to be registered to format %r, not %r."
-            % (semantic_type, exp_format, obs_format))
+            self.assertEqual(
+                obs_format, exp_format,
+                "Expected semantic type %r to be registered to format %r, "
+                "not %r." % (t, exp_format, obs_format))
 
     def transform_format(self, source_format, target, filename=None,
                          filenames=None):

--- a/qiime2/plugin/testing.py
+++ b/qiime2/plugin/testing.py
@@ -11,6 +11,7 @@ import tempfile
 import unittest
 import shutil
 import pathlib
+import itertools
 
 import qiime2
 
@@ -254,7 +255,8 @@ class TestPluginBase(unittest.TestCase):
         if self.plugin is None:
             raise ValueError('Attempted to run `execute_examples` without '
                              'configuring test harness.')
-        for _, action in self.plugin.actions.items():
+        for _, action in itertools.chain(self.plugin.actions.items(),
+                                         self.plugin.types.items()):
             for name, example_f in action.examples.items():
                 with self.subTest(example=name):
                     use = usage.ExecutionUsage()

--- a/qiime2/plugin/testing.py
+++ b/qiime2/plugin/testing.py
@@ -170,9 +170,9 @@ class TestPluginBase(unittest.TestCase):
         """
 
         obs_format = None
-        for type_format_record in self.plugin.type_formats:
-            if type_format_record.type_expression == semantic_type:
-                obs_format = type_format_record.format
+        for artifact_class_record in self.plugin.artifact_classes:
+            if artifact_class_record.semantic_type == semantic_type:
+                obs_format = artifact_class_record.format
                 break
 
         self.assertIsNotNone(

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -229,7 +229,9 @@ class TestPlugin(unittest.TestCase):
 
         self.assertFalse(tf[0].examples is tf[1].examples)
 
-
+    # Evan, this test is currently failing, meaning that it's possible
+    # to register an artifact_class multiple times. That should be disallowed,
+    # right?
     def test_duplicate_artifact_class_registration_disallowed(self):
         plugin = qiime2.plugin.Plugin(
             name='local-dummy-plugin',

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -200,13 +200,13 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
         self.assertEqual(tf[0].plugin, plugin)
         self.assertEqual(tf[0].description, "")
-        self.assertEqual(tf[0].examples, {})
+        self.assertEqual(tf[0].examples, types.MappingProxyType({}))
 
         self.assertEqual(tf[1].type_expression, IntSequence2)
         self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[1].plugin, plugin)
         self.assertEqual(tf[1].description, "")
-        self.assertEqual(tf[1].examples, {})
+        self.assertEqual(tf[1].examples, types.MappingProxyType({}))
 
         # errors are raised when both or neither the new or old names for the
         # format are provided
@@ -255,25 +255,25 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
         self.assertEqual(tf[0].plugin, plugin)
         self.assertEqual(tf[0].description, "")
-        self.assertEqual(tf[0].examples, {})
+        self.assertEqual(tf[0].examples, types.MappingProxyType({}))
 
         self.assertEqual(tf[1].type_expression, IntSequence2)
         self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[1].plugin, plugin)
         self.assertEqual(tf[1].description, "")
-        self.assertEqual(tf[1].examples, {})
+        self.assertEqual(tf[1].examples, types.MappingProxyType({}))
 
         self.assertEqual(tf[2].type_expression, Kennel[Dog])
         self.assertEqual(tf[2].format, IntSequenceDirectoryFormat)
         self.assertEqual(tf[2].plugin, plugin)
         self.assertEqual(tf[2].description, "")
-        self.assertEqual(tf[2].examples, {})
+        self.assertEqual(tf[2].examples, types.MappingProxyType({}))
 
         self.assertEqual(tf[3].type_expression, Kennel[Cat])
         self.assertEqual(tf[3].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[3].plugin, plugin)
         self.assertEqual(tf[3].description, "")
-        self.assertEqual(tf[3].examples, {})
+        self.assertEqual(tf[3].examples, types.MappingProxyType({}))
 
         self.assertFalse(tf[0].examples is tf[1].examples)
 
@@ -317,14 +317,14 @@ class TestPlugin(unittest.TestCase):
             version='0.0.0-dev',
             website='https://github.com/qiime2/qiime2',
             package='qiime2.core.testing')
-        plugin.register_artifact_class(IntSequence1,
-                                       IntSequenceDirectoryFormat,
-                                       description="A sequence of integers.",
-                                       examples={'Import ex 1': dummy_use1})
-        plugin.register_artifact_class(IntSequence2,
-                                       IntSequenceV2DirectoryFormat,
-                                       description="Different seq of ints.",
-                                       examples={'Import ex': dummy_use2})
+        plugin.register_artifact_class(
+            IntSequence1, IntSequenceDirectoryFormat,
+            description="A sequence of integers.",
+            examples=types.MappingProxyType({'Import ex 1': dummy_use1}))
+        plugin.register_artifact_class(
+            IntSequence2, IntSequenceV2DirectoryFormat,
+            description="Different seq of ints.",
+            examples=types.MappingProxyType({'Import ex': dummy_use2}))
 
         tf = plugin.type_formats
 
@@ -332,13 +332,15 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
         self.assertEqual(tf[0].plugin, plugin)
         self.assertEqual(tf[0].description, "A sequence of integers.")
-        self.assertEqual(tf[0].examples, {'Import ex 1': dummy_use1})
+        self.assertEqual(tf[0].examples,
+                         types.MappingProxyType({'Import ex 1': dummy_use1}))
 
         self.assertEqual(tf[1].type_expression, IntSequence2)
         self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[1].plugin, plugin)
         self.assertEqual(tf[1].description, "Different seq of ints.")
-        self.assertEqual(tf[1].examples, {'Import ex': dummy_use2})
+        self.assertEqual(tf[1].examples,
+            types.MappingProxyType({'Import ex': dummy_use2}))
 
     def test_register_artifact_class_multiple(self):
         plugin = qiime2.plugin.Plugin(
@@ -362,7 +364,7 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
         self.assertEqual(tf[0].plugin, plugin)
         self.assertEqual(tf[0].description, "")
-        self.assertEqual(tf[0].examples, {})
+        self.assertEqual(tf[0].examples, types.MappingProxyType({}))
 
         # multiple artifact_classes cannot be registered using
         # register_artifact_class, since default descriptions and examples

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -17,6 +17,7 @@ from qiime2.core.testing.type import (IntSequence1, IntSequence2, Mapping,
 from qiime2.core.testing.format import (IntSequenceDirectoryFormat,
                                         IntSequenceV2DirectoryFormat)
 from qiime2.core.testing.util import get_dummy_plugin
+from qiime2.core.testing.plugin import is1_use, is2_use
 
 
 class TestPlugin(unittest.TestCase):
@@ -233,7 +234,6 @@ class TestPlugin(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, regex):
             plugin.register_semantic_type_to_format(IntSequence1)
 
-
     def test_register_artifact_class(self):
         plugin = qiime2.plugin.Plugin(
             name='local-dummy-plugin',
@@ -318,41 +318,6 @@ class TestPlugin(unittest.TestCase):
                 IntSequence1, IntSequenceV2DirectoryFormat)
 
     def test_register_artifact_class_w_annotations(self):
-
-        ## Create ex1 usage example
-        def ex1_use(use):
-            def factory():
-                from qiime2.core.testing.format import IntSequenceFormat
-                from qiime2.plugin.util import transform
-                ff = transform([1, 2, 3], to_type=IntSequenceFormat)
-
-                ff.validate()
-                return ff
-
-            to_import = use.init_format('to_import', factory, ext='.hello')
-
-            ints = use.import_from_format('ints',
-                                          semantic_type='IntSequence1',
-                                          variable=to_import,
-                                          view_type='IntSequenceFormat')
-
-        ## Create ex2 usage example
-        def ex2_use(use):
-            def factory():
-                from qiime2.core.testing.format import IntSequenceFormat
-                from qiime2.plugin.util import transform
-                ff = transform([1, 2, 3], to_type=IntSequenceFormat)
-
-                ff.validate()
-                return ff
-
-            to_import = use.init_format('to_import', factory, ext='.hello')
-
-            ints = use.import_from_format('ints',
-                                          semantic_type='IntSequence2',
-                                          variable=to_import,
-                                          view_type='IntSequenceFormat')
-
         plugin = qiime2.plugin.Plugin(
             name='local-dummy-plugin',
             version='0.0.0-dev',
@@ -361,11 +326,11 @@ class TestPlugin(unittest.TestCase):
         plugin.register_artifact_class(
             IntSequence1, IntSequenceDirectoryFormat,
             description="A sequence of integers.",
-            examples=types.MappingProxyType({'Import ex 1': ex1_use}))
+            examples=types.MappingProxyType({'Import ex 1': is1_use}))
         plugin.register_artifact_class(
             IntSequence2, IntSequenceV2DirectoryFormat,
             description="Different seq of ints.",
-            examples=types.MappingProxyType({'Import ex': ex2_use}))
+            examples=types.MappingProxyType({'Import ex': is2_use}))
 
         tf = plugin.artifact_classes
 
@@ -374,14 +339,14 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(tf[0].plugin, plugin)
         self.assertEqual(tf[0].description, "A sequence of integers.")
         self.assertEqual(tf[0].examples,
-                         types.MappingProxyType({'Import ex 1': ex1_use}))
+                         types.MappingProxyType({'Import ex 1': is1_use}))
 
         self.assertEqual(tf[1].semantic_type, IntSequence2)
         self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[1].plugin, plugin)
         self.assertEqual(tf[1].description, "Different seq of ints.")
         self.assertEqual(tf[1].examples,
-            types.MappingProxyType({'Import ex': ex2_use}))
+                         types.MappingProxyType({'Import ex': is2_use}))
 
     def test_register_artifact_class_multiple(self):
         plugin = qiime2.plugin.Plugin(

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -288,9 +288,6 @@ class TestPlugin(unittest.TestCase):
 
         self.assertFalse(tf[0].examples is tf[1].examples)
 
-    # Evan, this test is currently failing, meaning that it's possible
-    # to register an artifact_class multiple times. That should be disallowed,
-    # right?
     def test_duplicate_artifact_class_registration_disallowed(self):
         plugin = qiime2.plugin.Plugin(
             name='local-dummy-plugin',
@@ -321,8 +318,41 @@ class TestPlugin(unittest.TestCase):
                 IntSequence1, IntSequenceV2DirectoryFormat)
 
     def test_register_artifact_class_w_annotations(self):
-        dummy_use1 = None # Evan, need input on creating import usage examples
-        dummy_use2 = None
+
+        ## Create ex1 usage example
+        def ex1_use(use):
+            def factory():
+                from qiime2.core.testing.format import IntSequenceFormat
+                from qiime2.plugin.util import transform
+                ff = transform([1, 2, 3], to_type=IntSequenceFormat)
+
+                ff.validate()
+                return ff
+
+            to_import = use.init_format('to_import', factory, ext='.hello')
+
+            ints = use.import_from_format('ints',
+                                          semantic_type='IntSequence1',
+                                          variable=to_import,
+                                          view_type='IntSequenceFormat')
+
+        ## Create ex2 usage example
+        def ex2_use(use):
+            def factory():
+                from qiime2.core.testing.format import IntSequenceFormat
+                from qiime2.plugin.util import transform
+                ff = transform([1, 2, 3], to_type=IntSequenceFormat)
+
+                ff.validate()
+                return ff
+
+            to_import = use.init_format('to_import', factory, ext='.hello')
+
+            ints = use.import_from_format('ints',
+                                          semantic_type='IntSequence2',
+                                          variable=to_import,
+                                          view_type='IntSequenceFormat')
+
         plugin = qiime2.plugin.Plugin(
             name='local-dummy-plugin',
             version='0.0.0-dev',
@@ -331,11 +361,11 @@ class TestPlugin(unittest.TestCase):
         plugin.register_artifact_class(
             IntSequence1, IntSequenceDirectoryFormat,
             description="A sequence of integers.",
-            examples=types.MappingProxyType({'Import ex 1': dummy_use1}))
+            examples=types.MappingProxyType({'Import ex 1': ex1_use}))
         plugin.register_artifact_class(
             IntSequence2, IntSequenceV2DirectoryFormat,
             description="Different seq of ints.",
-            examples=types.MappingProxyType({'Import ex': dummy_use2}))
+            examples=types.MappingProxyType({'Import ex': ex2_use}))
 
         tf = plugin.artifact_classes
 
@@ -344,14 +374,14 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(tf[0].plugin, plugin)
         self.assertEqual(tf[0].description, "A sequence of integers.")
         self.assertEqual(tf[0].examples,
-                         types.MappingProxyType({'Import ex 1': dummy_use1}))
+                         types.MappingProxyType({'Import ex 1': ex1_use}))
 
         self.assertEqual(tf[1].semantic_type, IntSequence2)
         self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[1].plugin, plugin)
         self.assertEqual(tf[1].description, "Different seq of ints.")
         self.assertEqual(tf[1].examples,
-            types.MappingProxyType({'Import ex': dummy_use2}))
+            types.MappingProxyType({'Import ex': ex2_use}))
 
     def test_register_artifact_class_multiple(self):
         plugin = qiime2.plugin.Plugin(

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -162,7 +162,7 @@ class TestPlugin(unittest.TestCase):
         # backward compatibility the Plugin.type_formats property returns
         # the plugin's artifact_classes
         self.assertEqual(self.plugin.type_formats,
-                         self.plugin.artifact_classes)
+                         list(self.plugin.artifact_classes.values()))
 
     def test_type_fragments(self):
         types = self.plugin.type_fragments.keys()
@@ -202,19 +202,19 @@ class TestPlugin(unittest.TestCase):
         plugin.register_semantic_type_to_format(
             IntSequence2, artifact_format=IntSequenceV2DirectoryFormat)
 
-        tf = plugin.artifact_classes
+        ac = plugin.artifact_classes['IntSequence1']
+        self.assertEqual(ac.semantic_type, IntSequence1)
+        self.assertEqual(ac.format, IntSequenceDirectoryFormat)
+        self.assertEqual(ac.plugin, plugin)
+        self.assertEqual(ac.description, "")
+        self.assertEqual(ac.examples, types.MappingProxyType({}))
 
-        self.assertEqual(tf[0].semantic_type, IntSequence1)
-        self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
-        self.assertEqual(tf[0].plugin, plugin)
-        self.assertEqual(tf[0].description, "")
-        self.assertEqual(tf[0].examples, types.MappingProxyType({}))
-
-        self.assertEqual(tf[1].semantic_type, IntSequence2)
-        self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
-        self.assertEqual(tf[1].plugin, plugin)
-        self.assertEqual(tf[1].description, "")
-        self.assertEqual(tf[1].examples, types.MappingProxyType({}))
+        ac = plugin.artifact_classes['IntSequence2']
+        self.assertEqual(ac.semantic_type, IntSequence2)
+        self.assertEqual(ac.format, IntSequenceV2DirectoryFormat)
+        self.assertEqual(ac.plugin, plugin)
+        self.assertEqual(ac.description, "")
+        self.assertEqual(ac.examples, types.MappingProxyType({}))
 
         # errors are raised when both or neither the new or old names for the
         # format are provided
@@ -253,40 +253,43 @@ class TestPlugin(unittest.TestCase):
         plugin.register_artifact_class(Kennel[Cat],
                                        IntSequenceV2DirectoryFormat)
 
-        tf = plugin.artifact_classes
-
         # all and only the expected artifact classes have been registered
-        self.assertEqual(len(tf), 4)
+        self.assertEqual(len(plugin.artifact_classes), 4)
 
-        self.assertEqual(tf[0].semantic_type, IntSequence1)
-        self.assertEqual(tf[0].type_expression, IntSequence1)
-        self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
-        self.assertEqual(tf[0].plugin, plugin)
-        self.assertEqual(tf[0].description, "")
-        self.assertEqual(tf[0].examples, types.MappingProxyType({}))
+        ac = plugin.artifact_classes['IntSequence1']
+        self.assertEqual(ac.semantic_type, IntSequence1)
+        self.assertEqual(ac.type_expression, IntSequence1)
+        self.assertEqual(ac.format, IntSequenceDirectoryFormat)
+        self.assertEqual(ac.plugin, plugin)
+        self.assertEqual(ac.description, "")
+        self.assertEqual(ac.examples, types.MappingProxyType({}))
 
-        self.assertEqual(tf[1].semantic_type, IntSequence2)
-        self.assertEqual(tf[1].type_expression, IntSequence2)
-        self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
-        self.assertEqual(tf[1].plugin, plugin)
-        self.assertEqual(tf[1].description, "")
-        self.assertEqual(tf[1].examples, types.MappingProxyType({}))
+        ac = plugin.artifact_classes['IntSequence2']
+        self.assertEqual(ac.semantic_type, IntSequence2)
+        self.assertEqual(ac.type_expression, IntSequence2)
+        self.assertEqual(ac.format, IntSequenceV2DirectoryFormat)
+        self.assertEqual(ac.plugin, plugin)
+        self.assertEqual(ac.description, "")
+        self.assertEqual(ac.examples, types.MappingProxyType({}))
 
-        self.assertEqual(tf[2].semantic_type, Kennel[Dog])
-        self.assertEqual(tf[2].type_expression, Kennel[Dog])
-        self.assertEqual(tf[2].format, IntSequenceDirectoryFormat)
-        self.assertEqual(tf[2].plugin, plugin)
-        self.assertEqual(tf[2].description, "")
-        self.assertEqual(tf[2].examples, types.MappingProxyType({}))
+        ac = plugin.artifact_classes['Kennel[Dog]']
+        self.assertEqual(ac.semantic_type, Kennel[Dog])
+        self.assertEqual(ac.type_expression, Kennel[Dog])
+        self.assertEqual(ac.format, IntSequenceDirectoryFormat)
+        self.assertEqual(ac.plugin, plugin)
+        self.assertEqual(ac.description, "")
+        self.assertEqual(ac.examples, types.MappingProxyType({}))
 
-        self.assertEqual(tf[3].semantic_type, Kennel[Cat])
-        self.assertEqual(tf[3].type_expression, Kennel[Cat])
-        self.assertEqual(tf[3].format, IntSequenceV2DirectoryFormat)
-        self.assertEqual(tf[3].plugin, plugin)
-        self.assertEqual(tf[3].description, "")
-        self.assertEqual(tf[3].examples, types.MappingProxyType({}))
+        ac = plugin.artifact_classes['Kennel[Cat]']
+        self.assertEqual(ac.semantic_type, Kennel[Cat])
+        self.assertEqual(ac.type_expression, Kennel[Cat])
+        self.assertEqual(ac.format, IntSequenceV2DirectoryFormat)
+        self.assertEqual(ac.plugin, plugin)
+        self.assertEqual(ac.description, "")
+        self.assertEqual(ac.examples, types.MappingProxyType({}))
 
-        self.assertFalse(tf[0].examples is tf[1].examples)
+        self.assertFalse(plugin.artifact_classes['IntSequence1'] is
+                         plugin.artifact_classes['IntSequence2'])
 
     def test_duplicate_artifact_class_registration_disallowed(self):
         plugin = qiime2.plugin.Plugin(
@@ -332,20 +335,20 @@ class TestPlugin(unittest.TestCase):
             description="Different seq of ints.",
             examples=types.MappingProxyType({'Import ex': is2_use}))
 
-        tf = plugin.artifact_classes
-
-        self.assertEqual(tf[0].semantic_type, IntSequence1)
-        self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
-        self.assertEqual(tf[0].plugin, plugin)
-        self.assertEqual(tf[0].description, "A sequence of integers.")
-        self.assertEqual(tf[0].examples,
+        ac = plugin.artifact_classes['IntSequence1']
+        self.assertEqual(ac.semantic_type, IntSequence1)
+        self.assertEqual(ac.format, IntSequenceDirectoryFormat)
+        self.assertEqual(ac.plugin, plugin)
+        self.assertEqual(ac.description, "A sequence of integers.")
+        self.assertEqual(ac.examples,
                          types.MappingProxyType({'Import ex 1': is1_use}))
 
-        self.assertEqual(tf[1].semantic_type, IntSequence2)
-        self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
-        self.assertEqual(tf[1].plugin, plugin)
-        self.assertEqual(tf[1].description, "Different seq of ints.")
-        self.assertEqual(tf[1].examples,
+        ac = plugin.artifact_classes['IntSequence2']
+        self.assertEqual(ac.semantic_type, IntSequence2)
+        self.assertEqual(ac.format, IntSequenceV2DirectoryFormat)
+        self.assertEqual(ac.plugin, plugin)
+        self.assertEqual(ac.description, "Different seq of ints.")
+        self.assertEqual(ac.examples,
                          types.MappingProxyType({'Import ex': is2_use}))
 
     def test_register_artifact_class_multiple(self):
@@ -360,22 +363,19 @@ class TestPlugin(unittest.TestCase):
         plugin.register_semantic_type_to_format(Kennel[Dog | Cat],
                                                 IntSequenceDirectoryFormat)
 
-        # the order of the types in artifact_classes seems to be inconsistent,
-        # so load these into a dict for testing
-        tf = {str(e.semantic_type): e for e in plugin.artifact_classes}
-        tf_c = tf['Kennel[Cat]']
-        self.assertEqual(tf_c.semantic_type, Kennel[Cat])
-        self.assertEqual(tf_c.format, IntSequenceDirectoryFormat)
-        self.assertEqual(tf_c.plugin, plugin)
-        self.assertEqual(tf_c.description, "")
-        self.assertEqual(tf_c.examples, types.MappingProxyType({}))
+        ac_c = plugin.artifact_classes['Kennel[Cat]']
+        self.assertEqual(ac_c.semantic_type, Kennel[Cat])
+        self.assertEqual(ac_c.format, IntSequenceDirectoryFormat)
+        self.assertEqual(ac_c.plugin, plugin)
+        self.assertEqual(ac_c.description, "")
+        self.assertEqual(ac_c.examples, types.MappingProxyType({}))
 
-        tf_d = tf['Kennel[Dog]']
-        self.assertEqual(tf_d.semantic_type, Kennel[Dog])
-        self.assertEqual(tf_d.format, IntSequenceDirectoryFormat)
-        self.assertEqual(tf_d.plugin, plugin)
-        self.assertEqual(tf_d.description, "")
-        self.assertEqual(tf_d.examples, types.MappingProxyType({}))
+        ac_d = plugin.artifact_classes['Kennel[Dog]']
+        self.assertEqual(ac_d.semantic_type, Kennel[Dog])
+        self.assertEqual(ac_d.format, IntSequenceDirectoryFormat)
+        self.assertEqual(ac_d.plugin, plugin)
+        self.assertEqual(ac_d.description, "")
+        self.assertEqual(ac_d.examples, types.MappingProxyType({}))
 
         # multiple artifact_classes cannot be registered using
         # register_artifact_class, since default descriptions and examples

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -156,6 +156,13 @@ class TestPlugin(unittest.TestCase):
 
     # TODO test registration of directory formats.
 
+    def test_deprecated_type_formats(self):
+        # Plugin.type_formats was replaced with Plugin.artifact_classes. For
+        # backward compatibility the Plugin.type_formats property returns
+        # the plugin's artifact_classes
+        self.assertEqual(self.plugin.type_formats,
+                         self.plugin.artifact_classes)
+
     def test_type_fragments(self):
         types = self.plugin.type_fragments.keys()
 
@@ -194,7 +201,7 @@ class TestPlugin(unittest.TestCase):
         plugin.register_semantic_type_to_format(
             IntSequence2, artifact_format=IntSequenceV2DirectoryFormat)
 
-        tf = plugin.type_formats
+        tf = plugin.artifact_classes
 
         self.assertEqual(tf[0].semantic_type, IntSequence1)
         self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
@@ -246,7 +253,7 @@ class TestPlugin(unittest.TestCase):
         plugin.register_artifact_class(Kennel[Cat],
                                        IntSequenceV2DirectoryFormat)
 
-        tf = plugin.type_formats
+        tf = plugin.artifact_classes
 
         # all and only the expected artifact classes have been registered
         self.assertEqual(len(tf), 4)
@@ -330,7 +337,7 @@ class TestPlugin(unittest.TestCase):
             description="Different seq of ints.",
             examples=types.MappingProxyType({'Import ex': dummy_use2}))
 
-        tf = plugin.type_formats
+        tf = plugin.artifact_classes
 
         self.assertEqual(tf[0].semantic_type, IntSequence1)
         self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
@@ -358,9 +365,9 @@ class TestPlugin(unittest.TestCase):
         plugin.register_semantic_type_to_format(Kennel[Dog | Cat],
                                                 IntSequenceDirectoryFormat)
 
-        # the order of the types in type_formats seems to be inconsistent,
+        # the order of the types in artifact_classes seems to be inconsistent,
         # so load these into a dict for testing
-        tf = {str(e.semantic_type): e for e in plugin.type_formats}
+        tf = {str(e.semantic_type): e for e in plugin.artifact_classes}
         tf_c = tf['Kennel[Cat]']
         self.assertEqual(tf_c.semantic_type, Kennel[Cat])
         self.assertEqual(tf_c.format, IntSequenceDirectoryFormat)

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -168,8 +168,8 @@ class TestPlugin(unittest.TestCase):
 
     def test_types(self):
         types = self.plugin.types
-        # Get just the SemanticTypeRecords out of the types dictionary, then
-        # get just the types out of the SemanticTypeRecord namedtuples
+        # Get just the ArtifactClassRecords out of the types dictionary, then
+        # get just the types out of the ArtifactClassRecords namedtuples
         types = {type_.semantic_type for type_ in types.values()}
 
         exp = {IntSequence1, IntSequence2, FourInts, Mapping, Kennel[Dog],

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -196,13 +196,13 @@ class TestPlugin(unittest.TestCase):
 
         tf = plugin.type_formats
 
-        self.assertEqual(tf[0].type_expression, IntSequence1)
+        self.assertEqual(tf[0].semantic_type, IntSequence1)
         self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
         self.assertEqual(tf[0].plugin, plugin)
         self.assertEqual(tf[0].description, "")
         self.assertEqual(tf[0].examples, types.MappingProxyType({}))
 
-        self.assertEqual(tf[1].type_expression, IntSequence2)
+        self.assertEqual(tf[1].semantic_type, IntSequence2)
         self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[1].plugin, plugin)
         self.assertEqual(tf[1].description, "")
@@ -251,24 +251,28 @@ class TestPlugin(unittest.TestCase):
         # all and only the expected artifact classes have been registered
         self.assertEqual(len(tf), 4)
 
+        self.assertEqual(tf[0].semantic_type, IntSequence1)
         self.assertEqual(tf[0].type_expression, IntSequence1)
         self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
         self.assertEqual(tf[0].plugin, plugin)
         self.assertEqual(tf[0].description, "")
         self.assertEqual(tf[0].examples, types.MappingProxyType({}))
 
+        self.assertEqual(tf[1].semantic_type, IntSequence2)
         self.assertEqual(tf[1].type_expression, IntSequence2)
         self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[1].plugin, plugin)
         self.assertEqual(tf[1].description, "")
         self.assertEqual(tf[1].examples, types.MappingProxyType({}))
 
+        self.assertEqual(tf[2].semantic_type, Kennel[Dog])
         self.assertEqual(tf[2].type_expression, Kennel[Dog])
         self.assertEqual(tf[2].format, IntSequenceDirectoryFormat)
         self.assertEqual(tf[2].plugin, plugin)
         self.assertEqual(tf[2].description, "")
         self.assertEqual(tf[2].examples, types.MappingProxyType({}))
 
+        self.assertEqual(tf[3].semantic_type, Kennel[Cat])
         self.assertEqual(tf[3].type_expression, Kennel[Cat])
         self.assertEqual(tf[3].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[3].plugin, plugin)
@@ -328,14 +332,14 @@ class TestPlugin(unittest.TestCase):
 
         tf = plugin.type_formats
 
-        self.assertEqual(tf[0].type_expression, IntSequence1)
+        self.assertEqual(tf[0].semantic_type, IntSequence1)
         self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
         self.assertEqual(tf[0].plugin, plugin)
         self.assertEqual(tf[0].description, "A sequence of integers.")
         self.assertEqual(tf[0].examples,
                          types.MappingProxyType({'Import ex 1': dummy_use1}))
 
-        self.assertEqual(tf[1].type_expression, IntSequence2)
+        self.assertEqual(tf[1].semantic_type, IntSequence2)
         self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
         self.assertEqual(tf[1].plugin, plugin)
         self.assertEqual(tf[1].description, "Different seq of ints.")
@@ -356,16 +360,16 @@ class TestPlugin(unittest.TestCase):
 
         # the order of the types in type_formats seems to be inconsistent,
         # so load these into a dict for testing
-        tf = {str(e.type_expression): e for e in plugin.type_formats}
+        tf = {str(e.semantic_type): e for e in plugin.type_formats}
         tf_c = tf['Kennel[Cat]']
-        self.assertEqual(tf_c.type_expression, Kennel[Cat])
+        self.assertEqual(tf_c.semantic_type, Kennel[Cat])
         self.assertEqual(tf_c.format, IntSequenceDirectoryFormat)
         self.assertEqual(tf_c.plugin, plugin)
         self.assertEqual(tf_c.description, "")
         self.assertEqual(tf_c.examples, types.MappingProxyType({}))
 
         tf_d = tf['Kennel[Dog]']
-        self.assertEqual(tf_d.type_expression, Kennel[Dog])
+        self.assertEqual(tf_d.semantic_type, Kennel[Dog])
         self.assertEqual(tf_d.format, IntSequenceDirectoryFormat)
         self.assertEqual(tf_d.plugin, plugin)
         self.assertEqual(tf_d.description, "")

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -179,6 +179,54 @@ class TestPlugin(unittest.TestCase):
         self.assertNotIn(Dog, types)
         self.assertNotIn(Kennel, types)
 
+    def test_register_semantic_type_to_format_deprecated_parameter_name(self):
+        plugin = qiime2.plugin.Plugin(
+            name='local-dummy-plugin',
+            version='0.0.0-dev',
+            website='https://github.com/qiime2/qiime2',
+            package='qiime2.core.testing')
+
+        # both the new (directory_format) and old (artifact_format) names for
+        # the format work
+        plugin.register_semantic_type_to_format(
+            IntSequence1, directory_format=IntSequenceDirectoryFormat)
+
+        plugin.register_semantic_type_to_format(
+            IntSequence2, artifact_format=IntSequenceV2DirectoryFormat)
+
+        tf = plugin.type_formats
+
+        self.assertEqual(tf[0].type_expression, IntSequence1)
+        self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
+        self.assertEqual(tf[0].plugin, plugin)
+        self.assertEqual(tf[0].description, "")
+        self.assertEqual(tf[0].examples, {})
+
+        self.assertEqual(tf[1].type_expression, IntSequence2)
+        self.assertEqual(tf[1].format, IntSequenceV2DirectoryFormat)
+        self.assertEqual(tf[1].plugin, plugin)
+        self.assertEqual(tf[1].description, "")
+        self.assertEqual(tf[1].examples, {})
+
+        # errors are raised when both or neither the new or old names for the
+        # format are provided
+        plugin = qiime2.plugin.Plugin(
+            name='local-dummy-plugin',
+            version='0.0.0-dev',
+            website='https://github.com/qiime2/qiime2',
+            package='qiime2.core.testing')
+
+        regex = r'ory_format and artifact_for.*IntSequence1'
+        with self.assertRaisesRegex(ValueError, regex):
+            plugin.register_semantic_type_to_format(
+                IntSequence1, directory_format=IntSequenceDirectoryFormat,
+                artifact_format=IntSequenceDirectoryFormat)
+
+        regex = r'ory_format or artifact_for.*IntSequence1'
+        with self.assertRaisesRegex(ValueError, regex):
+            plugin.register_semantic_type_to_format(IntSequence1)
+
+
     def test_register_artifact_class(self):
         plugin = qiime2.plugin.Plugin(
             name='local-dummy-plugin',

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -354,17 +354,22 @@ class TestPlugin(unittest.TestCase):
         plugin.register_semantic_type_to_format(Kennel[Dog | Cat],
                                                 IntSequenceDirectoryFormat)
 
-        tf = plugin.type_formats
+        # the order of the types in type_formats seems to be inconsistent,
+        # so load these into a dict for testing
+        tf = {str(e.type_expression): e for e in plugin.type_formats}
+        tf_c = tf['Kennel[Cat]']
+        self.assertEqual(tf_c.type_expression, Kennel[Cat])
+        self.assertEqual(tf_c.format, IntSequenceDirectoryFormat)
+        self.assertEqual(tf_c.plugin, plugin)
+        self.assertEqual(tf_c.description, "")
+        self.assertEqual(tf_c.examples, types.MappingProxyType({}))
 
-        # Evan - I was surprised by this behavior, I would have thought we'd
-        # have two type_formats here, one for Kennel[Dog] and one for
-        # Kennel[Cat]. Please confirm that I'm testing this the way I should
-        # be.
-        self.assertEqual(tf[0].type_expression, Kennel[Dog | Cat])
-        self.assertEqual(tf[0].format, IntSequenceDirectoryFormat)
-        self.assertEqual(tf[0].plugin, plugin)
-        self.assertEqual(tf[0].description, "")
-        self.assertEqual(tf[0].examples, types.MappingProxyType({}))
+        tf_d = tf['Kennel[Dog]']
+        self.assertEqual(tf_d.type_expression, Kennel[Dog])
+        self.assertEqual(tf_d.format, IntSequenceDirectoryFormat)
+        self.assertEqual(tf_d.plugin, plugin)
+        self.assertEqual(tf_d.description, "")
+        self.assertEqual(tf_d.examples, types.MappingProxyType({}))
 
         # multiple artifact_classes cannot be registered using
         # register_artifact_class, since default descriptions and examples

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -291,21 +291,21 @@ class TestPlugin(unittest.TestCase):
 
         # Registration of type to the same format with both registration
         # methods is disallowed
-        with self.assertRaisesRegex(NameError, "Type IntSequence1 .* format."):
+        with self.assertRaisesRegex(NameError, "ct class IntSequence1.*once"):
             plugin.register_semantic_type_to_format(
                 IntSequence1, IntSequenceDirectoryFormat)
 
-        with self.assertRaisesRegex(NameError, "Type IntSequence1 .* format."):
+        with self.assertRaisesRegex(NameError, "ct class IntSequence1.*once"):
             plugin.register_artifact_class(
                 IntSequence1, IntSequenceDirectoryFormat)
 
         # Registration of type to the different format with both registration
         # methods is disallowed
-        with self.assertRaisesRegex(NameError, "Type IntSequence1 .* format."):
+        with self.assertRaisesRegex(NameError, "ct class IntSequence1.*once"):
             plugin.register_semantic_type_to_format(
                 IntSequence1, IntSequenceV2DirectoryFormat)
 
-        with self.assertRaisesRegex(NameError, "Type IntSequence1 .* format."):
+        with self.assertRaisesRegex(NameError, "ct class IntSequence1.*once"):
             plugin.register_artifact_class(
                 IntSequence1, IntSequenceV2DirectoryFormat)
 

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -359,7 +359,7 @@ class PluginManager:
                 "Must provide a semantic type via `semantic_type`, not %r" %
                 semantic_type)
 
-        # Evan, ideally we could just lookup semantic_type in
+        # TODO: ideally we could just lookup semantic_type in
         # self.artifact_classes but properties get in the way. Is there a way
         # to strip properties so this could be simplified to return
         # self.artifact_classes[semantic_type] while catching a KeyError?

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -92,7 +92,7 @@ class PluginManager:
         self._reverse_transformers = collections.defaultdict(dict)
         self.formats = {}
         self.views = {}
-        self.type_formats = []
+        self.artifact_classes = []
         self._ff_to_sfdf = {}
         self.validators = {}
 
@@ -201,7 +201,7 @@ class PluginManager:
                 )
 
             self.formats[name] = record
-        self.type_formats.extend(plugin.type_formats)
+        self.artifact_classes.extend(plugin.artifact_classes)
 
         for semantic_type, validation_object in plugin.validators.items():
             if semantic_type not in self.validators:
@@ -215,7 +215,7 @@ class PluginManager:
         result = {}
 
         for plugin in self.plugins.values():
-            for tf in plugin.type_formats:
+            for tf in plugin.artifact_classes:
                 result[str(tf.semantic_type)] = tf
 
         return result
@@ -245,7 +245,7 @@ class PluginManager:
                              "valid.", (filter))
 
         if semantic_type is None:
-            formats = set(f.format for f in self.type_formats)
+            formats = set(f.format for f in self.artifact_classes)
 
         else:
             formats = set()
@@ -254,9 +254,9 @@ class PluginManager:
                 semantic_type = parse_type(semantic_type, "semantic")
 
             if is_semantic_type(semantic_type):
-                for type_format in self.type_formats:
-                    if semantic_type <= type_format.type_expression:
-                        formats.add(type_format.format)
+                for artifact_class in self.artifact_classes:
+                    if semantic_type <= artifact_class.semantic_type:
+                        formats.add(artifact_class.format)
                         break
 
                 if not formats:
@@ -323,6 +323,12 @@ class PluginManager:
         return result_formats
 
     @property
+    def type_formats(self):
+        # self.type_formats was replaced with self.artifact_classes - this
+        # property provides backward compatibility
+        return self.artifact_classes
+
+    @property
     def importable_formats(self):
         """Return formats that are importable.
         A format is importable in a QIIME 2 deployment if it can be transformed
@@ -345,9 +351,9 @@ class PluginManager:
                 semantic_type)
 
         dir_fmt = None
-        for type_format_record in self.type_formats:
-            if semantic_type <= type_format_record.type_expression:
-                dir_fmt = type_format_record.format
+        for artifact_class_record in self.artifact_classes:
+            if semantic_type <= artifact_class_record.semantic_type:
+                dir_fmt = artifact_class_record.format
                 break
 
         if dir_fmt is None:

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -212,26 +212,13 @@ class PluginManager:
                 validation_object)
 
     def get_semantic_types(self):
-        types = {}
+        result = {}
 
-        for plugin in self.plugins.values():
-            for type_record in plugin.types.values():
-                types[str(type_record.semantic_type)] = type_record
-
-        return types
-
-    def get_artifact_classes(self):
-        artifact_classes = {}
-
-        # Evan, how can I index the type_formats by semantic_types, rather than
-        # type_expressions (i.e., FeatureTable[Frequency] and
-        # FeatureTable[RelativeFrequency]), rather than
-        # FeatureTable[Frequency | RelativeFrequency]
         for plugin in self.plugins.values():
             for tf in plugin.type_formats:
-                artifact_classes[str(tf.type_expression)] = tf
+                result[str(tf.semantic_type)] = tf
 
-        return artifact_classes
+        return result
 
     # TODO: Should plugin loading be transactional? i.e. if there's
     # something wrong, the entire plugin fails to load any piece, like a

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -220,6 +220,19 @@ class PluginManager:
 
         return types
 
+    def get_artifact_classes(self):
+        artifact_classes = {}
+
+        # Evan, how can I index the type_formats by semantic_types, rather than
+        # type_expressions (i.e., FeatureTable[Frequency] and
+        # FeatureTable[RelativeFrequency]), rather than
+        # FeatureTable[Frequency | RelativeFrequency]
+        for plugin in self.plugins.values():
+            for tf in plugin.type_formats:
+                artifact_classes[str(tf.type_expression)] = tf
+
+        return artifact_classes
+
     # TODO: Should plugin loading be transactional? i.e. if there's
     # something wrong, the entire plugin fails to load any piece, like a
     # databases rollback/commit

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -165,14 +165,12 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(is2, artifact_classes['IntSequence2'])
         self.assertEqual(is3, artifact_classes['IntSequence3'])
 
-        self.assertNotIn(Cat, artifact_classes)
-        self.assertNotIn(Dog, artifact_classes)
-        self.assertNotIn(Kennel, artifact_classes)
+        self.assertNotIn('Cat', artifact_classes)
+        self.assertNotIn('Dog', artifact_classes)
+        self.assertNotIn('Kennel', artifact_classes)
 
-        # The following test fails because Kennel[Dog | Cat] is in the index,
-        # not Kennel[Dog]. I think this behavior should be changed so this
-        # test passes.
-        self.assertIn(Kennel[Dog], artifact_classes)
+        self.assertIn('Kennel[Dog]', artifact_classes)
+        self.assertIn('Kennel[Cat]', artifact_classes)
 
     # TODO: add tests for type/directory/transformer registrations
     def test_get_formats_no_type_or_filter(self):

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -38,6 +38,8 @@ from qiime2.core.testing.validator import (validator_example_null1,
 
 from qiime2.core.testing.util import get_dummy_plugin
 
+from qiime2.core.testing.plugin import is1_use, is2_use
+
 
 class TestPluginManager(unittest.TestCase):
     def setUp(self):
@@ -119,18 +121,20 @@ class TestPluginManager(unittest.TestCase):
     def test_get_semantic_types(self):
         artifact_classes = self.pm.get_semantic_types()
 
-        is1 = ArtifactClassRecord(semantic_type=IntSequence1,
-                                  format=IntSequenceDirectoryFormat,
-                                  plugin=self.plugin,
-                                  description="The first IntSequence",
-                                  examples={},
-                                  type_expression=IntSequence1)
-        is2 = ArtifactClassRecord(semantic_type=IntSequence2,
-                                  format=IntSequenceV2DirectoryFormat,
-                                  plugin=self.plugin,
-                                  description="The second IntSequence",
-                                  examples={},
-                                  type_expression=IntSequence2)
+        is1 = ArtifactClassRecord(
+            semantic_type=IntSequence1,
+            format=IntSequenceDirectoryFormat,
+            plugin=self.plugin,
+            description="The first IntSequence",
+            examples={'IntSequence1 import example': is1_use},
+            type_expression=IntSequence1)
+        is2 = ArtifactClassRecord(
+            semantic_type=IntSequence2,
+            format=IntSequenceV2DirectoryFormat,
+            plugin=self.plugin,
+            description="The second IntSequence",
+            examples={'IntSequence2 import example': is2_use},
+            type_expression=IntSequence2)
         is3 = ArtifactClassRecord(semantic_type=IntSequence3,
                                   format=IntSequenceMultiFileDirectoryFormat,
                                   plugin=self.plugin,

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -350,7 +350,7 @@ class TestPluginManager(unittest.TestCase):
         # PluginManager.type_formats property returns the plugin manager's
         # artifact_classes
         self.assertEqual(self.pm.type_formats,
-                         self.pm.artifact_classes)
+                         list(self.pm.artifact_classes.values()))
 
 
 if __name__ == '__main__':

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -340,6 +340,14 @@ class TestPluginManager(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "filter.*is not valid"):
             self.pm.get_formats(filter="EXPORTABLE")
 
+    def test_deprecated_type_formats(self):
+        # PluginManager.type_formats was replaced with
+        # PluginManager.artifact_classes. For backward compatibility the
+        # PluginManager.type_formats property returns the plugin manager's
+        # artifact_classes
+        self.assertEqual(self.pm.type_formats,
+                         self.pm.artifact_classes)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -10,7 +10,8 @@ import unittest
 
 import qiime2.plugin
 import qiime2.sdk
-from qiime2.plugin.plugin import SemanticTypeRecord, FormatRecord
+from qiime2.plugin.plugin import (SemanticTypeRecord, FormatRecord,
+                                  TypeFormatRecord)
 from qiime2.sdk.plugin_manager import GetFormatFilters
 
 from qiime2.core.testing.type import (IntSequence1, IntSequence2, IntSequence3,
@@ -139,6 +140,39 @@ class TestPluginManager(unittest.TestCase):
         self.assertNotIn(Cat, types)
         self.assertNotIn(Dog, types)
         self.assertNotIn(Kennel, types)
+
+    def test_get_artifact_classes(self):
+        artifact_classes = self.pm.get_artifact_classes()
+
+        is1 = TypeFormatRecord(type_expression=IntSequence1,
+                               format=IntSequenceDirectoryFormat,
+                               plugin=self.plugin,
+                               description="The first IntSequence",
+                               examples={})
+        is2 = TypeFormatRecord(type_expression=IntSequence2,
+                               format=IntSequenceV2DirectoryFormat,
+                               plugin=self.plugin,
+                               description="The second IntSequence",
+                               examples={})
+        is3 = TypeFormatRecord(type_expression=IntSequence3,
+                               format=IntSequenceMultiFileDirectoryFormat,
+                               plugin=self.plugin,
+                               description="",
+                               examples={})
+
+
+        self.assertEqual(is1, artifact_classes['IntSequence1'])
+        self.assertEqual(is2, artifact_classes['IntSequence2'])
+        self.assertEqual(is3, artifact_classes['IntSequence3'])
+
+        self.assertNotIn(Cat, artifact_classes)
+        self.assertNotIn(Dog, artifact_classes)
+        self.assertNotIn(Kennel, artifact_classes)
+
+        # The following test fails because Kennel[Dog | Cat] is in the index,
+        # not Kennel[Dog]. I think this behavior should be changed so this
+        # test passes.
+        self.assertIn(Kennel[Dog], artifact_classes)
 
     # TODO: add tests for type/directory/transformer registrations
     def test_get_formats_no_type_or_filter(self):

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -11,7 +11,7 @@ import unittest
 import qiime2.plugin
 import qiime2.sdk
 from qiime2.plugin.plugin import (SemanticTypeRecord, FormatRecord,
-                                  TypeFormatRecord)
+                                  ArtifactClassRecord)
 from qiime2.sdk.plugin_manager import GetFormatFilters
 
 from qiime2.core.testing.type import (IntSequence1, IntSequence2, IntSequence3,
@@ -117,49 +117,44 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(types, exp)
 
     def test_get_semantic_types(self):
-        types = self.pm.get_semantic_types()
+        artifact_classes = self.pm.get_semantic_types()
 
-        exp = {
-            'IntSequence1': SemanticTypeRecord(semantic_type=IntSequence1,
-                                               plugin=self.plugin),
-            'IntSequence2': SemanticTypeRecord(semantic_type=IntSequence2,
-                                               plugin=self.plugin),
-            'Mapping':      SemanticTypeRecord(semantic_type=Mapping,
-                                               plugin=self.plugin),
-            'FourInts':     SemanticTypeRecord(semantic_type=FourInts,
-                                               plugin=self.plugin),
-            'Kennel[Dog]':  SemanticTypeRecord(semantic_type=Kennel[Dog],
-                                               plugin=self.plugin),
-            'Kennel[Cat]':  SemanticTypeRecord(semantic_type=Kennel[Cat],
-                                               plugin=self.plugin),
-            'SingleInt':    SemanticTypeRecord(semantic_type=SingleInt,
-                                               plugin=self.plugin),
-        }
+        is1 = ArtifactClassRecord(semantic_type=IntSequence1,
+                                  format=IntSequenceDirectoryFormat,
+                                  plugin=self.plugin,
+                                  description="The first IntSequence",
+                                  examples={},
+                                  type_expression=IntSequence1)
+        is2 = ArtifactClassRecord(semantic_type=IntSequence2,
+                                  format=IntSequenceV2DirectoryFormat,
+                                  plugin=self.plugin,
+                                  description="The second IntSequence",
+                                  examples={},
+                                  type_expression=IntSequence2)
+        is3 = ArtifactClassRecord(semantic_type=IntSequence3,
+                                  format=IntSequenceMultiFileDirectoryFormat,
+                                  plugin=self.plugin,
+                                  description="",
+                                  examples={},
+                                  type_expression=IntSequence3)
 
-        self.assertLessEqual(exp.keys(), types.keys())
-        self.assertNotIn(Cat, types)
-        self.assertNotIn(Dog, types)
-        self.assertNotIn(Kennel, types)
+        kd = ArtifactClassRecord(semantic_type=Kennel[Dog],
+                                 format=MappingDirectoryFormat,
+                                 plugin=self.plugin,
+                                 description="",
+                                 examples={},
+                                 type_expression=Kennel[Dog])
 
-    def test_get_artifact_classes(self):
-        artifact_classes = self.pm.get_artifact_classes()
+        kc = ArtifactClassRecord(semantic_type=Kennel[Cat],
+                                 format=MappingDirectoryFormat,
+                                 plugin=self.plugin,
+                                 description="",
+                                 examples={},
+                                 type_expression=Kennel[Cat])
 
-        is1 = TypeFormatRecord(type_expression=IntSequence1,
-                               format=IntSequenceDirectoryFormat,
-                               plugin=self.plugin,
-                               description="The first IntSequence",
-                               examples={})
-        is2 = TypeFormatRecord(type_expression=IntSequence2,
-                               format=IntSequenceV2DirectoryFormat,
-                               plugin=self.plugin,
-                               description="The second IntSequence",
-                               examples={})
-        is3 = TypeFormatRecord(type_expression=IntSequence3,
-                               format=IntSequenceMultiFileDirectoryFormat,
-                               plugin=self.plugin,
-                               description="",
-                               examples={})
-
+        self.assertLessEqual(
+            {str(e.semantic_type) for e in [is1, is2, is3, kd, kc]},
+            artifact_classes.keys())
 
         self.assertEqual(is1, artifact_classes['IntSequence1'])
         self.assertEqual(is2, artifact_classes['IntSequence2'])


### PR DESCRIPTION
Adds support for registering descriptions and import examples for _artifact classes_. _Artifact class_ is a new term that we're using to refer to semantic types with a registered directory format. Previously these would be registered with `Plugin.register_semantic_type_to_format`, and that is still possible for backward compatibility. These can also now be registered with `Plugin.register_artifact_class`, which optionally takes a description and a dict of usage examples.  

Addresses #649. 

