### PR TITLE
SQUASH: Temporarily no op set_permissions

### DIFF
--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -494,8 +494,11 @@ class TestCache(unittest.TestCase):
                 cache_prefix,
                 i_acknowledge_this_is_dangerous=True) as (uname, user_cache):
             with user_cache:
-                user_result = concatenate_ints(
-                    self.art1, self.art2, self.art4, 4, 5)[0]
+                art1 = Artifact.import_data(IntSequence1, [0, 1, 2])
+                art2 = Artifact.import_data(IntSequence1, [3, 4, 5])
+                art4 = Artifact.import_data(IntSequence2, [9, 10, 11])
+
+                user_result = concatenate_ints(art1, art2, art4, 4, 5)[0]
 
             user_expected = set((
                 './VERSION', f'data/{user_result._archiver.uuid}',

--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -433,23 +433,29 @@ class TestCache(unittest.TestCase):
 
     @pytest.mark.skipif(os.geteuid() == 0, reason="super user always wins")
     def test_surreptitiously_write_artifact(self):
-        self.cache.save(self.art1, 'a')
-        target = self.cache.data / str(self.art1.uuid) / 'metadata.yaml'
+        """Test commented out because behavior is temporarily removed
+        """
+        pass
+        # self.cache.save(self.art1, 'a')
+        # target = self.cache.data / str(self.art1.uuid) / 'metadata.yaml'
 
-        with self.assertRaisesRegex(PermissionError,
-                                    f"Permission denied: '{target}'"):
-            with open(target, mode='a') as fh:
-                fh.write('gonna mess up ur metadata')
+        # with self.assertRaisesRegex(PermissionError,
+        #                             f"Permission denied: '{target}'"):
+        #     with open(target, mode='a') as fh:
+        #         fh.write('gonna mess up ur metadata')
 
     @pytest.mark.skipif(os.geteuid() == 0, reason="super user always wins")
     def test_surreptitiously_add_file(self):
-        self.cache.save(self.art1, 'a')
-        target = self.cache.data / str(self.art1.uuid) / 'extra.file'
+        """Test commented out because behavior is temporarily removed
+        """
+        pass
+        # self.cache.save(self.art1, 'a')
+        # target = self.cache.data / str(self.art1.uuid) / 'extra.file'
 
-        with self.assertRaisesRegex(PermissionError,
-                                    f"Permission denied: '{target}'"):
-            with open(target, mode='w') as fh:
-                fh.write('extra file')
+        # with self.assertRaisesRegex(PermissionError,
+        #                             f"Permission denied: '{target}'"):
+        #     with open(target, mode='w') as fh:
+        #         fh.write('extra file')
 
     @pytest.mark.skipif(
         os.geteuid() != 0, reason="only sudo can mess with users")

--- a/qiime2/core/util.py
+++ b/qiime2/core/util.py
@@ -282,23 +282,28 @@ def is_uuid4(uuid_str):
 
 def set_permissions(path, file_permissions=None, dir_permissions=None,
                     skip_root=False):
+    """Right now this doesn't seem to be doing anything but causing a thorn in
+    our side with panfs, but we may end up wanting it back later, and we are
+    already calling it in all (or most) of the locations we would want
+    """
+    pass
     """Set permissions on all directories and files under and including path
     """
-    for directory, _, files in os.walk(path):
-        # We may want to set permissions under a directory but not on the
-        # directory itself.
-        if dir_permissions and not (skip_root and directory == str(path)):
-            try:
-                os.chmod(directory, dir_permissions)
-            except FileNotFoundError:
-                pass
+    # for directory, _, files in os.walk(path):
+    #     # We may want to set permissions under a directory but not on the
+    #     # directory itself.
+    #     if dir_permissions and not (skip_root and directory == str(path)):
+    #         try:
+    #             os.chmod(directory, dir_permissions)
+    #         except FileNotFoundError:
+    #             pass
 
-        for file in files:
-            if file_permissions:
-                try:
-                    os.chmod(os.path.join(directory, file), file_permissions)
-                except FileNotFoundError:
-                    pass
+    #     for file in files:
+    #         if file_permissions:
+    #             try:
+    #                 os.chmod(os.path.join(directory, file), file_permissions)
+    #             except FileNotFoundError:
+    #                 pass
 
 
 def touch_under_path(path):


### PR DESCRIPTION
Currently setting permissions has been causing us some pain on panfs, and it doesn't necessarily seem to be gaining us anything, so we are disabling it at least for now.