### PR TITLE
BUG: Lock when removing the process pool in atexit

### DIFF
--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -229,8 +229,9 @@ def _exit_cleanup():
         # workers). It could also happen if someone deleted the process pool
         # but... They probably shouldn't do that
         if os.path.exists(target):
-            shutil.rmtree(target)
-            cache.garbage_collection()
+            with cache.lock:
+                shutil.rmtree(target)
+                cache.garbage_collection()
 
 
 def monitor_thread(cache_dir, is_done):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -228,10 +228,11 @@ def _exit_cleanup():
         # does not create a process pool (on Mac this atexit is invoked on
         # workers). It could also happen if someone deleted the process pool
         # but... They probably shouldn't do that
-        if os.path.exists(target):
+        if os.path.exists(cache.path):
             with cache.lock:
-                shutil.rmtree(target)
-                cache.garbage_collection()
+                if os.path.exists(target):
+                    shutil.rmtree(target)
+                    cache.garbage_collection()
 
 
 def monitor_thread(cache_dir, is_done):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -228,11 +228,17 @@ def _exit_cleanup():
         # does not create a process pool (on Mac this atexit is invoked on
         # workers). It could also happen if someone deleted the process pool
         # but... They probably shouldn't do that
-        if os.path.exists(cache.path):
-            with cache.lock:
+        try:
+            cache.lock.__enter__()
+        except Exception:
+            continue
+        else:
+            try:
                 if os.path.exists(target):
                     shutil.rmtree(target)
                     cache.garbage_collection()
+            finally:
+                cache.lock.__exit__()
 
 
 def monitor_thread(cache_dir, is_done):
@@ -280,7 +286,12 @@ class MEGALock(tm):
         """
         if self.re_entries == 0:
             self.thread_lock.acquire()
-            self.flufl_lock.lock()
+
+            try:
+                self.flufl_lock.lock()
+            except Exception:
+                self.thread_lock.release()
+                raise
 
         self.re_entries += 1
 


### PR DESCRIPTION
Lock the cache when removing our process pool at exit to prevent the case where we remove an already tracked process pool out from under a different process that is garbage collecting.