### PR TITLE
SQUASH: Rework config loading

### DIFF
--- a/qiime2/core/testing/tests/test_mapped_actions.py
+++ b/qiime2/core/testing/tests/test_mapped_actions.py
@@ -23,17 +23,10 @@ class ActionTester(unittest.TestCase):
         self.action = plugin.actions[self.ACTION]
 
     def run_action(self, **inputs):
-        if isinstance(self.action, Pipeline):
-            return self.run_pipeline(**inputs)
-        else:
-            return self.run_non_pipeline(**inputs)
-
-    def run_pipeline(self, **inputs):
         results = self.run_non_pipeline(**inputs)
-        parsl_results = self.action.parallel(**inputs)._result()
 
-        for a, b in zip(results, parsl_results):
-            self.assertEqual(a.type, b.type)
+        if isinstance(self.action, Pipeline):
+            self.run_pipeline(results, **inputs)
 
         return results
 
@@ -45,6 +38,12 @@ class ActionTester(unittest.TestCase):
             self.assertEqual(a.type, b.type)
 
         return results
+
+    def run_pipeline(self, results, **inputs):
+        parsl_results = self.action.parallel(**inputs)._result()
+
+        for a, b in zip(results, parsl_results):
+            self.assertEqual(a.type, b.type)
 
 
 class TestConstrainedInputVisualization(ActionTester):

--- a/qiime2/core/testing/tests/test_mapped_actions.py
+++ b/qiime2/core/testing/tests/test_mapped_actions.py
@@ -29,8 +29,7 @@ class ActionTester(unittest.TestCase):
             return self.run_non_pipeline(**inputs)
 
     def run_pipeline(self, **inputs):
-        results, _ = self.run_non_pipeline(**inputs)
-
+        results = self.run_non_pipeline(**inputs)
         parsl_results = self.action.parallel(**inputs)._result()
 
         for a, b in zip(results, parsl_results):
@@ -40,9 +39,7 @@ class ActionTester(unittest.TestCase):
 
     def run_non_pipeline(self, **inputs):
         results = self.action(**inputs)
-
-        future = self.action.asynchronous(**inputs)
-        async_results = future.result()
+        async_results = self.action.asynchronous(**inputs).result()
 
         for a, b in zip(results, async_results):
             self.assertEqual(a.type, b.type)

--- a/qiime2/core/tests/test_pipeline_resumption.py
+++ b/qiime2/core/tests/test_pipeline_resumption.py
@@ -113,7 +113,7 @@ class TestPipelineResumption(unittest.TestCase):
             complete_identity_uuid = _load_alias_uuid(identity_ret)
             complete_viz_uuid = _load_alias_uuid(viz_ret)
 
-            # Nothing should have been recyled because we didn't use a pool
+            # Nothing should have been recycled because we didn't use a pool
             self.assertNotEqual(ints1_uuids, complete_ints1_uuids)
             self.assertNotEqual(ints2_uuids, complete_ints2_uuids)
             self.assertNotEqual(int1_uuid, complete_int1_uuid)

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -405,6 +405,10 @@ class Action(metaclass=abc.ABCMeta):
 
     def _get_parsl_wrapper(self):
         def parsl_wrapper(*args, **kwargs):
+            # TODO: Maybe make this a warning instead?
+            if not isinstance(self, Pipeline):
+                raise ValueError('Only pipelines may be run in parallel')
+
             setup_parallel()
             return self._bind_parsl(qiime2.sdk.Context(parallel=True), *args,
                                     **kwargs)

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -14,7 +14,6 @@ import textwrap
 
 import decorator
 import dill
-import parsl
 from parsl.app.app import python_app, join_app
 
 import qiime2.sdk
@@ -22,7 +21,7 @@ import qiime2.core.type as qtype
 import qiime2.core.archive as archive
 from qiime2.core.util import (LateBindingAttribute, DropFirstParameter,
                               tuplize, create_collection_name)
-from qiime2.sdk.parsl_config import PARSL_CONFIG, setup_parsl
+from qiime2.sdk.parsl_config import setup_parsl
 from qiime2.sdk.proxy import Proxy
 
 
@@ -406,13 +405,6 @@ class Action(metaclass=abc.ABCMeta):
     def _get_parsl_wrapper(self):
         def parsl_wrapper(*args, **kwargs):
             setup_parsl()
-
-            # If you find a good way to determine if a parsl config is loaded.
-            # Use it here
-            try:
-                parsl.load(PARSL_CONFIG.parsl_config)
-            except RuntimeError:
-                pass
 
             return self._bind_parsl(qiime2.sdk.Context(parsl=True), *args,
                                     **kwargs)

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -69,15 +69,15 @@ def setup_parallel(config_fp=None):
         config_fp = _get_vendored_config()
 
     if config_fp is not None:
-        config_dict = _get_config(config_fp)
-        mapping = _get_mapping(config_dict)
+        config_dict = get_config(config_fp)
+        mapping = get_mapping(config_dict)
 
         # If config_dict is empty now, they gave a file that only contained a
         # mapping, so we want to load a default config assuming they do not
         # already have a loaded config
         if config_dict == {} and PARALLEL_CONFIG.parallel_config is None:
             config_fp = _get_vendored_config()
-            config_dict = _get_config(config_fp)
+            config_dict = get_config(config_fp)
 
         # Now if we actually have a config dict, we want to load the config. We
         # still will not have one if they gave us a file that only contained a
@@ -103,6 +103,22 @@ def setup_parallel(config_fp=None):
     PARALLEL_CONFIG.parallel_config = config
     if mapping != {}:
         PARALLEL_CONFIG.action_executor_mapping = mapping
+
+
+def get_config(fp):
+    """Takes a config filepath and determines if the file exists and if so if
+    it contains parsl config info.
+    """
+    with open(fp, 'r') as fh:
+        config_dict = tomlkit.load(fh)
+
+    return config_dict.get('parsl')
+
+
+def get_mapping(config_dict):
+    """Takes a config dict and pops off the action_executor_mapping
+    """
+    return config_dict.pop('executor_mapping', {})
 
 
 def _get_vendored_config():
@@ -134,23 +150,6 @@ def _get_vendored_config():
             config_fp = VENDORED_FP
 
     return config_fp
-
-
-def _get_config(fp):
-    """Takes a config filepath and determines if the file exists and if so if
-    it contains parsl config info.
-    """
-    with open(fp, 'r') as fh:
-        config_dict = tomlkit.load(fh)
-
-    return config_dict.get('parsl')
-
-
-def _get_mapping(config_dict):
-    """Takes a config filepath and determines if the file exists and if so if
-    it contains action executor mapping info.
-    """
-    return config_dict.pop('executor_mapping', {})
 
 
 def _process_config(config_dict):

--- a/qiime2/sdk/parsl_config.py
+++ b/qiime2/sdk/parsl_config.py
@@ -204,8 +204,9 @@ class ParallelConfig():
         errors will only occur if an action that is being run in a given
         QIIME 2 invocation has been mapped to an executor that does not exist
 
-        parsl_config: Specifies which executors should be created and how they
-        should be created
+        parallel_config: Specifies which executors should be created and how
+        they should be created. If this is None, it will use the default
+        config.
         """
         self.parsl_config = parsl_config
         self.action_executor_mapping = action_executor_mapping

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -115,7 +115,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(PARALLEL_CONFIG.action_executor_mapping, {})
 
     def test_mapping_from_config(self):
-        setup_parsl(self.config_fp)
+        setup_parallel(self.config_fp)
 
         with self.cache:
             future = self.pipeline.parallel(self.art, self.art)

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -33,6 +33,7 @@ class TestConfig(unittest.TestCase):
 
         plugin = get_dummy_plugin()
         self.pipeline = plugin.pipelines['resumable_pipeline']
+        self.method = plugin.methods['list_of_ints']
 
         # Create temp test dir
         self.test_dir = tempfile.TemporaryDirectory(prefix='qiime2-test-temp-')
@@ -212,6 +213,11 @@ class TestConfig(unittest.TestCase):
 
                 self.assertEqual(list_execution_contexts, self.tpool_expected)
                 self.assertEqual(dict_execution_contexts, self.tpool_expected)
+
+    def test_parallel_non_pipeline(self):
+        with self.assertRaisesRegex(
+                ValueError, 'Only pipelines may be run in parallel'):
+            self.method.parallel(self.art)
 
     def _load_alias_execution_contexts(self, collection):
         execution_contexts = []


### PR DESCRIPTION
Loading configs in the way we initially envisioned is a bit more complex than we initially hoped. This got grosser than I intended. Refactors/unit tests will come tomorrow. Fortunately, we should not need this to start messing with Parsl.
