### PR TITLE
SQUASH: Usage example fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,5 @@ jobs:
       with:
         package-name: qiime2
         build-target: dev
-        additional-tests: QIIMETEST= py.test --pyargs qiime2
+        additional-tests: QIIMETEST= py.test --pyargs --doctest-modules qiime2
         library-token: ${{ secrets.LIBRARY_TOKEN }}

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - dill
     - psutil
     - flufl.lock
-    - tornado
 
 test:
   requires:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -29,10 +29,12 @@ requirements:
     - dill
     - psutil
     - flufl.lock
+    - tornado
 
 test:
   requires:
     - pytest
+    - tornado
 
   imports:
     - qiime2

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -34,6 +34,7 @@ test:
   requires:
     - pytest
     - tornado
+    - notebook
 
   imports:
     - qiime2

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -1004,8 +1004,7 @@ class Usage:
             example. If a QIIME 2 epoch (e.g., 2022.11) is part of the URL, as
             might be the case if obtaining an Artifact from docs.qiime2.org,
             it can be templated in by including `{qiime2.__release__}` in an
-            F-string defining the URL (see the doc string for this method for
-            an example).
+            F-string defining the URL.
 
         Returns
         -------
@@ -1016,10 +1015,10 @@ class Usage:
         Examples
         --------
         >>> import qiime2
-        >>> url = (f'https://data.qiime2.org/{qiime2.__release__}/tutorials/'
-        ...        'moving-pictures/sample_metadata.tsv')
+        >>> url = ('https://data.qiime2.org/usage-examples/moving-pictures/'
+        ...        'sample-metadata.tsv')
         >>> print(url)
-        https://data.qiime2.org/20...
+        https://data.qiime2.org/usage...
         >>> md = use.init_metadata_from_url('md', url)
         >>> md
         <ExecutionUsageVariable name='md', var_type='metadata'>


### PR DESCRIPTION
Fixes a usage example still using the moving-pictures metadata URL with the epoch interpolated.