### PR TITLE
SQUASH: Can now only set rwx for user and group

### DIFF
--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -53,7 +53,7 @@ import qiime2
 from .path import ArchivePath
 from qiime2.sdk.result import Result
 from qiime2.core.util import (is_uuid4, set_permissions, touch_under_path,
-                              READ_ONLY_FILE, READ_ONLY_DIR, ALL_PERMISSIONS)
+                              READ_ONLY_FILE, READ_ONLY_DIR, USER_GROUP_RWX)
 from qiime2.core.archive.archiver import Archiver
 
 _VERSION_TEMPLATE = """\
@@ -435,8 +435,8 @@ class Cache:
                         warnings.warn(
                             "Your temporary cache was found to be in an "
                             "inconsistent state. It has been recreated.")
-                        set_permissions(self.path, ALL_PERMISSIONS,
-                                        ALL_PERMISSIONS, skip_root=True)
+                        set_permissions(self.path, USER_GROUP_RWX,
+                                        USER_GROUP_RWX, skip_root=True)
                         self._remove_cache_contents()
                         self._create_cache_contents()
                     else:
@@ -716,7 +716,7 @@ class Cache:
                 if data not in referenced_data:
                     target = self.data / data
 
-                    set_permissions(target, None, ALL_PERMISSIONS)
+                    set_permissions(target, None, USER_GROUP_RWX)
                     shutil.rmtree(target)
 
     def save(self, ref, key):

--- a/qiime2/core/path.py
+++ b/qiime2/core/path.py
@@ -13,7 +13,7 @@ import distutils
 import tempfile
 import weakref
 
-from qiime2.core.util import set_permissions, ALL_PERMISSIONS
+from qiime2.core.util import set_permissions, USER_GROUP_RWX
 
 _ConcretePath = type(pathlib.Path())
 
@@ -121,7 +121,7 @@ class InternalDirectory(_ConcretePath):
     def _destruct(cls, path):
         """DO NOT USE DIRECTLY, use `_destructor()` instead"""
         if os.path.exists(path):
-            set_permissions(path, None, ALL_PERMISSIONS)
+            set_permissions(path, None, USER_GROUP_RWX)
             shutil.rmtree(path)
 
     @classmethod

--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -494,8 +494,14 @@ class TestCache(unittest.TestCase):
                 cache_prefix,
                 i_acknowledge_this_is_dangerous=True) as (uname, user_cache):
             with user_cache:
-                user_result = concatenate_ints(
-                    self.art1, self.art2, self.art4, 4, 5)[0]
+                # We can't use the artifacts that are on the class here anymore
+                # because they exist in root's temp cache and this user no
+                # longer has access to it (which is good honestly)
+                art1 = Artifact.import_data(IntSequence1, [0, 1, 2])
+                art2 = Artifact.import_data(IntSequence1, [3, 4, 5])
+                art4 = Artifact.import_data(IntSequence2, [9, 10, 11])
+
+                user_result = concatenate_ints(art1, art2, art4, 4, 5)[0]
 
             user_expected = set((
                 './VERSION', f'data/{user_result._archiver.uuid}',

--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -433,23 +433,29 @@ class TestCache(unittest.TestCase):
 
     @pytest.mark.skipif(os.geteuid() == 0, reason="super user always wins")
     def test_surreptitiously_write_artifact(self):
-        self.cache.save(self.art1, 'a')
-        target = self.cache.data / str(self.art1.uuid) / 'metadata.yaml'
+        """Test temporarily no-oped because behavior is temporarily no-oped
+        """
+        return
+        # self.cache.save(self.art1, 'a')
+        # target = self.cache.data / str(self.art1.uuid) / 'metadata.yaml'
 
-        with self.assertRaisesRegex(PermissionError,
-                                    f"Permission denied: '{target}'"):
-            with open(target, mode='a') as fh:
-                fh.write('gonna mess up ur metadata')
+        # with self.assertRaisesRegex(PermissionError,
+        #                             f"Permission denied: '{target}'"):
+        #     with open(target, mode='a') as fh:
+        #         fh.write('gonna mess up ur metadata')
 
     @pytest.mark.skipif(os.geteuid() == 0, reason="super user always wins")
     def test_surreptitiously_add_file(self):
-        self.cache.save(self.art1, 'a')
-        target = self.cache.data / str(self.art1.uuid) / 'extra.file'
+        """Test temporarily no-oped because behavior is temporarily no-oped
+        """
+        return
+        # self.cache.save(self.art1, 'a')
+        # target = self.cache.data / str(self.art1.uuid) / 'extra.file'
 
-        with self.assertRaisesRegex(PermissionError,
-                                    f"Permission denied: '{target}'"):
-            with open(target, mode='w') as fh:
-                fh.write('extra file')
+        # with self.assertRaisesRegex(PermissionError,
+        #                             f"Permission denied: '{target}'"):
+        #     with open(target, mode='w') as fh:
+        #         fh.write('extra file')
 
     @pytest.mark.skipif(
         os.geteuid() != 0, reason="only sudo can mess with users")

--- a/qiime2/core/util.py
+++ b/qiime2/core/util.py
@@ -20,7 +20,7 @@ import decorator
 READ_ONLY_FILE = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
 READ_ONLY_DIR = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH | stat.S_IRUSR \
     | stat.S_IRGRP | stat.S_IROTH
-ALL_PERMISSIONS = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+USER_GROUP_RWX = stat.S_IRWXU | stat.S_IRWXG
 OTHER_NO_WRITE = stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH
 
 
@@ -284,6 +284,16 @@ def set_permissions(path, file_permissions=None, dir_permissions=None,
                     skip_root=False):
     """Set permissions on all directories and files under and including path
     """
+    # Panfs is currently causing issues for us setting permissions. We still
+    # want to set rwx for user and group before we remove things to ensure we
+    # can remove them, but we want to temporarily no-op other permission
+    # changes
+    if file_permissions != USER_GROUP_RWX:
+        file_permissions = None
+
+    if dir_permissions != USER_GROUP_RWX:
+        dir_permissions = None
+
     for directory, _, files in os.walk(path):
         # We may want to set permissions under a directory but not on the
         # directory itself.

--- a/qiime2/core/util.py
+++ b/qiime2/core/util.py
@@ -294,6 +294,10 @@ def set_permissions(path, file_permissions=None, dir_permissions=None,
     if dir_permissions != USER_GROUP_RWX:
         dir_permissions = None
 
+    # Just get out if we aren't doing anything
+    if file_permissions is None and dir_permissions is None:
+        return
+
     for directory, _, files in os.walk(path):
         # We may want to set permissions under a directory but not on the
         # directory itself.


### PR DESCRIPTION
Completely no-oping set permissions seemed to be causing some issues with backward compatibility. Caches could still have read-only artifacts in them, and we were unable to remove them because we were no longer setting them to rwx before trying to. This should resolve that. We now set rwx for user and group before trying to remove anything. Those are the only permissions settable with set_permissions