### PR TITLE
NEW: adds ResultCollection to Usage API

### DIFF
--- a/qiime2/core/testing/examples.py
+++ b/qiime2/core/testing/examples.py
@@ -25,7 +25,7 @@ def ints3_factory():
     return Artifact.import_data(IntSequence2, [6, 7, 8])
 
 
-def result_collection_factory():
+def artifact_collection_factory():
     return ResultCollection({'Foo': Artifact.import_data(SingleInt, 1),
                              'Bar': Artifact.import_data(SingleInt, 2)})
 
@@ -243,7 +243,7 @@ def optional_inputs(use):
 
 
 def collection_list_of_ints(use):
-    ints = use.init_result_collection('ints', result_collection_factory)
+    ints = use.init_result_collection('ints', artifact_collection_factory)
 
     out, = use.action(
                 use.UsageAction(plugin_id='dummy_plugin',
@@ -254,7 +254,7 @@ def collection_list_of_ints(use):
 
 
 def collection_dict_of_ints(use):
-    ints = use.init_result_collection('ints', result_collection_factory)
+    ints = use.init_result_collection('ints', artifact_collection_factory)
 
     out, = use.action(
                 use.UsageAction(plugin_id='dummy_plugin',

--- a/qiime2/core/testing/examples.py
+++ b/qiime2/core/testing/examples.py
@@ -8,7 +8,7 @@
 
 import pandas as pd
 
-from qiime2 import Artifact, Metadata
+from qiime2 import Artifact, Metadata, ResultCollection
 
 from .type import IntSequence1, IntSequence2, Mapping, SingleInt
 
@@ -23,6 +23,11 @@ def ints2_factory():
 
 def ints3_factory():
     return Artifact.import_data(IntSequence2, [6, 7, 8])
+
+
+def result_collection_factory():
+    return ResultCollection({'SingleInt1': Artifact.import_data(SingleInt, 1),
+                             'SingleInt2': Artifact.import_data(SingleInt, 2)})
 
 
 def mapping1_factory():
@@ -234,4 +239,16 @@ def optional_inputs(use):
                         action_id='optional_artifacts_method'),
         use.UsageInputs(ints=ints, optional1=output3, num1=3, num2=4),
         use.UsageOutputNames(output='output4'),
+    )
+
+
+def collection_list_of_ints(use):
+    int_collection = use.init_result_collection('int_collection',
+                                                result_collection_factory)
+
+    out, = use.action(
+                use.UsageAction(plugin_id='dummy_plugin',
+                                action_id='list_of_ints'),
+                use.UsageInputs(ints=int_collection),
+                use.UsageOutputNames(output='out'),
     )

--- a/qiime2/core/testing/examples.py
+++ b/qiime2/core/testing/examples.py
@@ -26,8 +26,8 @@ def ints3_factory():
 
 
 def result_collection_factory():
-    return ResultCollection({'SingleInt1': Artifact.import_data(SingleInt, 1),
-                             'SingleInt2': Artifact.import_data(SingleInt, 2)})
+    return ResultCollection({'Foo': Artifact.import_data(SingleInt, 1),
+                             'Bar': Artifact.import_data(SingleInt, 2)})
 
 
 def mapping1_factory():
@@ -243,12 +243,24 @@ def optional_inputs(use):
 
 
 def collection_list_of_ints(use):
-    int_collection = use.init_result_collection('int_collection',
-                                                result_collection_factory)
+    ints = use.init_result_collection('ints', result_collection_factory)
 
     out, = use.action(
                 use.UsageAction(plugin_id='dummy_plugin',
                                 action_id='list_of_ints'),
-                use.UsageInputs(ints=int_collection),
+                use.UsageInputs(ints=ints),
                 use.UsageOutputNames(output='out'),
     )
+
+
+def collection_dict_of_ints(use):
+    ints = use.init_result_collection('ints', result_collection_factory)
+
+    out, = use.action(
+                use.UsageAction(plugin_id='dummy_plugin',
+                                action_id='dict_of_ints'),
+                use.UsageInputs(ints=ints),
+                use.UsageOutputNames(output='out'),
+    )
+
+    out.assert_output_type(semantic_type='SingleInt', key='Foo')

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -67,7 +67,7 @@ from .examples import (concatenate_ints_simple, concatenate_ints_complex,
                        identity_with_metadata_merging,
                        identity_with_metadata_column_get_mdc,
                        variadic_input_simple, optional_inputs,
-                       comments_only_factory,
+                       comments_only_factory, collection_list_of_ints,
                        )
 
 
@@ -913,7 +913,8 @@ dummy_plugin.methods.register_function(
     },
     output_descriptions={
         'output': 'Reversed Collection of ints'
-    }
+    },
+    examples={'collection_list_of_ints': collection_list_of_ints}
 )
 
 dummy_plugin.methods.register_function(

--- a/qiime2/core/testing/plugin.py
+++ b/qiime2/core/testing/plugin.py
@@ -68,6 +68,7 @@ from .examples import (concatenate_ints_simple, concatenate_ints_complex,
                        identity_with_metadata_column_get_mdc,
                        variadic_input_simple, optional_inputs,
                        comments_only_factory, collection_list_of_ints,
+                       collection_dict_of_ints,
                        )
 
 
@@ -933,7 +934,8 @@ dummy_plugin.methods.register_function(
     },
     output_descriptions={
         'output': 'Collection of ints'
-    }
+    },
+    examples={'collection_dict_of_ints': collection_dict_of_ints}
 )
 
 dummy_plugin.methods.register_function(

--- a/qiime2/plugins.py
+++ b/qiime2/plugins.py
@@ -41,8 +41,9 @@ class ArtifactAPIUsageVariable(usage.UsageVariable):
 
         parts = {
             'artifact': [self.name],
-            'result_collection': [self.name, 'collection'],
+            'artifact_collection': [self.name, 'artifact_collection'],
             'visualization': [self.name, 'viz'],
+            'visualization_collection': [self.name, 'viz_collection'],
             'metadata': [self.name, 'md'],
             'column': [self.name, 'mdc'],
             # No format here - it shouldn't be possible to make it this far

--- a/qiime2/plugins.py
+++ b/qiime2/plugins.py
@@ -41,6 +41,7 @@ class ArtifactAPIUsageVariable(usage.UsageVariable):
 
         parts = {
             'artifact': [self.name],
+            'result_collection': [self.name, 'collection'],
             'visualization': [self.name, 'viz'],
             'metadata': [self.name, 'md'],
             'column': [self.name, 'mdc'],
@@ -77,6 +78,8 @@ class ArtifactAPIUsageVariable(usage.UsageVariable):
 
         name = self.to_interface_name()
 
+        # TODO: we expect a syntax error to occur here, need to ensure that
+        # this fails if not a string, and potentially update to "%s[%r]"
         if key:
             name = "%s[%s]" % (name, key)
 
@@ -173,6 +176,14 @@ class ArtifactAPIUsage(usage.Usage):
 
     def init_metadata(self, name, factory):
         variable = super().init_metadata(name, factory)
+
+        var_name = str(variable.to_interface_name())
+        self.init_data_refs[var_name] = variable
+
+        return variable
+
+    def init_result_collection(self, name, factory):
+        variable = super().init_result_collection(name, factory)
 
         var_name = str(variable.to_interface_name())
         self.init_data_refs[var_name] = variable

--- a/qiime2/plugins.py
+++ b/qiime2/plugins.py
@@ -78,8 +78,6 @@ class ArtifactAPIUsageVariable(usage.UsageVariable):
 
         name = self.to_interface_name()
 
-        # TODO: we expect a syntax error to occur here, need to ensure that
-        # this fails if not a string, and potentially update to "%s[%r]"
         if key:
             name = "%s[%s]" % (name, key)
 

--- a/qiime2/plugins.py
+++ b/qiime2/plugins.py
@@ -71,7 +71,8 @@ class ArtifactAPIUsageVariable(usage.UsageVariable):
 
         self.use._add(lines)
 
-    def assert_output_type(self, semantic_type):
+    # TODO: add key param to assert type of ResultCollection contents
+    def assert_output_type(self, semantic_type, key=None):
         if not self.use.enable_assertions:
             return
 

--- a/qiime2/plugins.py
+++ b/qiime2/plugins.py
@@ -71,12 +71,14 @@ class ArtifactAPIUsageVariable(usage.UsageVariable):
 
         self.use._add(lines)
 
-    # TODO: add key param to assert type of ResultCollection contents
     def assert_output_type(self, semantic_type, key=None):
         if not self.use.enable_assertions:
             return
 
         name = self.to_interface_name()
+
+        if key:
+            name = "%s[%s]" % (name, key)
 
         lines = [
             'if str(%r.type) != %r:' % (name, str(semantic_type)),

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -618,11 +618,11 @@ class ResultCollection:
         # Do this to give us a unified API with Result.save
         return directory
 
-    def _save_galaxy_(self, directory):
+    def save_unordered(self, directory):
         """Saves a collection of QIIME 2 Results into a given directory without
-           an order file. This is to be used by q2galaxy where an order file
-           will be interpreted as another dataset in the collection which is
-           not desirable
+           an order file. This is used by q2galaxy where an order file will be
+           interpreted as another dataset in the collection which is not
+           desirable
 
            NOTE: The directory given must not exist
         """
@@ -632,6 +632,7 @@ class ResultCollection:
                              "the collection to.")
 
         os.makedirs(directory)
+
         for name, result in self.collection.items():
             result_fp = os.path.join(directory, name)
             result.save(result_fp)

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -589,6 +589,13 @@ class ResultCollection:
 
         return qiime2.core.type.Collection[inner_type]
 
+    @property
+    def extension(self):
+        if str(self.type) == 'Collection[Visualization]':
+            return '.qzv'
+
+        return '.qza'
+
     def save(self, directory):
         """Saves a collection of QIIME 2 Results into a given directory with
            an order file.

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -611,6 +611,27 @@ class ResultCollection:
         # Do this to give us a unified API with Result.save
         return directory
 
+    def _save_galaxy_(self, directory):
+        """Saves a collection of QIIME 2 Results into a given directory without
+           an order file. This is to be used by q2galaxy where an order file
+           will be interpreted as another dataset in the collection which is
+           not desirable
+
+           NOTE: The directory given must not exist
+        """
+        if os.path.exists(directory):
+            raise ValueError(f"The given directory '{directory}' already "
+                             "exists. A new directory must be given to save "
+                             "the collection to.")
+
+        os.makedirs(directory)
+        for name, result in self.collection.items():
+            result_fp = os.path.join(directory, name)
+            result.save(result_fp)
+
+        # Do this to give us a unified API with Result.save
+        return directory
+
     def keys(self):
         return self.collection.keys()
 

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -375,7 +375,7 @@ class TestDiagnosticUsage(TestCaseUsage):
         self.assertEqual('init_result_collection', obs1.source)
         self.assertEqual('action', obs2.source)
 
-        self.assertEqual('int_collection', obs1.variable.name)
+        self.assertEqual('ints', obs1.variable.name)
         self.assertEqual('out', obs2.variable[0].name)
 
         self.assertEqual('result_collection', obs1.variable.var_type)

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -390,8 +390,8 @@ class TestExecutionUsage(TestCaseUsage):
 
     def test_variadic_input_simple(self):
         use = usage.ExecutionUsage()
-        action = self.plugin.actions['list_of_ints']
-        action.examples['list_of_ints'](use)
+        action = self.plugin.actions['variadic_input_method']
+        action.examples['variadic_input_simple'](use)
 
         ints_a, ints_b, single_int1, single_int2, out = use.render().values()
 
@@ -414,7 +414,7 @@ class TestExecutionUsage(TestCaseUsage):
         self.assertIsInstance(single_int2.value, Artifact)
         self.assertIsInstance(out.value, Artifact)
 
-    def test_result_collection_blah_blah_blah(self):
+    def test_result_collection_list_of_ints(self):
         use = usage.ExecutionUsage()
         action = self.plugin.actions['list_of_ints']
         action.examples['collection_list_of_ints'](use)

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -363,26 +363,26 @@ class TestDiagnosticUsage(TestCaseUsage):
         self.assertTrue(obs4.variable[0].is_deferred)
         self.assertTrue(obs5.variable[0].is_deferred)
 
-    def test_result_collections_list_of_ints(self):
-        action = self.plugin.actions['list_of_ints']
-        use = usage.DiagnosticUsage()
-        action.examples['collection_list_of_ints'](use)
+    # def test_result_collection_list_of_ints(self):
+    #     action = self.plugin.actions['list_of_ints']
+    #     use = usage.DiagnosticUsage()
+    #     action.examples['collection_list_of_ints'](use)
 
-        self.assertEqual(2, len(use.render()))
+    #     self.assertEqual(2, len(use.render()))
 
-        obs1, obs2 = use.render()
+    #     obs1, obs2 = use.render()
 
-        self.assertEqual('init_result_collection', obs1.source)
-        self.assertEqual('action', obs2.source)
+    #     self.assertEqual('init_result_collection', obs1.source)
+    #     self.assertEqual('action', obs2.source)
 
-        self.assertEqual('int_collection', obs1.variable.name)
-        self.assertEqual('out', obs2.variable[0].name)
+    #     self.assertEqual('int_collection', obs1.variable.name)
+    #     self.assertEqual('out', obs2.variable[0].name)
 
-        self.assertEqual('result_collection', obs1.variable.var_type)
-        self.assertEqual('result_collection', obs2.variable[0].var_type)
+    #     self.assertEqual('result_collection', obs1.variable.var_type)
+    #     self.assertEqual('result_collection', obs2.variable[0].var_type)
 
-        self.assertTrue(obs1.variable.is_deferred)
-        self.assertTrue(obs2.variable[0].is_deferred)
+    #     self.assertTrue(obs1.variable.is_deferred)
+    #     self.assertTrue(obs2.variable[0].is_deferred)
 
 
 class TestExecutionUsage(TestCaseUsage):
@@ -440,8 +440,9 @@ class TestExecutionUsage(TestCaseUsage):
         action = self.plugin.actions['list_of_ints']
         action.examples['collection_list_of_ints'](use)
 
-        out, = use.render().values()
+        ints, out = use.render().values()
 
+        self.assertIsInstance(ints.value, ResultCollection)
         self.assertIsInstance(out.value, ResultCollection)
 
     def test_init_artifact_from_url_error(self):

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -363,6 +363,27 @@ class TestDiagnosticUsage(TestCaseUsage):
         self.assertTrue(obs4.variable[0].is_deferred)
         self.assertTrue(obs5.variable[0].is_deferred)
 
+    def test_result_collections_list_of_ints(self):
+        action = self.plugin.actions['list_of_ints']
+        use = usage.DiagnosticUsage()
+        action.examples['collection_list_of_ints'](use)
+
+        self.assertEqual(2, len(use.render()))
+
+        obs1, obs2 = use.render()
+
+        self.assertEqual('init_result_collection', obs1.source)
+        self.assertEqual('action', obs2.source)
+
+        self.assertEqual('int_collection', obs1.variable.name)
+        self.assertEqual('out', obs2.variable[0].name)
+
+        self.assertEqual('result_collection', obs1.variable.var_type)
+        self.assertEqual('result_collection', obs2.variable[0].var_type)
+
+        self.assertTrue(obs1.variable.is_deferred)
+        self.assertTrue(obs2.variable[0].is_deferred)
+
 
 class TestExecutionUsage(TestCaseUsage):
     def test_basic(self):

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -378,8 +378,8 @@ class TestDiagnosticUsage(TestCaseUsage):
         self.assertEqual('ints', obs1.variable.name)
         self.assertEqual('out', obs2.variable[0].name)
 
-        self.assertEqual('result_collection', obs1.variable.var_type)
-        self.assertEqual('result_collection', obs2.variable[0].var_type)
+        self.assertEqual('artifact_collection', obs1.variable.var_type)
+        self.assertEqual('artifact_collection', obs2.variable[0].var_type)
 
         self.assertTrue(obs1.variable.is_deferred)
         self.assertTrue(obs2.variable[0].is_deferred)

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -13,7 +13,7 @@ import tempfile
 from qiime2.core.testing.util import get_dummy_plugin
 import qiime2.core.testing.examples as examples
 from qiime2.sdk import usage, action, UninitializedPluginManagerError
-from qiime2 import Metadata, Artifact
+from qiime2 import Metadata, Artifact, ResultCollection
 
 
 class TestCaseUsage(unittest.TestCase):
@@ -390,8 +390,8 @@ class TestExecutionUsage(TestCaseUsage):
 
     def test_variadic_input_simple(self):
         use = usage.ExecutionUsage()
-        action = self.plugin.actions['variadic_input_method']
-        action.examples['variadic_input_simple'](use)
+        action = self.plugin.actions['list_of_ints']
+        action.examples['list_of_ints'](use)
 
         ints_a, ints_b, single_int1, single_int2, out = use.render().values()
 
@@ -413,6 +413,15 @@ class TestExecutionUsage(TestCaseUsage):
         self.assertIsInstance(single_int1.value, Artifact)
         self.assertIsInstance(single_int2.value, Artifact)
         self.assertIsInstance(out.value, Artifact)
+
+    def test_result_collection_blah_blah_blah(self):
+        use = usage.ExecutionUsage()
+        action = self.plugin.actions['list_of_ints']
+        action.examples['collection_list_of_ints'](use)
+
+        out, = use.render().values()
+
+        self.assertIsInstance(out.value, ResultCollection)
 
     def test_init_artifact_from_url_error(self):
         use = usage.ExecutionUsage()

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -363,26 +363,26 @@ class TestDiagnosticUsage(TestCaseUsage):
         self.assertTrue(obs4.variable[0].is_deferred)
         self.assertTrue(obs5.variable[0].is_deferred)
 
-    # def test_result_collection_list_of_ints(self):
-    #     action = self.plugin.actions['list_of_ints']
-    #     use = usage.DiagnosticUsage()
-    #     action.examples['collection_list_of_ints'](use)
+    def test_result_collection_list_of_ints(self):
+        action = self.plugin.actions['list_of_ints']
+        use = usage.DiagnosticUsage()
+        action.examples['collection_list_of_ints'](use)
 
-    #     self.assertEqual(2, len(use.render()))
+        self.assertEqual(2, len(use.render()))
 
-    #     obs1, obs2 = use.render()
+        obs1, obs2 = use.render()
 
-    #     self.assertEqual('init_result_collection', obs1.source)
-    #     self.assertEqual('action', obs2.source)
+        self.assertEqual('init_result_collection', obs1.source)
+        self.assertEqual('action', obs2.source)
 
-    #     self.assertEqual('int_collection', obs1.variable.name)
-    #     self.assertEqual('out', obs2.variable[0].name)
+        self.assertEqual('int_collection', obs1.variable.name)
+        self.assertEqual('out', obs2.variable[0].name)
 
-    #     self.assertEqual('result_collection', obs1.variable.var_type)
-    #     self.assertEqual('result_collection', obs2.variable[0].var_type)
+        self.assertEqual('result_collection', obs1.variable.var_type)
+        self.assertEqual('result_collection', obs2.variable[0].var_type)
 
-    #     self.assertTrue(obs1.variable.is_deferred)
-    #     self.assertTrue(obs2.variable[0].is_deferred)
+        self.assertTrue(obs1.variable.is_deferred)
+        self.assertTrue(obs2.variable[0].is_deferred)
 
 
 class TestExecutionUsage(TestCaseUsage):

--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -363,7 +363,7 @@ class TestDiagnosticUsage(TestCaseUsage):
         self.assertTrue(obs4.variable[0].is_deferred)
         self.assertTrue(obs5.variable[0].is_deferred)
 
-    def test_result_collection_list_of_ints(self):
+    def test_artifact_collection_list_of_ints(self):
         action = self.plugin.actions['list_of_ints']
         use = usage.DiagnosticUsage()
         action.examples['collection_list_of_ints'](use)
@@ -435,7 +435,7 @@ class TestExecutionUsage(TestCaseUsage):
         self.assertIsInstance(single_int2.value, Artifact)
         self.assertIsInstance(out.value, Artifact)
 
-    def test_result_collection_list_of_ints(self):
+    def test_artifact_collection_list_of_ints(self):
         use = usage.ExecutionUsage()
         action = self.plugin.actions['list_of_ints']
         action.examples['collection_list_of_ints'](use)

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -888,9 +888,9 @@ class Usage:
         ...          'Bar': qiime2.Artifact.import_data('IntSequence1', [4, 5, 6])})
         ...     return a
         ...
-        >>> my_collection = use.init_result_collection('my_collection', factory)
-        >>> my_collection
-        <ExecutionUsageVariable name='my_collection', var_type='result_collection'>
+        >>> int_collection = use.init_result_collection('int_collection', factory)
+        >>> int_collection
+        <ExecutionUsageVariable name='int_collection', var_type='result_collection'>
         """  # noqa: E501
         return self._usage_variable(name, factory, 'result_collection')
 

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -645,6 +645,7 @@ class UsageVariable:
         ----------
         path : str
             The relative path in a result's /data/ directory to check.
+
         expression : str
             The regular expression to evaluate for a line within `path`.
 
@@ -661,7 +662,26 @@ class UsageVariable:
         ...     use.UsageOutputNames(out='bar4')
         ... )
         >>> bar.assert_has_line_matching('mapping.tsv', r'foo\\s42')
-        """
+        ...
+        >>> # A factory which will be used in the example to generate data.
+        >>> def factory():
+        ...     import qiime2
+        ...     # This type is only available during testing.
+        ...     # A real example would use a real type.
+        ...     a = qiime2.ResultCollection(
+        ...         {'Foo': qiime2.Artifact.import_data('SingleInt', 1),
+        ...          'Bar': qiime2.Artifact.import_data('SingleInt', 2)})
+        ...     return a
+        ...
+        >>> int_collection = use.init_result_collection('int_collection', factory)
+        >>> bar, = use.action(
+        ...     use.UsageAction(plugin_id='dummy_plugin',
+        ...                     action_id='dict_of_ints'),
+        ...     use.UsageInputs(ints=int_collection),
+        ...     use.UsageOutputNames(output='bar6')
+        ... )
+        >>> bar.assert_has_line_matching('bar6/Foo.qza', r'1')
+        """  # noqa: E501
         pass
 
     def assert_output_type(self, semantic_type: str, key: str = None):
@@ -1605,7 +1625,8 @@ class DiagnosticUsage(Usage):
 class ExecutionUsageVariable(UsageVariable):
     """A specialized implementation for :class:`ExecutionUsage`."""
     def assert_has_line_matching(self, path, expression):
-        assert_usage_var_type(self, 'artifact', 'visualization')
+        assert_usage_var_type(self, 'artifact', 'visualization',
+                              'result_collection')
 
         data = self.value
 

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -1640,8 +1640,8 @@ class ExecutionUsageVariable(UsageVariable):
 
     # Utility method for key handling within result collections
     def _collection_key_util(self, data, key):
-        if (self.var_type !=
-                'artifact_collection' or 'visualization_collection'):
+        if self.var_type != ('artifact_collection' or
+                             'visualization_collection'):
             raise TypeError("Key can only be provided for output of type"
                             " artifact_collection or visualization_collection."
                             " Output of type %s was provided."

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -42,7 +42,9 @@ import re
 
 import qiime2
 from qiime2 import sdk
-from qiime2.core.type import is_semantic_type, is_visualization_type
+from qiime2.core.type import (is_semantic_type,
+                              is_visualization_type,
+                              is_collection_type)
 
 
 def assert_usage_var_type(usage_variable, *valid_types):
@@ -1457,8 +1459,8 @@ class Usage:
             qiime_type = action_f.signature.outputs[param_name].qiime_type
             if is_visualization_type(qiime_type):
                 var_type = 'visualization'
-            # elif is_collection_type(qiime_type):
-                # var_type = 'result_collection'
+            elif is_collection_type(qiime_type):
+                var_type = 'result_collection'
             elif is_semantic_type(qiime_type):
                 var_type = 'artifact'
             else:

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -451,8 +451,7 @@ class UsageOutputs(sdk.Results):
 
 VAR_TYPES = ('artifact', 'result_collection', 'visualization',
              'metadata', 'column', 'format')
-T_VAR_TYPES = Literal['artifact', 'visualization', 'metadata', 'column',
-                      'format']
+T_VAR_TYPES = Literal['artifact', 'visualization', 'metadata', 'column', 'format']
 
 
 class UsageVariable:
@@ -1651,6 +1650,9 @@ class ExecutionUsageVariable(UsageVariable):
 
         data = self.value
 
+        if key is not None:
+            key = str(key)
+
         if key:
             data = self._collection_key_util(data=data, key=key)
 
@@ -1668,6 +1670,9 @@ class ExecutionUsageVariable(UsageVariable):
     def assert_output_type(self, semantic_type, key=None):
         data = self.value
         name = self.name
+
+        if key is not None:
+            key = str(key)
 
         if key:
             data = self._collection_key_util(data=data, key=key)

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -1640,8 +1640,8 @@ class ExecutionUsageVariable(UsageVariable):
 
     # Utility method for key handling within result collections
     def _collection_key_util(self, data, key):
-        if self.var_type != ('artifact_collection' or
-                             'visualization_collection'):
+        collection_types = ('artifact_collection', 'visualization_collection')
+        if self.var_type not in collection_types:
             raise TypeError("Key can only be provided for output of type"
                             " artifact_collection or visualization_collection."
                             " Output of type %s was provided."

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -455,6 +455,7 @@ VAR_TYPES = ('artifact', 'artifact_collection', 'visualization',
 T_VAR_TYPES = Literal['artifact', 'artifact_collection', 'visualization',
                       'visualization_collection',
                       'metadata', 'column', 'format']
+COLLECTION_VAR_TYPES = ('artifact_collection', 'visualization_collection')
 
 
 class UsageVariable:
@@ -466,6 +467,7 @@ class UsageVariable:
     """
     DEFERRED = object()
     VAR_TYPES = VAR_TYPES
+    COLLECTION_VAR_TYPES = COLLECTION_VAR_TYPES
 
     def __init__(self, name: str, factory: Callable[[], Any],
                  var_type: T_VAR_TYPES, usage: 'Usage'):
@@ -1513,7 +1515,7 @@ class Usage:
             if is_visualization_type(qiime_type):
                 var_type = 'visualization'
             elif is_collection_type(qiime_type):
-                if 'Visualization' in str(qiime_type):
+                if str(qiime_type) == 'Collection[Visualization]':
                     var_type = 'visualization_collection'
                 else:
                     var_type = 'artifact_collection'
@@ -1640,8 +1642,7 @@ class ExecutionUsageVariable(UsageVariable):
 
     # Utility method for key handling within result collections
     def _collection_key_util(self, data, key):
-        collection_types = ('artifact_collection', 'visualization_collection')
-        if self.var_type not in collection_types:
+        if self.var_type not in self.COLLECTION_VAR_TYPES:
             raise TypeError("Key can only be provided for output of type"
                             " artifact_collection or visualization_collection."
                             " Output of type %s was provided."

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -52,7 +52,8 @@ def assert_usage_var_type(usage_variable, *valid_types):
     ----------
     usage_variable : `qiime2.sdk.usage.UsageVariable`
         The usage variable to test.
-    *valid_types : 'artifact', 'visualization', 'metadata', 'column', 'format'
+    *valid_types : 'artifact', 'result_collection', 'visualization',
+                   'metadata', 'column', 'format'
         The valid variable types to expect.
 
     Raises
@@ -445,7 +446,8 @@ class UsageOutputs(sdk.Results):
     pass
 
 
-VAR_TYPES = ('artifact', 'visualization', 'metadata', 'column', 'format')
+VAR_TYPES = ('artifact', 'result_collection', 'visualization',
+             'metadata', 'column', 'format')
 T_VAR_TYPES = Literal['artifact', 'visualization', 'metadata', 'column',
                       'format']
 
@@ -476,7 +478,8 @@ class UsageVariable:
             point).
         factory : Callable[[], Any]
             A function which will return a realized value of `var_type`.
-        var_type : 'artifact', 'visualization', 'metadata', 'column', 'format'
+        var_type : 'artifact', 'result_collection', 'visualization',
+                   'metadata', 'column', 'format'
             The type of value which will be returned by the factory.
             Most are self-explanatory, but "format" indicates that the factory
             produces a QIIME 2 file format or directory format, which is used
@@ -510,7 +513,8 @@ class UsageVariable:
         For use by interface drivers only (and rarely at that).
         Do not use in a written usage example.
         """
-        self.var_type: Literal['artifact', 'visualization', 'metadata',
+        self.var_type: Literal['artifact', 'result_collection',
+                               'visualization', 'metadata',
                                'column', 'format'] = var_type
         """The general type of this variable.
 
@@ -629,6 +633,7 @@ class UsageVariable:
         """
         return self.name
 
+    # going to add another assertion for
     def assert_has_line_matching(self, path: str, expression: str):
         """Communicate that the result of this variable should match a regex.
 
@@ -846,6 +851,47 @@ class Usage:
         <ExecutionUsageVariable name='my_artifact', var_type='artifact'>
         """
         return self._usage_variable(name, factory, 'artifact')
+
+    def init_result_collection(
+        self, name: str,
+            factory: Callable[[], qiime2.ResultCollection]) -> UsageVariable:
+        """Communicate that a result collection will be needed.
+
+        Driver implementations may use this to intialize data for an example.
+
+        Parameters
+        ----------
+        name : str
+            The canonical name of the variable to be returned.
+        factory : Callable which returns :class:`qiime2.sdk.ResultCollection`
+            A function which takes no parameters, and returns
+            a result collection.
+            This function may do anything internally to create
+            the result collection.
+
+        Returns
+        -------
+        UsageVariable
+            This particular return class can be changed by a driver which
+            overrides :meth:`usage_variable`.
+
+        Examples
+        --------
+        >>> # A factory which will be used in the example to generate data.
+        >>> def factory():
+        ...     import qiime2
+        ...     # This type is only available during testing.
+        ...     # A real example would use a real type.
+        ...     a = qiime2.ResultCollection(
+                    {'Foo': qiime2.Artifact.import_data('IntSequence1', [1, 2, 3]),  #noqa: E501
+                     'Bar': qiime2.Artifact.import_data('IntSequence1', [4, 5, 6])}) #noqa: E501
+        ...     return a
+        ...
+        >>> my_collection = use.init_result_collection('my_collection', factory)    #noqa: E501
+        >>> my_collection
+        <ExecutionUsageVariable name='my_collection', var_type='result_collection'> #noqa: E501
+        """
+        return self._usage_variable(name, factory, 'result_collection')
 
     def init_metadata(self, name: str,
                       factory: Callable[[], qiime2.Metadata]) -> UsageVariable:
@@ -1410,6 +1456,8 @@ class Usage:
             qiime_type = action_f.signature.outputs[param_name].qiime_type
             if is_visualization_type(qiime_type):
                 var_type = 'visualization'
+            # elif is_collection_type(qiime_type):
+                # var_type = 'result_collection'
             elif is_semantic_type(qiime_type):
                 var_type = 'artifact'
             else:
@@ -1607,6 +1655,12 @@ class ExecutionUsage(Usage):
         self._recorder[variable.name] = variable
 
         return variable
+
+    def init_result(self, name, factory):
+        variable = super().init_result_collection(name, factory)
+
+        variable.execute()
+        self._recorder[variable.name] = variable
 
     def init_metadata(self, name, factory):
         variable = super().init_metadata(name, factory)

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -705,9 +705,9 @@ class UsageVariable:
         >>> int_collection = use.init_result_collection('int_collection', factory)
         >>> bar, = use.action(
         ...     use.UsageAction(plugin_id='dummy_plugin',
-        ...                     action_id='list_of_ints'),
+        ...                     action_id='dict_of_ints'),
         ...     use.UsageInputs(ints=int_collection),
-        ...     use.UsageOutputs(output='bar6')
+        ...     use.UsageOutputNames(output='bar6')
         ... )
         >>> bar.assert_output_type(semantic_type='SingleInt', key='Foo')
         ...
@@ -913,9 +913,9 @@ class Usage:
         ...          'Bar': qiime2.Artifact.import_data('IntSequence1', [4, 5, 6])})
         ...     return a
         ...
-        >>> int_collection = use.init_result_collection('int_collection', factory)
-        >>> int_collection
-        <ExecutionUsageVariable name='int_collection', var_type='result_collection'>
+        >>> int_seq_collection = use.init_result_collection('int_seq_collection', factory)
+        >>> int_seq_collection
+        <ExecutionUsageVariable name='int_seq_collection', var_type='result_collection'>
         """  # noqa: E501
         return self._usage_variable(name, factory, 'result_collection')
 
@@ -1629,7 +1629,7 @@ class ExecutionUsageVariable(UsageVariable):
                 raise TypeError("Key can only be provided for output of type"
                                 " result_collection. Output of type %s was"
                                 " provided." % (self.var_type))
-            if key not in data:
+            if key not in data.keys():
                 raise ValueError("Provided key %s not found in output" % (key))
 
             data = data[key]

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -884,18 +884,14 @@ class Usage:
         ...     # This type is only available during testing.
         ...     # A real example would use a real type.
         ...     a = qiime2.ResultCollection(
-                    {'Foo': qiime2.Artifact.import_data('IntSequence1',
-                                                        [1, 2, 3]),
-                     'Bar': qiime2.Artifact.import_data('IntSequence1',
-                                                        [4, 5, 6])})
+        ...         {'Foo': qiime2.Artifact.import_data('IntSequence1', [1, 2, 3]),
+        ...          'Bar': qiime2.Artifact.import_data('IntSequence1', [4, 5, 6])})
         ...     return a
         ...
-        >>> my_collection = use.init_result_collection('my_collection',
-                                                       factory)
+        >>> my_collection = use.init_result_collection('my_collection', factory)
         >>> my_collection
-        <ExecutionUsageVariable name='my_collection',
-                                var_type='result_collection'>
-        """
+        <ExecutionUsageVariable name='my_collection', var_type='result_collection'>
+        """  # noqa: E501
         return self._usage_variable(name, factory, 'result_collection')
 
     def init_metadata(self, name: str,

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -313,7 +313,8 @@ class UsageInputs:
 
         def mapped(v):
             if isinstance(v, UsageVariable):
-                assert_usage_var_type(v, 'artifact', 'metadata', 'column')
+                assert_usage_var_type(v, 'artifact', 'result_collection',
+                                      'metadata', 'column')
                 v = function(v)
             return v
 
@@ -883,13 +884,17 @@ class Usage:
         ...     # This type is only available during testing.
         ...     # A real example would use a real type.
         ...     a = qiime2.ResultCollection(
-                    {'Foo': qiime2.Artifact.import_data('IntSequence1', [1, 2, 3]),  #noqa: E501
-                     'Bar': qiime2.Artifact.import_data('IntSequence1', [4, 5, 6])}) #noqa: E501
+                    {'Foo': qiime2.Artifact.import_data('IntSequence1',
+                                                        [1, 2, 3]),
+                     'Bar': qiime2.Artifact.import_data('IntSequence1',
+                                                        [4, 5, 6])})
         ...     return a
         ...
-        >>> my_collection = use.init_result_collection('my_collection', factory)    #noqa: E501
+        >>> my_collection = use.init_result_collection('my_collection',
+                                                       factory)
         >>> my_collection
-        <ExecutionUsageVariable name='my_collection', var_type='result_collection'> #noqa: E501
+        <ExecutionUsageVariable name='my_collection',
+                                var_type='result_collection'>
         """
         return self._usage_variable(name, factory, 'result_collection')
 
@@ -1522,6 +1527,11 @@ class DiagnosticUsage(Usage):
     def init_artifact(self, name, factory):
         variable = super().init_artifact(name, factory)
         self._append_record('init_artifact', variable)
+        return variable
+
+    def init_result_collection(self, name, factory):
+        variable = super().init_result_collection(name, factory)
+        self._append_record('init_result_collection', variable)
         return variable
 
     def init_metadata(self, name, factory):

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -451,7 +451,8 @@ class UsageOutputs(sdk.Results):
 
 VAR_TYPES = ('artifact', 'result_collection', 'visualization',
              'metadata', 'column', 'format')
-T_VAR_TYPES = Literal['artifact', 'visualization', 'metadata', 'column', 'format']
+T_VAR_TYPES = Literal['artifact', 'result_collection', 'visualization',
+                      'metadata', 'column', 'format']
 
 
 class UsageVariable:

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -1664,7 +1664,7 @@ class ExecutionUsage(Usage):
 
         return variable
 
-    def init_result(self, name, factory):
+    def init_result_collection(self, name, factory):
         variable = super().init_result_collection(name, factory)
 
         variable.execute()

--- a/qiime2/sdk/usage.py
+++ b/qiime2/sdk/usage.py
@@ -665,7 +665,8 @@ class UsageVariable:
         """
         pass
 
-    def assert_output_type(self, semantic_type: str):
+    # TODO: add key param to assert details about result collection contents
+    def assert_output_type(self, semantic_type: str, key: str):
         """Communicate that this variable should have a given semantic type.
 
         The default implementation is to do nothing.
@@ -675,10 +676,14 @@ class UsageVariable:
         semantic_type : QIIME 2 Semantic Type or str
             The semantic type to match.
 
+        key : str
+            TODO: does stuff. more on this soon.
+
         Note
         ----
         Should not be called on non-artifact variables.
 
+        # TODO: include key param in existing example, or add new example
         Examples
         --------
         >>> bar, = use.action(

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -277,15 +277,15 @@ output4, = dummy_plugin_actions.optional_artifacts_method(
 
         self.assertEqual(exp, use.render())
 
-    def test_result_collection_dict_of_ints(self):
+    def test_artifact_collection_dict_of_ints(self):
         action = self.plugin.actions['dict_of_ints']
         use = ArtifactAPIUsage()
         action.examples['collection_dict_of_ints'](use)
         exp = """\
 import qiime2.plugins.dummy_plugin.actions as dummy_plugin_actions
 
-out_collection, = dummy_plugin_actions.dict_of_ints(
-    ints=ints_collection,
+out_artifact_collection, = dummy_plugin_actions.dict_of_ints(
+    ints=ints_artifact_collection,
 )"""
 
         self.assertEqual(exp, use.render())

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -277,6 +277,19 @@ output4, = dummy_plugin_actions.optional_artifacts_method(
 
         self.assertEqual(exp, use.render())
 
+    def test_result_collection_dict_of_ints(self):
+        action = self.plugin.actions['dict_of_ints']
+        use = ArtifactAPIUsage()
+        action.examples['collection_dict_of_ints'](use)
+        exp = """\
+import qiime2.plugins.dummy_plugin.actions as dummy_plugin_actions
+
+out_collection, = dummy_plugin_actions.dict_of_ints(
+    ints=ints_collection,
+)"""
+
+        self.assertEqual(exp, use.render())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds ResultCollections to Usage API with the following steps (notes for myself while developing):

1. Change base Usage class to accept Collections
2. Implement in ExecutionUsage class
3. Use dummy plugin to test that this works

Co-Authored by: @Oddant1 
