### PR TITLE
improve support for looking up formats

### DIFF
--- a/qiime2/core/testing/format.py
+++ b/qiime2/core/testing/format.py
@@ -159,3 +159,15 @@ class Cephalapod(TextFileFormat):
 
 CephalapodDirectoryFormat = model.SingleFileDirectoryFormat(
     'CephalapodDirectoryFormat', 'squids.tsv', Cephalapod)
+
+
+class ImportableOnlyFormat(TextFileFormat):
+    """
+    A format that can only be transformed from.
+    """
+
+
+class ExportableOnlyFormat(TextFileFormat):
+    """
+    A format that can only be transformed to.
+    """

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -29,6 +29,8 @@ from .format import (
     EchoDirectoryFormat,
     Cephalapod,
     CephalapodDirectoryFormat,
+    ImportableOnlyFormat,
+    ExportableOnlyFormat
 )
 
 from .type import (IntSequence1, IntSequence2, IntSequence3, Mapping, FourInts,
@@ -89,7 +91,8 @@ dummy_plugin.register_semantic_types(IntSequence1, IntSequence2, IntSequence3,
 dummy_plugin.register_formats(
     IntSequenceFormatV2, MappingFormat, IntSequenceV2DirectoryFormat,
     IntSequenceMultiFileDirectoryFormat, MappingDirectoryFormat,
-    EchoDirectoryFormat, EchoFormat, Cephalapod, CephalapodDirectoryFormat)
+    EchoDirectoryFormat, EchoFormat, Cephalapod, CephalapodDirectoryFormat,
+    ImportableOnlyFormat, ExportableOnlyFormat)
 
 dummy_plugin.register_formats(
     FourIntsDirectoryFormat, UnimportableDirectoryFormat, UnimportableFormat,

--- a/qiime2/core/testing/transformer.py
+++ b/qiime2/core/testing/transformer.py
@@ -21,7 +21,9 @@ from .format import (
     MappingFormat,
     UnimportableFormat,
     RedundantSingleIntDirectoryFormat,
-    EchoFormat
+    EchoFormat,
+    ImportableOnlyFormat,
+    ExportableOnlyFormat
 )
 from .plugin import dummy_plugin, citations
 
@@ -192,3 +194,15 @@ def _a1(data: str) -> EchoFormat:
     with ff.open() as fh:
         fh.write(data)
     return ff
+
+
+# only for testing get_formats - otherwise useless
+@dummy_plugin.register_transformer()
+def _4242(data: ImportableOnlyFormat) -> IntSequenceDirectoryFormat:
+    return IntSequenceDirectoryFormat()
+
+
+# only for testing get_formats - otherwise useless
+@dummy_plugin.register_transformer()
+def _4243(data: IntSequenceDirectoryFormat) -> ExportableOnlyFormat:
+    return ExportableOnlyFormat()

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -348,7 +348,7 @@ class PluginManager:
         A format is importable in a QIIME 2 deployment if it can be transformed
         into at least one of the canonical semantic type formats.
         """
-        return self.get_importable_formats()
+        return self.get_formats(filter=GetFormatFilters.IMPORTABLE)
 
     @property
     def exportable_formats(self):
@@ -356,7 +356,7 @@ class PluginManager:
         A format is exportable in a QIIME 2 deployment if it can be transformed
         from at least one of the canonical semantic type formats.
         """
-        return self.get_exportable_formats()
+        return self.get_formats(filter=GetFormatFilters.EXPORTABLE)
 
     @property
     def importable_types(self):

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -237,7 +237,7 @@ class PluginManager:
         """
         get_formats(self, *, filter=None, semantic_type=None)
 
-        filter : enum
+        filter : enum | "IMPORTABLE" | "EXPORTABLE"
             filter is an enum integer that will be used to determine user
             input to output specified formats
 
@@ -249,9 +249,14 @@ class PluginManager:
         the user and the semantic type. The return is a dictionary of filtered
         formats keyed on their string names.
         """
-        if filter is not None and not isinstance(filter, GetFormatFilters):
-            raise ValueError("The format filter provided: %s is not "
-                             "valid.", (filter))
+        filter_map = {"IMPORTABLE": GetFormatFilters.IMPORTABLE,
+                      "EXPORTABLE": GetFormatFilters.EXPORTABLE}
+        if filter is not None and not isinstance(filter, GetFormatFilters) \
+            and filter not in filter_map:
+            raise ValueError(
+                f"The provided format filter {filter} is not valid.")
+        if isinstance(filter, str):
+            filter = filter_map[filter]
 
         if semantic_type is None:
             formats = set(f.format for f in self.artifact_classes.values())
@@ -345,14 +350,6 @@ class PluginManager:
         """
         return self.get_importable_formats()
 
-    def get_importable_formats(self, semantic_type=None):
-        """Return formats that are importable.
-        A format is importable in a QIIME 2 deployment if it can be transformed
-        into at least one of the canonical semantic type formats.
-        """
-        return self.get_formats(filter=GetFormatFilters.IMPORTABLE,
-                                semantic_type=semantic_type)
-
     @property
     def exportable_formats(self):
         """Formats that are exportable.
@@ -360,14 +357,6 @@ class PluginManager:
         from at least one of the canonical semantic type formats.
         """
         return self.get_exportable_formats()
-
-    def get_exportable_formats(self, semantic_type=None):
-        """Return formats that are exportable.
-        A format is exportable in a QIIME 2 deployment if it can be transformed
-        from at least one of the canonical semantic type formats.
-        """
-        return self.get_formats(filter=GetFormatFilters.EXPORTABLE,
-                                semantic_type=semantic_type)
 
     @property
     def importable_types(self):

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -252,7 +252,7 @@ class PluginManager:
         filter_map = {"IMPORTABLE": GetFormatFilters.IMPORTABLE,
                       "EXPORTABLE": GetFormatFilters.EXPORTABLE}
         if filter is not None and not isinstance(filter, GetFormatFilters) \
-            and filter not in filter_map:
+                and filter not in filter_map:
             raise ValueError(
                 f"The provided format filter {filter} is not valid.")
         if isinstance(filter, str):

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -339,11 +339,35 @@ class PluginManager:
 
     @property
     def importable_formats(self):
+        """Formats that are importable.
+        A format is importable in a QIIME 2 deployment if it can be transformed
+        into at least one of the canonical semantic type formats.
+        """
+        return self.get_importable_formats()
+
+    def get_importable_formats(self, semantic_type=None):
         """Return formats that are importable.
         A format is importable in a QIIME 2 deployment if it can be transformed
         into at least one of the canonical semantic type formats.
         """
-        return self.get_formats(filter=GetFormatFilters.IMPORTABLE)
+        return self.get_formats(filter=GetFormatFilters.IMPORTABLE,
+                                semantic_type=semantic_type)
+
+    @property
+    def exportable_formats(self):
+        """Formats that are exportable.
+        A format is exportable in a QIIME 2 deployment if it can be transformed
+        from at least one of the canonical semantic type formats.
+        """
+        return self.get_exportable_formats()
+
+    def get_exportable_formats(self, semantic_type=None):
+        """Return formats that are exportable.
+        A format is exportable in a QIIME 2 deployment if it can be transformed
+        from at least one of the canonical semantic type formats.
+        """
+        return self.get_formats(filter=GetFormatFilters.EXPORTABLE,
+                                semantic_type=semantic_type)
 
     @property
     def importable_types(self):

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -30,7 +30,9 @@ from qiime2.core.testing.format import (Cephalapod, IntSequenceDirectoryFormat,
                                         RedundantSingleIntDirectoryFormat,
                                         EchoFormat,
                                         EchoDirectoryFormat,
-                                        CephalapodDirectoryFormat)
+                                        CephalapodDirectoryFormat,
+                                        ImportableOnlyFormat,
+                                        ExportableOnlyFormat)
 
 from qiime2.core.testing.validator import (validator_example_null1,
                                            validate_ascending_seq,
@@ -209,6 +211,12 @@ class TestPluginManager(unittest.TestCase):
             'CephalapodDirectoryFormat':
                 FormatRecord(format=CephalapodDirectoryFormat,
                              plugin=self.plugin),
+            'ImportableOnlyFormat':
+                FormatRecord(format=ImportableOnlyFormat,
+                             plugin=self.plugin),
+            'ExportableOnlyFormat':
+                FormatRecord(format=ExportableOnlyFormat,
+                             plugin=self.plugin),
         }
 
         obs = self.pm.get_formats()
@@ -231,7 +239,13 @@ class TestPluginManager(unittest.TestCase):
                              plugin=self.plugin),
             'IntSequenceMultiFileDirectoryFormat':
                 FormatRecord(format=IntSequenceMultiFileDirectoryFormat,
-                             plugin=self.plugin)
+                             plugin=self.plugin),
+            'ImportableOnlyFormat':
+                FormatRecord(format=ImportableOnlyFormat,
+                             plugin=self.plugin),
+            'ExportableOnlyFormat':
+                FormatRecord(format=ExportableOnlyFormat,
+                             plugin=self.plugin),
         }
 
         obs = self.pm.get_formats(semantic_type='IntSequence1')
@@ -251,6 +265,9 @@ class TestPluginManager(unittest.TestCase):
                              plugin=self.plugin),
             'IntSequenceV2DirectoryFormat':
                 FormatRecord(format=IntSequenceV2DirectoryFormat,
+                             plugin=self.plugin),
+            'ExportableOnlyFormat':
+                FormatRecord(format=ExportableOnlyFormat,
                              plugin=self.plugin)
         }
 
@@ -269,6 +286,9 @@ class TestPluginManager(unittest.TestCase):
                              plugin=self.plugin),
             'IntSequenceMultiFileDirectoryFormat':
                 FormatRecord(format=IntSequenceMultiFileDirectoryFormat,
+                             plugin=self.plugin),
+            'ImportableOnlyFormat':
+                FormatRecord(format=ImportableOnlyFormat,
                              plugin=self.plugin)
         }
 
@@ -380,25 +400,25 @@ class TestPluginManager(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "filter.*is not valid"):
             self.pm.get_formats(filter="xyz")
 
-    def test_format_properties(self):
+    def test_importable_formats_property(self):
         # super basic tests of the properties
         imp_f = self.pm.importable_formats
         self.assertTrue(isinstance(imp_f, dict))
-        self.assertTrue(len(imp_f) > 0)
         # spot check for a few formats that should be present
         self.assertTrue('IntSequenceFormatV2' in imp_f)
         self.assertTrue('CephalapodDirectoryFormat' in imp_f)
+        self.assertTrue('ImportableOnlyFormat' in imp_f)
+        # spot check one that shouldn't be here
+        self.assertFalse('ExportableOnlyFormat' in imp_f)
 
+    def test_exportable_formats_property(self):
         exp_f = self.pm.exportable_formats
         self.assertTrue(isinstance(exp_f, dict))
-        self.assertTrue(len(exp_f) > 0)
         self.assertTrue('IntSequenceDirectoryFormat' in exp_f)
         self.assertTrue('IntSequenceV2DirectoryFormat' in exp_f)
-
-        self.assertTrue(len(self.pm.get_formats()) > len(imp_f))
-        self.assertTrue(len(self.pm.get_formats()) > len(exp_f))
-
-        raise ValueError
+        self.assertTrue('ExportableOnlyFormat' in exp_f)
+        # spot check one that shouldn't be here
+        self.assertFalse('ImportableOnlyFormat' in exp_f)
 
     def test_deprecated_type_formats(self):
         # PluginManager.type_formats was replaced with

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -401,7 +401,6 @@ class TestPluginManager(unittest.TestCase):
             self.pm.get_formats(filter="xyz")
 
     def test_importable_formats_property(self):
-        # super basic tests of the properties
         imp_f = self.pm.importable_formats
         self.assertTrue(isinstance(imp_f, dict))
         # spot check for a few formats that should be present
@@ -414,6 +413,7 @@ class TestPluginManager(unittest.TestCase):
     def test_exportable_formats_property(self):
         exp_f = self.pm.exportable_formats
         self.assertTrue(isinstance(exp_f, dict))
+        # spot check for a few formats that should be present
         self.assertTrue('IntSequenceDirectoryFormat' in exp_f)
         self.assertTrue('IntSequenceV2DirectoryFormat' in exp_f)
         self.assertTrue('ExportableOnlyFormat' in exp_f)

--- a/qiime2/sdk/tests/test_plugin_manager.py
+++ b/qiime2/sdk/tests/test_plugin_manager.py
@@ -318,6 +318,24 @@ class TestPluginManager(unittest.TestCase):
 
         self.assertEqual(exp, obs)
 
+    def test_get_formats_DF_exportable_str(self):
+        exp = {
+            'IntSequenceFormat':
+                FormatRecord(format=IntSequenceFormat,
+                             plugin=self.plugin),
+            'IntSequenceDirectoryFormat':
+                FormatRecord(format=IntSequenceDirectoryFormat,
+                             plugin=self.plugin),
+            'IntSequenceMultiFileDirectoryFormat':
+                FormatRecord(format=IntSequenceMultiFileDirectoryFormat,
+                             plugin=self.plugin)
+        }
+
+        obs = self.pm.get_formats(filter="EXPORTABLE",
+                                  semantic_type=IntSequence3)
+
+        self.assertEqual(exp, obs)
+
     def test_get_formats_DF_IMPORTABLE(self):
         exp = {
             'IntSequenceFormatV2':
@@ -336,13 +354,51 @@ class TestPluginManager(unittest.TestCase):
 
         self.assertEqual(exp, obs)
 
+    def test_get_formats_DF_importable_str(self):
+        exp = {
+            'IntSequenceFormatV2':
+                FormatRecord(format=IntSequenceFormatV2,
+                             plugin=self.plugin),
+            'IntSequenceV2DirectoryFormat':
+                FormatRecord(format=IntSequenceV2DirectoryFormat,
+                             plugin=self.plugin),
+            'IntSequenceMultiFileDirectoryFormat':
+                FormatRecord(format=IntSequenceMultiFileDirectoryFormat,
+                             plugin=self.plugin)
+        }
+
+        obs = self.pm.get_formats(filter="IMPORTABLE",
+                                  semantic_type=IntSequence3)
+
+        self.assertEqual(exp, obs)
+
     def test_get_formats_invalid_type(self):
         with self.assertRaisesRegex(ValueError, "No formats associated"):
             self.pm.get_formats(semantic_type='Random[Frequency]')
 
     def test_get_formats_invalid_filter(self):
         with self.assertRaisesRegex(ValueError, "filter.*is not valid"):
-            self.pm.get_formats(filter="EXPORTABLE")
+            self.pm.get_formats(filter="xyz")
+
+    def test_format_properties(self):
+        # super basic tests of the properties
+        imp_f = self.pm.importable_formats
+        self.assertTrue(isinstance(imp_f, dict))
+        self.assertTrue(len(imp_f) > 0)
+        # spot check for a few formats that should be present
+        self.assertTrue('IntSequenceFormatV2' in imp_f)
+        self.assertTrue('CephalapodDirectoryFormat' in imp_f)
+
+        exp_f = self.pm.exportable_formats
+        self.assertTrue(isinstance(exp_f, dict))
+        self.assertTrue(len(exp_f) > 0)
+        self.assertTrue('IntSequenceDirectoryFormat' in exp_f)
+        self.assertTrue('IntSequenceV2DirectoryFormat' in exp_f)
+
+        self.assertTrue(len(self.pm.get_formats()) > len(imp_f))
+        self.assertTrue(len(self.pm.get_formats()) > len(exp_f))
+
+        raise ValueError
 
     def test_deprecated_type_formats(self):
         # PluginManager.type_formats was replaced with


### PR DESCRIPTION
* Allows `PluginManager.get_formats` to take filters as strings to support easier access from outside of `qiime2`.
* Adds `PluginManager.get_exportable_formats` property, mirroring `PluginManager.get_importable_formats` 