### PR TITLE
imp: adds helpers to get metadata/artifacts from URLs in usage examples

### DIFF
--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -10,6 +10,7 @@ import unittest.mock as mock
 import unittest
 import tempfile
 
+import qiime2
 from qiime2.core.testing.util import get_dummy_plugin
 import qiime2.core.testing.examples as examples
 from qiime2.sdk import usage, action, UninitializedPluginManagerError
@@ -441,7 +442,6 @@ class TestExecutionUsage(TestCaseUsage):
     #     self.assertIsInstance(a, Artifact)
 
     def test_init_artifact_from_url_error_on_non_artifact(self):
-        # TODO: is this a reliable enough url for tests?
         metadata_url = \
             'https://data.qiime2.org/2022.11/tutorials/' \
             'moving-pictures/sample_metadata.tsv'
@@ -458,7 +458,6 @@ class TestExecutionUsage(TestCaseUsage):
             use.init_metadata_from_url('a', url)
 
     def test_init_metadata_from_url(self):
-        # TODO: is this a reliable enough url for tests?
         metadata_url = \
             'https://data.qiime2.org/2022.11/tutorials/' \
             'moving-pictures/sample_metadata.tsv'
@@ -469,7 +468,6 @@ class TestExecutionUsage(TestCaseUsage):
         self.assertIsInstance(md.value, Metadata)
 
     def test_init_metadata_column_from_url(self):
-        # TODO: is this a reliable enough url for tests?
         metadata_url = \
             'https://data.qiime2.org/2022.11/tutorials/' \
             'moving-pictures/sample_metadata.tsv'
@@ -480,18 +478,11 @@ class TestExecutionUsage(TestCaseUsage):
         self.assertIsInstance(md.value, MetadataColumn)
 
     def test_init_metadata_from_url_epoch(self):
-        # TODO: is this a reliable enough url for tests?
         metadata_url = \
-            'https://data.qiime2.org/{epoch}/tutorials/' \
+            f'https://data.qiime2.org/{qiime2.__release__}/tutorials/' \
             'moving-pictures/sample_metadata.tsv'
         use = usage.ExecutionUsage()
 
         md = use.init_metadata_from_url('md', metadata_url)
 
         self.assertIsInstance(md.value, Metadata)
-
-        with self.assertRaisesRegex(ValueError, 'Could no.*{epoch}'):
-            use.init_metadata_from_url(
-                'bad_url_metadata',
-                metadata_url,
-                replace_url_epoch=False)

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -13,7 +13,7 @@ import tempfile
 from qiime2.core.testing.util import get_dummy_plugin
 import qiime2.core.testing.examples as examples
 from qiime2.sdk import usage, action, UninitializedPluginManagerError
-from qiime2 import Metadata, Artifact
+from qiime2 import Metadata, Artifact, MetadataColumn
 
 
 class TestCaseUsage(unittest.TestCase):
@@ -413,3 +413,85 @@ class TestExecutionUsage(TestCaseUsage):
         self.assertIsInstance(single_int1.value, Artifact)
         self.assertIsInstance(single_int2.value, Artifact)
         self.assertIsInstance(out.value, Artifact)
+
+    def test_init_artifact_from_url_error(self):
+        use = usage.ExecutionUsage()
+
+        with self.assertRaisesRegex(ValueError, 'Could no.*not-a-url'):
+            use.init_artifact_from_url(
+                'bad_url_artifact',
+                'https://not-a-url.qiime2.org/junk.qza',)
+
+    def test_init_metadata_from_url_error(self):
+        use = usage.ExecutionUsage()
+
+        with self.assertRaisesRegex(ValueError, 'Could no.*https://not-a-url'):
+            use.init_metadata_from_url(
+                'bad_url_metadata',
+                'https://not-a-url.qiime2.org/junk.tsv',)
+
+    # def _test_init_artifact_from_url(self):
+    #     TODO: need a url to an artifact that the test suite plugin manager
+    #     knows about.
+    #     artifact_url = ''
+    #     use = usage.ExecutionUsage()
+
+    #     a = use.init_artifact_from_url('a', artifact_url)
+
+    #     self.assertIsInstance(a, Artifact)
+
+    def test_init_artifact_from_url_error_on_non_artifact(self):
+        # TODO: is this a reliable enough url for tests?
+        metadata_url = \
+            'https://data.qiime2.org/2022.8/tutorials/' \
+            'moving-pictures/sample_metadata.tsv'
+        use = usage.ExecutionUsage()
+
+        with self.assertRaisesRegex(ValueError, "Could not.*\n.*a QIIME arc"):
+            use.init_artifact_from_url('a', metadata_url)
+
+    def test_init_metadata_from_url_error_on_non_metadata(self):
+        url = 'https://www.qiime2.org/'
+        use = usage.ExecutionUsage()
+
+        with self.assertRaisesRegex(ValueError, "Could not.*\n.*nized ID"):
+            use.init_metadata_from_url('a', url)
+
+    def test_init_metadata_from_url(self):
+        # TODO: is this a reliable enough url for tests?
+        metadata_url = \
+            'https://data.qiime2.org/2022.8/tutorials/' \
+            'moving-pictures/sample_metadata.tsv'
+        use = usage.ExecutionUsage()
+
+        md = use.init_metadata_from_url('md', metadata_url)
+
+        self.assertIsInstance(md.value, Metadata)
+
+    def test_init_metadata_column_from_url(self):
+        # TODO: is this a reliable enough url for tests?
+        metadata_url = \
+            'https://data.qiime2.org/2022.8/tutorials/' \
+            'moving-pictures/sample_metadata.tsv'
+        use = usage.ExecutionUsage()
+
+        md = use.init_metadata_from_url('md', metadata_url, column='body-site')
+
+        self.assertIsInstance(md.value, MetadataColumn)
+
+    def test_init_metadata_from_url_epoch(self):
+        # TODO: is this a reliable enough url for tests?
+        metadata_url = \
+            'https://data.qiime2.org/{epoch}/tutorials/' \
+            'moving-pictures/sample_metadata.tsv'
+        use = usage.ExecutionUsage()
+
+        md = use.init_metadata_from_url('md', metadata_url)
+
+        self.assertIsInstance(md.value, Metadata)
+
+        with self.assertRaisesRegex(ValueError, 'Could no.*{epoch}'):
+            use.init_metadata_from_url(
+                'bad_url_metadata',
+                metadata_url,
+                replace_url_epoch=False)

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -443,7 +443,7 @@ class TestExecutionUsage(TestCaseUsage):
     def test_init_artifact_from_url_error_on_non_artifact(self):
         # TODO: is this a reliable enough url for tests?
         metadata_url = \
-            'https://data.qiime2.org/2022.8/tutorials/' \
+            'https://data.qiime2.org/2022.11/tutorials/' \
             'moving-pictures/sample_metadata.tsv'
         use = usage.ExecutionUsage()
 
@@ -460,7 +460,7 @@ class TestExecutionUsage(TestCaseUsage):
     def test_init_metadata_from_url(self):
         # TODO: is this a reliable enough url for tests?
         metadata_url = \
-            'https://data.qiime2.org/2022.8/tutorials/' \
+            'https://data.qiime2.org/2022.11/tutorials/' \
             'moving-pictures/sample_metadata.tsv'
         use = usage.ExecutionUsage()
 
@@ -471,7 +471,7 @@ class TestExecutionUsage(TestCaseUsage):
     def test_init_metadata_column_from_url(self):
         # TODO: is this a reliable enough url for tests?
         metadata_url = \
-            'https://data.qiime2.org/2022.8/tutorials/' \
+            'https://data.qiime2.org/2022.11/tutorials/' \
             'moving-pictures/sample_metadata.tsv'
         use = usage.ExecutionUsage()
 

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -14,7 +14,7 @@ import qiime2
 from qiime2.core.testing.util import get_dummy_plugin
 import qiime2.core.testing.examples as examples
 from qiime2.sdk import usage, action, UninitializedPluginManagerError
-from qiime2 import Metadata, Artifact, MetadataColumn
+from qiime2 import Metadata, Artifact
 
 
 class TestCaseUsage(unittest.TestCase):
@@ -466,16 +466,6 @@ class TestExecutionUsage(TestCaseUsage):
         md = use.init_metadata_from_url('md', metadata_url)
 
         self.assertIsInstance(md.value, Metadata)
-
-    def test_init_metadata_column_from_url(self):
-        metadata_url = \
-            'https://data.qiime2.org/2022.11/tutorials/' \
-            'moving-pictures/sample_metadata.tsv'
-        use = usage.ExecutionUsage()
-
-        md = use.init_metadata_from_url('md', metadata_url, column='body-site')
-
-        self.assertIsInstance(md.value, MetadataColumn)
 
     def test_init_metadata_from_url_epoch(self):
         metadata_url = \

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -909,7 +909,7 @@ class Usage:
         """
         return self._usage_variable(name, factory, 'metadata')
 
-    def init_metadata_from_url(self, name: str, url: str,
+    def init_metadata_from_url(self, name: str, url: str, column: str = None,
                                replace_url_epoch: bool = True
                                ) -> UsageVariable:
         """Communicate that metadata should be obtained from a url."""
@@ -924,7 +924,11 @@ class Usage:
             with tempfile.NamedTemporaryFile() as f:
                 f.write(data.content)
                 f.flush()
-                return qiime2.Metadata.load(f.name)
+                md = qiime2.Metadata.load(f.name)
+                if column is None:
+                    return md
+                else:
+                    return md.get_column(column)
 
         return self.init_metadata(name, factory)
 

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -851,9 +851,9 @@ class Usage:
         return url.replace('{epoch}', '2022.8')
 
     def init_artifact_from_url(self, name: str, url: str,
-                               replace_url_epoch: bool=True) -> UsageVariable:
-        """Communicate that an artifact should be obtained from a url.
-        """
+                               replace_url_epoch: bool = True
+                               ) -> UsageVariable:
+        """Communicate that an artifact should be obtained from a url."""
         if replace_url_epoch:
             url = self._replace_url_epoch(url)
 
@@ -910,9 +910,9 @@ class Usage:
         return self._usage_variable(name, factory, 'metadata')
 
     def init_metadata_from_url(self, name: str, url: str,
-                               replace_url_epoch: bool=True) -> UsageVariable:
-        """Communicate that metadata should be obtained from a url.
-        """
+                               replace_url_epoch: bool = True
+                               ) -> UsageVariable:
+        """Communicate that metadata should be obtained from a url."""
         if replace_url_epoch:
             url = self._replace_url_epoch(url)
 

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -930,14 +930,14 @@ class Usage:
         return url.replace('{epoch}', epoch)
 
     def _request_url(self, url):
-        import requests
+        import urllib.request
+        import urllib.error
 
         try:
-            data = requests.get(url)
-            data.raise_for_status()
-        except requests.exceptions.RequestException as ex:
+            data = urllib.request.urlopen(url)
+        except urllib.error.URLError as ex:
             raise ValueError(
-                'Could not obtain URL: %s\n Requests exception: %s' %
+                'Could not obtain URL: %s\n Exception: %s' %
                 (url, str(ex)))
 
         return data
@@ -988,7 +988,7 @@ class Usage:
             data = self._request_url(url)
 
             with tempfile.NamedTemporaryFile() as f:
-                f.write(data.content)
+                f.write(data.read())
                 f.flush()
                 try:
                     result = qiime2.Artifact.load(f.name)
@@ -1045,7 +1045,7 @@ class Usage:
             data = self._request_url(url)
 
             with tempfile.NamedTemporaryFile() as f:
-                f.write(data.content)
+                f.write(data.read())
                 f.flush()
                 try:
                     md = qiime2.Metadata.load(f.name)

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -963,7 +963,8 @@ class Usage:
         # Examples
         # --------
         # >>> import qiime2
-        # >>> url = 'https://data.qiime2.org/{qiime2.__release__}/data/tutorials/moving-pictures/table.qza' # noqa: E501
+        # >>> url = (f'https://data.qiime2.org/{qiime2.__release__}/data/'
+        # ...        'tutorials/moving-pictures/table.qza')
         # >>> mvp_table = use.init_artifact_from_url('mvp_table', url)
         # >>> mvp_table
         # <ExecutionUsageVariable name='mvp_table', var_type='artifact'>
@@ -988,7 +989,7 @@ class Usage:
 
         return self.init_artifact(name, factory)
 
-    def init_metadata_from_url(self, name: str, url: str, column: str = None,
+    def init_metadata_from_url(self, name: str, url: str,
                                ) -> UsageVariable:
         """Obtain metadata from a url.
 
@@ -1015,7 +1016,8 @@ class Usage:
         Examples
         --------
         >>> import qiime2
-        >>> url = f'https://data.qiime2.org/{qiime2.__release__}/tutorials/moving-pictures/sample_metadata.tsv' # noqa: E501
+        >>> url = (f'https://data.qiime2.org/{qiime2.__release__}/tutorials/'
+        ...        'moving-pictures/sample_metadata.tsv')
         >>> print(url)
         https://data.qiime2.org/20...
         >>> md = use.init_metadata_from_url('md', url)
@@ -1040,10 +1042,7 @@ class Usage:
                         ' Original exception: %s'
                         % (url, str(ex)))
 
-                if column is None:
-                    return md
-                else:
-                    return md.get_column(column)
+                return md
 
         return self.init_metadata(name, factory)
 

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -923,8 +923,11 @@ class Usage:
         return self._usage_variable(name, factory, 'format')
 
     def _replace_url_epoch(self, url):
-        # TODO: This is intended to be updated before merge.
-        return url.replace('{epoch}', '2022.8')
+        # Obtaining epoch modeled on qiime2.metadata.io.MetadataFileError
+        import qiime2
+
+        epoch = qiime2.__release__
+        return url.replace('{epoch}', epoch)
 
     def _request_url(self, url):
         import requests

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -908,7 +908,6 @@ class Usage:
         def factory():
             import tempfile
             import requests
-            import pandas as pd
 
             data = requests.get(url)
             with tempfile.NamedTemporaryFile() as f:

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -942,7 +942,39 @@ class Usage:
     def init_artifact_from_url(self, name: str, url: str,
                                replace_url_epoch: bool = True
                                ) -> UsageVariable:
-        """Obtain an artifact from a url."""
+        """Obtain an artifact from a url.
+
+        Driver implementations may use this to intialize data for an example.
+
+        Parameters
+        ----------
+        name : str
+            The canonical name of the variable to be returned.
+        url : str
+            The url of the Artifact that should be downloaded for the
+            example. If a QIIME 2 epoch is part of the URL, as might be the
+            case if obtaining an Artifact from docs.qiime2.org, it can be
+            templated in by including `{epoch}` in the URL.
+         replace_url_epoch : bool = True
+            Replace `{epoch}` in `url` with the most relevant QIIME 2 epoch
+            string.
+
+        Returns
+        -------
+        UsageVariable
+            This particular return class can be changed by a driver which
+            overrides :meth:`usage_variable`.
+        """
+        # The following example needs to use an Artifact that the test suite's
+        # plugin manager can handle.
+        # Examples
+        # --------
+        # >>> d = 'https://data.qiime2.org/'
+        # >>> p = '{epoch}/data/tutorials/moving-pictures/table.qza'
+        # >>> mvp_table = use.init_artifact_from_url('mvp_table', d + p)
+        # >>> mvp_table
+        # <ExecutionUsageVariable name='mvp_table', var_type='artifact'>
+
         if replace_url_epoch:
             url = self._replace_url_epoch(url)
 
@@ -970,7 +1002,37 @@ class Usage:
     def init_metadata_from_url(self, name: str, url: str, column: str = None,
                                replace_url_epoch: bool = True
                                ) -> UsageVariable:
-        """Obtain metadata from a url."""
+        """Obtain metadata from a url.
+
+        Driver implementations may use this to intialize example metadata.
+
+        Parameters
+        ----------
+        name : str
+            The canonical name of the variable to be returned.
+        url : str
+            The url of the Metadata that should be downloaded for the
+            example. If a QIIME 2 epoch is part of the URL, as might be the
+            case if obtaining Metadata from docs.qiime2.org, it can be
+            templated in by including `{epoch}` in the URL.
+         replace_url_epoch : bool = True
+            Replace `{epoch}` in `url` with the most relevant QIIME 2 epoch
+            string.
+
+        Returns
+        -------
+        UsageVariable
+            This particular return class can be changed by a driver which
+            overrides :meth:`usage_variable`.
+
+        Examples
+        --------
+        >>> domain = 'https://data.qiime2.org/'
+        >>> path = '{epoch}/tutorials/moving-pictures/sample_metadata.tsv'
+        >>> md = use.init_metadata_from_url('md', domain + path)
+        >>> md
+        <ExecutionUsageVariable name='md', var_type='metadata'>
+        """
         if replace_url_epoch:
             url = self._replace_url_epoch(url)
 

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -922,13 +922,6 @@ class Usage:
         """
         return self._usage_variable(name, factory, 'format')
 
-    def _replace_url_epoch(self, url):
-        # Obtaining epoch modeled on qiime2.metadata.io.MetadataFileError
-        import qiime2
-
-        epoch = qiime2.__release__
-        return url.replace('{epoch}', epoch)
-
     def _request_url(self, url):
         import urllib.request
         import urllib.error
@@ -954,10 +947,10 @@ class Usage:
             The canonical name of the variable to be returned.
         url : str
             The url of the Artifact that should be downloaded for the
-            example. If a QIIME 2 epoch is part of the URL, as might be the
-            case if obtaining an Artifact from docs.qiime2.org, it can be
-            templated in by including `{qiime2.__release__}` in an F-string
-            defining the URL.
+            example. If a QIIME 2 epoch (e.g., 2022.11) is part of the URL, as
+            might be the case if obtaining an Artifact from docs.qiime2.org,
+            it can be templated in by including `{qiime2.__release__}` in an
+            F-string defining the URL.
 
         Returns
         -------
@@ -1007,11 +1000,11 @@ class Usage:
             The canonical name of the variable to be returned.
         url : str
             The url of the Artifact that should be downloaded for the
-            example. If a QIIME 2 epoch is part of the URL, as might be the
-            case if obtaining an Artifact from docs.qiime2.org, it can be
-            templated in by including `{qiime2.__release__}` in an F-string
-            defining the URL (see the doc string for this method for an
-            example).
+            example. If a QIIME 2 epoch (e.g., 2022.11) is part of the URL, as
+            might be the case if obtaining an Artifact from docs.qiime2.org,
+            it can be templated in by including `{qiime2.__release__}` in an
+            F-string defining the URL (see the doc string for this method for
+            an example).
 
         Returns
         -------

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -943,7 +943,6 @@ class Usage:
         return data
 
     def init_artifact_from_url(self, name: str, url: str,
-                               replace_url_epoch: bool = True
                                ) -> UsageVariable:
         """Obtain an artifact from a url.
 
@@ -957,10 +956,8 @@ class Usage:
             The url of the Artifact that should be downloaded for the
             example. If a QIIME 2 epoch is part of the URL, as might be the
             case if obtaining an Artifact from docs.qiime2.org, it can be
-            templated in by including `{epoch}` in the URL.
-         replace_url_epoch : bool = True
-            Replace `{epoch}` in `url` with the most relevant QIIME 2 epoch
-            string.
+            templated in by including `{qiime2.__release__}` in an F-string
+            defining the URL.
 
         Returns
         -------
@@ -972,15 +969,11 @@ class Usage:
         # plugin manager can handle.
         # Examples
         # --------
-        # >>> d = 'https://data.qiime2.org/'
-        # >>> p = '{epoch}/data/tutorials/moving-pictures/table.qza'
-        # >>> mvp_table = use.init_artifact_from_url('mvp_table', d + p)
+        # >>> import qiime2
+        # >>> url = 'https://data.qiime2.org/{qiime2.__release__}/data/tutorials/moving-pictures/table.qza' # noqa: E501
+        # >>> mvp_table = use.init_artifact_from_url('mvp_table', url)
         # >>> mvp_table
         # <ExecutionUsageVariable name='mvp_table', var_type='artifact'>
-
-        if replace_url_epoch:
-            url = self._replace_url_epoch(url)
-
         def factory():
             import tempfile
             import qiime2
@@ -1003,7 +996,6 @@ class Usage:
         return self.init_artifact(name, factory)
 
     def init_metadata_from_url(self, name: str, url: str, column: str = None,
-                               replace_url_epoch: bool = True
                                ) -> UsageVariable:
         """Obtain metadata from a url.
 
@@ -1014,13 +1006,12 @@ class Usage:
         name : str
             The canonical name of the variable to be returned.
         url : str
-            The url of the Metadata that should be downloaded for the
+            The url of the Artifact that should be downloaded for the
             example. If a QIIME 2 epoch is part of the URL, as might be the
-            case if obtaining Metadata from docs.qiime2.org, it can be
-            templated in by including `{epoch}` in the URL.
-         replace_url_epoch : bool = True
-            Replace `{epoch}` in `url` with the most relevant QIIME 2 epoch
-            string.
+            case if obtaining an Artifact from docs.qiime2.org, it can be
+            templated in by including `{qiime2.__release__}` in an F-string
+            defining the URL (see the doc string for this method for an
+            example).
 
         Returns
         -------
@@ -1030,15 +1021,16 @@ class Usage:
 
         Examples
         --------
-        >>> domain = 'https://data.qiime2.org/'
-        >>> path = '{epoch}/tutorials/moving-pictures/sample_metadata.tsv'
-        >>> md = use.init_metadata_from_url('md', domain + path)
+        >>> import qiime2
+        >>> url = f'https://data.qiime2.org/{qiime2.__release__}/tutorials/moving-pictures/sample_metadata.tsv' # noqa: E501
+        >>> print(url)
+        https://data.qiime2.org/20...
+        >>> md = use.init_metadata_from_url('md', url)
         >>> md
         <ExecutionUsageVariable name='md', var_type='metadata'>
         """
-        if replace_url_epoch:
-            url = self._replace_url_epoch(url)
-
+        # the print statement in the above doc string provides an illustration
+        # of how F-strings are interpreted
         def factory():
             import tempfile
 

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -847,9 +847,16 @@ class Usage:
         """
         return self._usage_variable(name, factory, 'artifact')
 
-    def init_artifact_from_url(self, name: str, url: str) -> UsageVariable:
+    def _replace_url_epoch(self, url):
+        return url.replace('{epoch}', '2022.8')
+
+    def init_artifact_from_url(self, name: str, url: str,
+                               replace_url_epoch: bool=True) -> UsageVariable:
         """Communicate that an artifact should be obtained from a url.
         """
+        if replace_url_epoch:
+            url = self._replace_url_epoch(url)
+
         def factory():
             import tempfile
             import requests
@@ -902,9 +909,13 @@ class Usage:
         """
         return self._usage_variable(name, factory, 'metadata')
 
-    def init_metadata_from_url(self, name: str, url: str) -> UsageVariable:
+    def init_metadata_from_url(self, name: str, url: str,
+                               replace_url_epoch: bool=True) -> UsageVariable:
         """Communicate that metadata should be obtained from a url.
         """
+        if replace_url_epoch:
+            url = self._replace_url_epoch(url)
+
         def factory():
             import tempfile
             import requests

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -847,6 +847,25 @@ class Usage:
         """
         return self._usage_variable(name, factory, 'artifact')
 
+    def init_artifact_from_url(self, name: str, url: str) -> UsageVariable:
+        """Communicate that an artifact should be obtained from a url.
+        """
+        def factory():
+            import tempfile
+            import requests
+            import qiime2
+
+            data = requests.get(url)
+
+            with tempfile.NamedTemporaryFile() as f:
+                f.write(data.content)
+                f.flush()
+                result = qiime2.Artifact.load(f.name)
+
+            return result
+
+        return self.init_artifact(name, factory)
+
     def init_metadata(self, name: str,
                       factory: Callable[[], qiime2.Metadata]) -> UsageVariable:
         """Communicate that metadata will be needed.
@@ -882,6 +901,22 @@ class Usage:
         <ExecutionUsageVariable name='my_metadata', var_type='metadata'>
         """
         return self._usage_variable(name, factory, 'metadata')
+
+    def init_metadata_from_url(self, name: str, url: str) -> UsageVariable:
+        """Communicate that metadata should be obtained from a url.
+        """
+        def factory():
+            import tempfile
+            import requests
+            import pandas as pd
+
+            data = requests.get(url)
+            with tempfile.NamedTemporaryFile() as f:
+                f.write(data.content)
+                f.flush()
+                return qiime2.Metadata.load(f.name)
+
+        return self.init_metadata(name, factory)
 
     def init_format(self, name: str,
                     factory: Callable[[], 'qiime2.core.format.FormatBase'],


### PR DESCRIPTION
Addresses #657 

Still needs:
 - [x] doc strings
 - [x] unit tests
 - [x] error detection and reporting on failed downloads (e.g., report 404 with the URL rather than failing when trying to load nonsense data as Metadata)
 - [x] ~`init_metadata_column_from_url`~ ~this is hooked up by passing `column` to `init_metadata_from_url`~ going to skip this in this PR altogether
 - [x] update handling of integration of `{epoch}` in URLs to replace with the most recent epoch
 - [x] is this encoding/replacement of `{epoch}` a reasonable way to handle this? _we decided to use f-strings instead, based on feedback from @ebolyen_
 - [x] address new TODOs throughout

Submitting a draft PR so we can use it in our usage sprint example. 