### PR TITLE
Use 'none'

### DIFF
--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -160,9 +160,9 @@ def _process_config(config_dict):
     config_kwargs = {}
 
     for key, value in config_dict.items():
-        # Our value is a None
+        # Parsl likes the string 'none' as opposed to None or 'None'
         if isinstance(value, str) and value.lower() == 'none':
-            config_kwargs[key] = None
+            config_kwargs[key] = value.lower()
         # We have a list of values
         elif isinstance(value, list):
             config_kwargs[key] = []


### PR DESCRIPTION
Get rid of a deprecation warning about using the literal `None` versus the string 'none'
