### PR TITLE
Socket leaks

### DIFF
--- a/qiime2/core/testing/tests/test_mapped_actions.py
+++ b/qiime2/core/testing/tests/test_mapped_actions.py
@@ -23,14 +23,6 @@ class ActionTester(unittest.TestCase):
         self.action = plugin.actions[self.ACTION]
 
     def run_action(self, **inputs):
-        results = self.run_non_pipeline(**inputs)
-
-        if isinstance(self.action, Pipeline):
-            self.run_pipeline(results, **inputs)
-
-        return results
-
-    def run_non_pipeline(self, **inputs):
         results = self.action(**inputs)
         async_results = self.action.asynchronous(**inputs).result()
 
@@ -38,12 +30,6 @@ class ActionTester(unittest.TestCase):
             self.assertEqual(a.type, b.type)
 
         return results
-
-    def run_pipeline(self, results, **inputs):
-        parsl_results = self.action.parallel(**inputs)._result()
-
-        for a, b in zip(results, parsl_results):
-            self.assertEqual(a.type, b.type)
 
 
 class TestConstrainedInputVisualization(ActionTester):

--- a/qiime2/core/testing/tests/test_mapped_actions.py
+++ b/qiime2/core/testing/tests/test_mapped_actions.py
@@ -9,7 +9,6 @@
 import unittest
 
 from qiime2 import Artifact
-from qiime2.sdk.action import Pipeline
 from qiime2.core.testing.util import get_dummy_plugin
 
 from ..type import IntSequence1, IntSequence2

--- a/qiime2/core/tests/test_pipeline_resumption.py
+++ b/qiime2/core/tests/test_pipeline_resumption.py
@@ -17,6 +17,7 @@ from qiime2.core.cache import Cache
 from qiime2.core.testing.type import IntSequence1, SingleInt
 from qiime2.core.testing.util import get_dummy_plugin, PipelineError
 from qiime2.sdk.result import Artifact
+from qiime2.sdk.parallel_config import ParallelConfig
 from qiime2.core.util import load_action_yaml
 
 
@@ -158,18 +159,20 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                future = self.pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
-                    fail=True)
-                future._result()
+                with ParallelConfig():
+                    future = self.pipeline.parallel(
+                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        fail=True)
+                    future._result()
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
-            future = self.pipeline.parallel(
-                self.ints1, self.ints2, self.int1, 'Hi', self.md1)
-            ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
-                identity_ret, viz_ret = future._result()
+            with ParallelConfig():
+                future = self.pipeline.parallel(
+                    self.ints1, self.ints2, self.int1, 'Hi', self.md1)
+                ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                    identity_ret, viz_ret = future._result()
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -227,19 +230,21 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_artifact_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                future = self.pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
-                    fail=True)
-                future._result()
+                with ParallelConfig():
+                    future = self.pipeline.parallel(
+                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        fail=True)
+                    future._result()
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass int2 instead of int1
-            future = self.pipeline.parallel(
-                self.ints1, self.ints2, self.int2, 'Hi', self.md1)
-            ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, identity_ret, \
-                viz_ret = future._result()
+            with ParallelConfig():
+                future = self.pipeline.parallel(
+                    self.ints1, self.ints2, self.int2, 'Hi', self.md1)
+                ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                    identity_ret, viz_ret = future._result()
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -297,19 +302,21 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_collection_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                future = self.pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
-                    fail=True)
-                future._result()
+                with ParallelConfig():
+                    future = self.pipeline.parallel(
+                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        fail=True)
+                    future._result()
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass ints1_2 instead of ints1
-            future = self.pipeline.parallel(
-                self.ints1_2, self.ints2, self.int2, 'Hi', self.md1)
-            ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, identity_ret, \
-                viz_ret = future._result()
+            with ParallelConfig():
+                future = self.pipeline.parallel(
+                    self.ints1_2, self.ints2, self.int2, 'Hi', self.md1)
+                ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                    identity_ret, viz_ret = future._result()
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -367,19 +374,21 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_str_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                future = self.pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
-                    fail=True)
-                future._result()
+                with ParallelConfig():
+                    future = self.pipeline.parallel(
+                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        fail=True)
+                    future._result()
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass in Bye instead of Hi
-            future = self.pipeline.parallel(
-                self.ints1, self.ints2, self.int1, 'Bye', self.md1)
-            ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
-                identity_ret, viz_ret = future._result()
+            with ParallelConfig():
+                future = self.pipeline.parallel(
+                    self.ints1, self.ints2, self.int1, 'Bye', self.md1)
+                ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                    identity_ret, viz_ret = future._result()
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -437,19 +446,21 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_md_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                future = self.pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
-                    fail=True)
-                future._result()
+                with ParallelConfig():
+                    future = self.pipeline.parallel(
+                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        fail=True)
+                    future._result()
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass in md2 instead of md1
-            future = self.pipeline.parallel(
-                self.ints1, self.ints2, self.int1, 'Hi', self.md2)
-            ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
-                identity_ret, viz_ret = future._result()
+            with ParallelConfig():
+                future = self.pipeline.parallel(
+                    self.ints1, self.ints2, self.int1, 'Hi', self.md2)
+                ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                    identity_ret, viz_ret = future._result()
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -510,18 +521,20 @@ class TestPipelineResumption(unittest.TestCase):
     def test_nested_resumable_pipeline_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                future = self.nested_pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
-                    fail=True)
-                future._result()
+                with ParallelConfig():
+                    future = self.nested_pipeline.parallel(
+                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        fail=True)
+                    future._result()
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
-            future = self.nested_pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1)
-            ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
-                identity_ret, viz_ret = future._result()
+            with ParallelConfig():
+                future = self.nested_pipeline.parallel(
+                        self.ints1, self.ints2, self.int1, 'Hi', self.md1)
+                ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                    identity_ret, viz_ret = future._result()
 
             complete_ints1_uuids = _load_nested_alias_uuids(
                 ints1_ret, self.cache)

--- a/qiime2/core/tests/test_pipeline_resumption.py
+++ b/qiime2/core/tests/test_pipeline_resumption.py
@@ -159,7 +159,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig(__test__=True):
+                with ParallelConfig():
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -168,7 +168,7 @@ class TestPipelineResumption(unittest.TestCase):
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
-            with ParallelConfig(__test__=True):
+            with ParallelConfig():
                 future = self.pipeline.parallel(
                     self.ints1, self.ints2, self.int1, 'Hi', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -230,7 +230,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_artifact_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig(__test__=True):
+                with ParallelConfig():
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -240,7 +240,7 @@ class TestPipelineResumption(unittest.TestCase):
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass int2 instead of int1
-            with ParallelConfig(__test__=True):
+            with ParallelConfig():
                 future = self.pipeline.parallel(
                     self.ints1, self.ints2, self.int2, 'Hi', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -302,7 +302,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_collection_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig(__test__=True):
+                with ParallelConfig():
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -312,7 +312,7 @@ class TestPipelineResumption(unittest.TestCase):
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass ints1_2 instead of ints1
-            with ParallelConfig(__test__=True):
+            with ParallelConfig():
                 future = self.pipeline.parallel(
                     self.ints1_2, self.ints2, self.int2, 'Hi', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -374,7 +374,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_str_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig(__test__=True):
+                with ParallelConfig():
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -384,7 +384,7 @@ class TestPipelineResumption(unittest.TestCase):
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass in Bye instead of Hi
-            with ParallelConfig(__test__=True):
+            with ParallelConfig():
                 future = self.pipeline.parallel(
                     self.ints1, self.ints2, self.int1, 'Bye', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -446,7 +446,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_md_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig(__test__=True):
+                with ParallelConfig():
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -456,7 +456,7 @@ class TestPipelineResumption(unittest.TestCase):
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass in md2 instead of md1
-            with ParallelConfig(__test__=True):
+            with ParallelConfig():
                 future = self.pipeline.parallel(
                     self.ints1, self.ints2, self.int1, 'Hi', self.md2)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -521,7 +521,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_nested_resumable_pipeline_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig(__test__=True):
+                with ParallelConfig():
                     future = self.nested_pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -530,7 +530,7 @@ class TestPipelineResumption(unittest.TestCase):
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
-            with ParallelConfig(__test__=True):
+            with ParallelConfig():
                 future = self.nested_pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \

--- a/qiime2/core/tests/test_pipeline_resumption.py
+++ b/qiime2/core/tests/test_pipeline_resumption.py
@@ -159,7 +159,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig():
+                with ParallelConfig(__test__=True):
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -168,7 +168,7 @@ class TestPipelineResumption(unittest.TestCase):
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
-            with ParallelConfig():
+            with ParallelConfig(__test__=True):
                 future = self.pipeline.parallel(
                     self.ints1, self.ints2, self.int1, 'Hi', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -230,7 +230,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_artifact_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig():
+                with ParallelConfig(__test__=True):
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -240,7 +240,7 @@ class TestPipelineResumption(unittest.TestCase):
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass int2 instead of int1
-            with ParallelConfig():
+            with ParallelConfig(__test__=True):
                 future = self.pipeline.parallel(
                     self.ints1, self.ints2, self.int2, 'Hi', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -302,7 +302,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_collection_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig():
+                with ParallelConfig(__test__=True):
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -312,7 +312,7 @@ class TestPipelineResumption(unittest.TestCase):
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass ints1_2 instead of ints1
-            with ParallelConfig():
+            with ParallelConfig(__test__=True):
                 future = self.pipeline.parallel(
                     self.ints1_2, self.ints2, self.int2, 'Hi', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -374,7 +374,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_str_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig():
+                with ParallelConfig(__test__=True):
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -384,7 +384,7 @@ class TestPipelineResumption(unittest.TestCase):
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass in Bye instead of Hi
-            with ParallelConfig():
+            with ParallelConfig(__test__=True):
                 future = self.pipeline.parallel(
                     self.ints1, self.ints2, self.int1, 'Bye', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -446,7 +446,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_resumable_pipeline_md_varies_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig():
+                with ParallelConfig(__test__=True):
                     future = self.pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -456,7 +456,7 @@ class TestPipelineResumption(unittest.TestCase):
                 identity_uuid, viz_uuid = e.exception.uuids
 
             # Pass in md2 instead of md1
-            with ParallelConfig():
+            with ParallelConfig(__test__=True):
                 future = self.pipeline.parallel(
                     self.ints1, self.ints2, self.int1, 'Hi', self.md2)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
@@ -521,7 +521,7 @@ class TestPipelineResumption(unittest.TestCase):
     def test_nested_resumable_pipeline_parsl(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
-                with ParallelConfig():
+                with ParallelConfig(__test__=True):
                     future = self.nested_pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1,
                         fail=True)
@@ -530,7 +530,7 @@ class TestPipelineResumption(unittest.TestCase):
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
                 identity_uuid, viz_uuid = e.exception.uuids
 
-            with ParallelConfig():
+            with ParallelConfig(__test__=True):
                 future = self.nested_pipeline.parallel(
                         self.ints1, self.ints2, self.int1, 'Hi', self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \

--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -21,7 +21,6 @@ import qiime2.core.type as qtype
 import qiime2.core.archive as archive
 from qiime2.core.util import (LateBindingAttribute, DropFirstParameter,
                               tuplize, create_collection_name)
-from qiime2.sdk.parallel_config import setup_parallel
 from qiime2.sdk.proxy import Proxy
 
 
@@ -408,7 +407,6 @@ class Action(metaclass=abc.ABCMeta):
             if not isinstance(self, Pipeline):
                 raise ValueError('Only pipelines may be run in parallel')
 
-            setup_parallel()
             return self._bind_parsl(qiime2.sdk.Context(parallel=True), *args,
                                     **kwargs)
 

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -58,7 +58,7 @@ def setup_parallel(config_fp=None):
     path or looks through several default paths if no path is provided and
     loads a vendored config as a last resort
     """
-    config = PARALLEL_CONFIG.parallel_config
+    parallel_config = PARALLEL_CONFIG.parallel_config
     mapping = PARALLEL_CONFIG.action_executor_mapping
 
     # If we don't have a filepath or a currently existing config then get the
@@ -69,22 +69,14 @@ def setup_parallel(config_fp=None):
         config_fp = _get_vendored_config()
 
     if config_fp is not None:
-        config_dict = get_config(config_fp)
-        mapping = get_mapping(config_dict)
+        parallel_config, mapping = get_config(config_fp)
 
         # If config_dict is empty now, they gave a file that only contained a
         # mapping, so we want to load a default config assuming they do not
         # already have a loaded config
-        if config_dict == {} and PARALLEL_CONFIG.parallel_config is None:
+        if parallel_config is None and PARALLEL_CONFIG.parallel_config is None:
             config_fp = _get_vendored_config()
-            config_dict = get_config(config_fp)
-
-        # Now if we actually have a config dict, we want to load the config. We
-        # still will not have one if they gave us a file that only contained a
-        # mapping while already having a config set up.
-        if config_dict != {}:
-            processed_config = _process_config(config_dict)
-            config = Config(**processed_config)
+            parallel_config, = get_config(config_fp)
 
     # We only want to clear the config if the config we are trying to load is
     # actually different. If we clear the config then load the same config
@@ -92,23 +84,29 @@ def setup_parallel(config_fp=None):
     # someone is trying to change the config in the middle of doing something,
     # they are doing things wrong (probably forgot to resolve their future
     # inside of their context manager).
-    if PARALLEL_CONFIG.parallel_config != config:
+    if PARALLEL_CONFIG.parallel_config != parallel_config:
         # If a dfk is already loaded, clean it up, if one doesn't exist we get
-        # a runtime error which we except
+        # a runtime error which we except.
         try:
             dfk = parsl.dfk()
             dfk.cleanup()
-        except RuntimeError:
-            pass
+        except RuntimeError as e:
+            if 'Must first load config' in str(e):
+                pass
+            else:
+                raise e
 
         parsl.clear()
 
     try:
-        parsl.load(config)
-    except RuntimeError:
-        pass
+        parsl.load(parallel_config)
+    except RuntimeError as e:
+        if 'Config has already been loaded' in str(e):
+            pass
+        else:
+            raise e
 
-    PARALLEL_CONFIG.parallel_config = config
+    PARALLEL_CONFIG.parallel_config = parallel_config
     if mapping != {}:
         PARALLEL_CONFIG.action_executor_mapping = mapping
 
@@ -120,13 +118,19 @@ def get_config(fp):
     with open(fp, 'r') as fh:
         config_dict = tomlkit.load(fh)
 
-    return config_dict.get('parsl')
+    parallel_config_dict = config_dict.get('parsl')
+    mapping = parallel_config_dict.pop('executor_mapping', {})
 
+    processed_parallel_config_dict = _process_config(parallel_config_dict)
 
-def get_mapping(config_dict):
-    """Takes a config dict and pops off the action_executor_mapping
-    """
-    return config_dict.pop('executor_mapping', {})
+    # They could have given us a file that contained a mapping but no config.
+    # This is technically valid.
+    if processed_parallel_config_dict != {}:
+        parallel_config = parsl.Config(**processed_parallel_config_dict)
+    else:
+        parallel_config = None
+
+    return parallel_config, mapping
 
 
 def _get_vendored_config():

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -68,8 +68,9 @@ def setup_parallel(config_fp=None):
     # they are doing things wrong (probably forgot to resolve their future
     # inside of their context manager).
     if PARALLEL_CONFIG.parallel_config != parallel_config:
-        # If a dfk is already loaded, clean it up, if one doesn't exist we get
-        # a runtime error which we except.
+        # If a config was already loaded, clean up the DFK and clear it for a
+        # new one. If there wasn't already a config loaded, we get an error
+        # which we except and ignore
         try:
             dfk = parsl.dfk()
             dfk.cleanup()
@@ -81,6 +82,10 @@ def setup_parallel(config_fp=None):
 
         parsl.clear()
 
+    # If a config is already loaded at this point, we will get an error which
+    # we except and ignore. This will happen if this function was called and no
+    # new config was provided (if there was a new config, the old one would
+    # have been cleard above).
     try:
         parsl.load(parallel_config)
     except RuntimeError as e:

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -93,6 +93,12 @@ def setup_parallel(config_fp=None):
     # they are doing things wrong (probably forgot to resolve their future
     # inside of their context manager).
     if PARALLEL_CONFIG.parallel_config != config:
+        try:
+            dfk = parsl.dfk()
+            dfk.cleanup()
+        except RuntimeError:
+            pass
+
         parsl.clear()
 
     try:

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -19,6 +19,26 @@ PARALLEL_CONFIG = threading.local()
 PARALLEL_CONFIG.parallel_config = None
 PARALLEL_CONFIG.action_executor_mapping = {}
 
+# We write a default config to a location in the conda env if there is an
+# active conda env. If there is not an active conda env (most likely because we
+# are using Docker) then the path we want to write the default to will not
+# exist, so we will not write a default, we will just load it from memory
+CONDA_PREFIX = os.environ.get('CONDA_PREFIX', '')
+VENDORED_FP = os.path.join(CONDA_PREFIX, 'etc', 'qiime2_config.toml')
+
+VENDORED_CONFIG = {
+    'parsl': {
+        'strategy': 'None',
+        'executors': [
+            {'class': 'ThreadPoolExecutor', 'label': 'default',
+                'max_threads': max(psutil.cpu_count() - 1, 1)},
+            {'class': 'HighThroughputExecutor', 'label': 'htex',
+                'max_workers': max(psutil.cpu_count() - 1, 1),
+                'provider': {'class': 'LocalProvider'}}
+            ]
+        }
+    }
+
 # Directs keys in the config whose values need to be objects to the module that
 # contains the class they need to instantiate
 module_paths = {
@@ -54,12 +74,19 @@ def setup_parallel(config_fp=None):
     if config_fp is not None:
         parallel_config, mapping = get_config(config_fp)
 
-        # If config_dict is empty now, they gave a file that only contained a
+        # If we don't have a config now, they gave a file that only contained a
         # mapping, so we want to load a default config assuming they do not
         # already have a loaded config
         if parallel_config is None and PARALLEL_CONFIG.parallel_config is None:
             config_fp = _get_vendored_config()
             parallel_config, _ = get_config(config_fp)
+    # If we do not have a config_fp or loaded config here, then they did not
+    # give us an fp and _get_vendored config returned None, so as a last resort
+    # we load the VENDORED_CONFIG directly
+    elif config_fp is None and PARALLEL_CONFIG.parallel_config is None:
+        parallel_config_dict = VENDORED_CONFIG.get('parsl')
+        processed_parallel_config_dict = _process_config(parallel_config_dict)
+        parallel_config = parsl.Config(**processed_parallel_config_dict)
 
     # We only want to clear the config if the config we are trying to load is
     # actually different. If we clear the config then load the same config
@@ -111,27 +138,6 @@ def get_config(fp):
 
 
 def _get_vendored_config():
-    conda_prefix = os.environ.get('CONDA_PREFIX')
-
-    if conda_prefix is None:
-        VENDORED_FP = None
-    else:
-        VENDORED_FP = os.path.join(
-            os.environ.get('CONDA_PREFIX'), 'etc', 'qiime2_config.toml')
-
-    VENDORED_CONFIG = {
-        'parsl': {
-            'strategy': 'None',
-            'executors': [
-                {'class': 'ThreadPoolExecutor', 'label': 'default',
-                 'max_threads': max(psutil.cpu_count() - 1, 1)},
-                {'class': 'HighThroughputExecutor', 'label': 'htex',
-                 'max_workers': max(psutil.cpu_count() - 1, 1),
-                 'provider': {'class': 'LocalProvider'}}
-                ]
-            }
-        }
-
     # 1. Check envvar
     config_fp = os.environ.get('QIIME2_CONFIG')
 
@@ -148,13 +154,14 @@ def _get_vendored_config():
         elif os.path.exists(fp_ := os.path.join(
                 appdirs.site_config_dir('qiime2'), 'qiime2_config.toml')):
             config_fp = fp_
+        # NOTE: These next two are dependent on us being in a conda environment
         # 4. Check in conda env
         # ~/miniconda3/env/{env_name}/conf
-        elif VENDORED_FP is not None and os.path.exists(fp_ := VENDORED_FP):
+        elif CONDA_PREFIX != '' and os.path.exists(fp_ := VENDORED_FP):
             config_fp = fp_
         # 5. Write the vendored config to the vendored location and use
         # that
-        elif VENDORED_FP is not None:
+        elif CONDA_PREFIX != '':
             with open(VENDORED_FP, 'w') as fh:
                 tomlkit.dump(VENDORED_CONFIG, fh)
             config_fp = VENDORED_FP
@@ -234,3 +241,21 @@ class ParallelConfig():
         """
         PARALLEL_CONFIG.parallel_config = self.backup_config
         PARALLEL_CONFIG.action_executor_mapping = self.backup_map
+
+
+# Used to test config loading behavior when outside of a conda environment
+class _MaskCondaEnv():
+    def __enter__(self):
+        global CONDA_PREFIX, VENDORED_FP
+
+        self.old_prefix = CONDA_PREFIX
+        self.old_fp = VENDORED_FP
+
+        CONDA_PREFIX = ''
+        VENDORED_FP = None
+
+    def __exit__(self, *args):
+        global CONDA_PREFIX, VENDORED_FP
+
+        CONDA_PREFIX = self.old_prefix
+        VENDORED_FP = self.old_fp

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -93,6 +93,8 @@ def setup_parallel(config_fp=None):
     # they are doing things wrong (probably forgot to resolve their future
     # inside of their context manager).
     if PARALLEL_CONFIG.parallel_config != config:
+        # If a dfk is already loaded, clean it up, if one doesn't exist we get
+        # a runtime error which we except
         try:
             dfk = parsl.dfk()
             dfk.cleanup()

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -59,7 +59,7 @@ def setup_parallel(config_fp=None):
         # already have a loaded config
         if parallel_config is None and PARALLEL_CONFIG.parallel_config is None:
             config_fp = _get_vendored_config()
-            parallel_config, = get_config(config_fp)
+            parallel_config, _ = get_config(config_fp)
 
     # We only want to clear the config if the config we are trying to load is
     # actually different. If we clear the config then load the same config

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -129,7 +129,6 @@ def get_config_from_file(config_fp):
 
 
 def get_config_from_dict(config_dict):
-    # raise ValueError(config_dict)
     parallel_config_dict = config_dict.get('parsl')
     mapping = parallel_config_dict.pop('executor_mapping', {})
 

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -277,8 +277,17 @@ class ParallelConfig():
         PARALLEL_CONFIG.action_executor_mapping = {}
 
 
+def _check_env(cls):
+    if 'QIIMETEST' not in os.environ:
+        raise ValueError(
+            f"Do not instantiate the class '{cls}' when not testing")
+
+
 # Used to test config loading behavior when outside of a conda environment
-class _MaskCondaEnv():
+class _MASK_CONDA_ENV_():
+    def __init__(self):
+        _check_env(self.__class__)
+
     def __enter__(self):
         global CONDA_PREFIX, VENDORED_FP
 
@@ -299,11 +308,9 @@ class _TEST_EXECUTOR_(parsl.executors.threads.ThreadPoolExecutor):
     """We needed multiple kinds of executor to ensure we were mapping things
     correctly, but the HighThroughputExecutor was leaking sockets, so we avoid
     creating those during the tests because so many sockets were being opened
-    that we were getting 'Too many open files' errors, so this gets used as the
+    that we were getting "Too many open files" errors, so this gets used as the
     second executor type."""
 
     def __init__(self, *args, **kwargs):
-        if os.environ.get('QIIMETEST') is None:
-            raise ValueError('Do not instantiate this class when not testing')
-
+        _check_env(self.__class__)
         super(_TEST_EXECUTOR_, self).__init__(*args, **kwargs)

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -46,11 +46,13 @@ VENDORED_CONFIG = {
 # HighThroughputExecutor was created to mitigate that scenario. This config is
 # only to be used in tests that do not specifically need to test multiple
 # different executors
-__TEST_CONFIG__ = {
+_TEST_CONFIG_ = {
     'parsl': {
         'strategy': 'None',
         'executors': [
             {'class': 'ThreadPoolExecutor', 'label': 'default',
+                'max_threads': 1},
+            {'class': '_TEST_EXECUTOR_', 'label': 'test',
                 'max_threads': 1}
             ]
         }
@@ -73,7 +75,7 @@ module_paths = {
 }
 
 
-def _setup_parallel(config_fp=None, __test__=False):
+def _setup_parallel(config_fp=None, ):
     """Sets the parsl config and action executor mapping from a file at a given
     path or looks through several default paths if no path is provided and
     loads a vendored config as a last resort
@@ -81,8 +83,8 @@ def _setup_parallel(config_fp=None, __test__=False):
     parallel_config = PARALLEL_CONFIG.parallel_config
     mapping = PARALLEL_CONFIG.action_executor_mapping
 
-    if __test__:
-        parallel_config, mapping = get_config_from_dict(__TEST_CONFIG__)
+    if os.environ.get('QIIMETEST') is not None and parallel_config is None:
+        parallel_config, mapping = get_config_from_dict(_TEST_CONFIG_)
         _finalize_setup(parallel_config, mapping)
         return
 
@@ -213,8 +215,14 @@ def _process_key(key, value):
     if key in module_paths:
         # Get the module our class is from
         module = importlib.import_module(module_paths[key])
-        # Get the class we need to instantiate
-        cls = getattr(module, value['class'])
+
+        _type = value['class']
+        if _type == '_TEST_EXECUTOR_':
+            # Only used for tests
+            cls = _TEST_EXECUTOR_
+        else:
+            # Get the class we need to instantiate
+            cls = getattr(module, value['class'])
 
         # Get the kwargs we need to pass to the class constructor
         kwargs = {}
@@ -231,8 +239,7 @@ def _process_key(key, value):
 
 
 class ParallelConfig():
-    def __init__(self, parallel_config=None, action_executor_mapping={},
-                 __test__=False):
+    def __init__(self, parallel_config=None, action_executor_mapping={}):
         """Tell QIIME 2 how to parsl from the Python API
 
         action_executor_mapping: maps actions to executors. All unmapped
@@ -244,13 +251,9 @@ class ParallelConfig():
         parallel_config: Specifies which executors should be created and how
         they should be created. If this is None, it will use the default
         config.
-
-        __test__: Set to true when writing a unit test that is fine with only a
-        ThreadPool executor.
         """
         self.parallel_config = parallel_config
         self.action_executor_mapping = action_executor_mapping
-        self.__test__ = __test__
 
     def __enter__(self):
         """Set this to be our Parsl config on the current thread local
@@ -262,7 +265,7 @@ class ParallelConfig():
         PARALLEL_CONFIG.parallel_config = self.parallel_config
         PARALLEL_CONFIG.action_executor_mapping = self.action_executor_mapping
 
-        _setup_parallel(__test__=self.__test__)
+        _setup_parallel()
 
     def __exit__(self, *args):
         """Set our Parsl config back to whatever it was before this one
@@ -290,3 +293,17 @@ class _MaskCondaEnv():
 
         CONDA_PREFIX = self.old_prefix
         VENDORED_FP = self.old_fp
+
+
+class _TEST_EXECUTOR_(parsl.executors.threads.ThreadPoolExecutor):
+    """We needed multiple kinds of executor to ensure we were mapping things
+    correctly, but the HighThroughputExecutor was leaking sockets, so we avoid
+    creating those during the tests because so many sockets were being opened
+    that we were getting 'Too many open files' errors, so this gets used as the
+    second executor type."""
+
+    def __init__(self, *args, **kwargs):
+        if os.environ.get('QIIMETEST') is None:
+            raise ValueError('Do not instantiate this class when not testing')
+
+        super(_TEST_EXECUTOR_, self).__init__(*args, **kwargs)

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -7,15 +7,13 @@
 # ----------------------------------------------------------------------------
 
 import os
-import parsl
 import psutil
 import appdirs
-import tomlkit
 import threading
 import importlib
 
-from parsl.config import Config
-
+import parsl
+import tomlkit
 
 PARALLEL_CONFIG = threading.local()
 PARALLEL_CONFIG.parallel_config = None
@@ -132,10 +130,10 @@ def _get_vendored_config():
             'strategy': 'None',
             'executors': [
                 {'class': 'ThreadPoolExecutor', 'label': 'default',
-                'max_threads': max(psutil.cpu_count() - 1, 1)},
+                 'max_threads': max(psutil.cpu_count() - 1, 1)},
                 {'class': 'HighThroughputExecutor', 'label': 'htex',
-                'max_workers': max(psutil.cpu_count() - 1, 1),
-                'provider': {'class': 'LocalProvider'}}
+                 'max_workers': max(psutil.cpu_count() - 1, 1),
+                 'provider': {'class': 'LocalProvider'}}
                 ]
             }
         }

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -81,18 +81,7 @@ def setup_parallel(config_fp=None):
                 raise e
 
         parsl.clear()
-
-    # If a config is already loaded at this point, we will get an error which
-    # we except and ignore. This will happen if this function was called and no
-    # new config was provided (if there was a new config, the old one would
-    # have been cleard above).
-    try:
         parsl.load(parallel_config)
-    except RuntimeError as e:
-        if 'Config has already been loaded' in str(e):
-            pass
-        else:
-            raise e
 
     PARALLEL_CONFIG.parallel_config = parallel_config
     if mapping != {}:

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -112,9 +112,15 @@ def _setup_parallel(config_fp=None):
 
 
 def _cleanup_parallel():
+    executors = PARALLEL_CONFIG.dfk.config.executors
+    for executor in executors:
+        if isinstance(executor, parsl.executors.HighThroughputExecutor):
+            job_ids = executor.provider.resources.keys()
+            executor.scale_in(len(job_ids))
+            # executor.scale_in(0)
+        executor.shutdown()
+
     PARALLEL_CONFIG.dfk.cleanup()
-    import time
-    time.sleep(500)
     parsl.clear()
 
 

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -114,6 +114,8 @@ def _setup_parallel(config_fp=None):
 
 
 def _cleanup_parallel():
+    """Ask parsl to cleanup and then remove the currently active dfk
+    """
     PARALLEL_CONFIG.dfk.cleanup()
     parsl.clear()
 
@@ -143,6 +145,8 @@ def get_config_from_dict(config_dict):
 
 
 def _finalize_setup(parallel_config, mapping):
+    """Finish loading the config and setting up our threadlocal
+    """
     PARALLEL_CONFIG.dfk = parsl.load(parallel_config)
 
     PARALLEL_CONFIG.parallel_config = parallel_config
@@ -282,8 +286,9 @@ def _check_env(cls):
             f"Do not instantiate the class '{cls}' when not testing")
 
 
-# Used to test config loading behavior when outside of a conda environment
 class _MASK_CONDA_ENV_():
+    """Used to test config loading behavior when outside of a conda environment
+    """
     def __init__(self):
         _check_env(self.__class__)
 

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -40,6 +40,22 @@ VENDORED_CONFIG = {
         }
     }
 
+# As near as I can tell, loading a config with a HighThroughputExecutor leaks
+# open sockets. This leads to issues (especially on osx) with "too many open
+# files" errors while running the test, so this test config with no
+# HighThroughputExecutor was created to mitigate that scenario. This config is
+# only to be used in tests that do not specifically need to test multiple
+# different executors
+__TEST_CONFIG__ = {
+    'parsl': {
+        'strategy': 'None',
+        'executors': [
+            {'class': 'ThreadPoolExecutor', 'label': 'default',
+                'max_threads': 1}
+            ]
+        }
+    }
+
 # Directs keys in the config whose values need to be objects to the module that
 # contains the class they need to instantiate
 module_paths = {
@@ -57,13 +73,18 @@ module_paths = {
 }
 
 
-def _setup_parallel(config_fp=None):
+def _setup_parallel(config_fp=None, __test__=False):
     """Sets the parsl config and action executor mapping from a file at a given
     path or looks through several default paths if no path is provided and
     loads a vendored config as a last resort
     """
     parallel_config = PARALLEL_CONFIG.parallel_config
     mapping = PARALLEL_CONFIG.action_executor_mapping
+
+    if __test__:
+        parallel_config, mapping = get_config_from_dict(__TEST_CONFIG__)
+        _finalize_setup(parallel_config, mapping)
+        return
 
     # If we don't have a filepath or a currently existing config then get the
     # path to the vendored one. We do not want to get the vendored path if they
@@ -73,77 +94,59 @@ def _setup_parallel(config_fp=None):
         config_fp = _get_vendored_config()
 
     if config_fp is not None:
-        parallel_config, mapping = get_config(config_fp)
+        parallel_config, mapping = get_config_from_file(config_fp)
 
         # If we don't have a config now, they gave a file that only contained a
         # mapping, so we want to load a default config assuming they do not
         # already have a loaded config
         if parallel_config is None and PARALLEL_CONFIG.parallel_config is None:
             config_fp = _get_vendored_config()
-            parallel_config, _ = get_config(config_fp)
+            parallel_config, _ = get_config_from_file(config_fp)
     # If we do not have a config_fp or loaded config here, then they did not
     # give us an fp and _get_vendored config returned None, so as a last resort
     # we load the VENDORED_CONFIG directly
     elif config_fp is None and PARALLEL_CONFIG.parallel_config is None:
-        parallel_config_dict = VENDORED_CONFIG.get('parsl')
-        processed_parallel_config_dict = _process_config(parallel_config_dict)
-        parallel_config = parsl.Config(**processed_parallel_config_dict)
+        parallel_config, mapping = get_config_from_dict(VENDORED_CONFIG)
 
-    # We only want to clear the config if the config we are trying to load is
-    # actually different. If we clear the config then load the same config
-    # while in the middle of doing something, we're going to have problems. If
-    # someone is trying to change the config in the middle of doing something,
-    # they are doing things wrong (probably forgot to resolve their future
-    # # inside of their context manager).
-    # if PARALLEL_CONFIG.parallel_config != parallel_config:
-    #     _cleanup_parsl()
-
-    # try:
-    PARALLEL_CONFIG.dfk = parsl.load(parallel_config)
-    # except RuntimeError as e:
-    #     if 'Config has already been loaded' in str(e):
-    #         pass
-    #     else:
-    #         raise e
-
-    PARALLEL_CONFIG.parallel_config = parallel_config
-    if mapping != {}:
-        PARALLEL_CONFIG.action_executor_mapping = mapping
+    _finalize_setup(parallel_config, mapping)
 
 
 def _cleanup_parallel():
-    executors = PARALLEL_CONFIG.dfk.config.executors
-    for executor in executors:
-        if isinstance(executor, parsl.executors.HighThroughputExecutor):
-            job_ids = executor.provider.resources.keys()
-            executor.scale_in(len(job_ids))
-            # executor.scale_in(0)
-        executor.shutdown()
-
     PARALLEL_CONFIG.dfk.cleanup()
     parsl.clear()
 
 
-def get_config(fp):
+def get_config_from_file(config_fp):
     """Takes a config filepath and determines if the file exists and if so if
     it contains parsl config info.
     """
-    with open(fp, 'r') as fh:
+    with open(config_fp, 'r') as fh:
         config_dict = tomlkit.load(fh)
 
+    return get_config_from_dict(config_dict)
+
+
+def get_config_from_dict(config_dict):
+    # raise ValueError(config_dict)
     parallel_config_dict = config_dict.get('parsl')
     mapping = parallel_config_dict.pop('executor_mapping', {})
 
     processed_parallel_config_dict = _process_config(parallel_config_dict)
 
-    # They could have given us a file that contained a mapping but no config.
-    # This is technically valid.
     if processed_parallel_config_dict != {}:
         parallel_config = parsl.Config(**processed_parallel_config_dict)
     else:
         parallel_config = None
 
     return parallel_config, mapping
+
+
+def _finalize_setup(parallel_config, mapping):
+    PARALLEL_CONFIG.dfk = parsl.load(parallel_config)
+
+    PARALLEL_CONFIG.parallel_config = parallel_config
+    if mapping != {}:
+        PARALLEL_CONFIG.action_executor_mapping = mapping
 
 
 def _get_vendored_config():
@@ -208,11 +211,19 @@ def _process_key(key, value):
     """
     # Our key needs to point to some object.
     if key in module_paths:
+        # Get the module our class is from
         module = importlib.import_module(module_paths[key])
-        cls = getattr(module, value.pop('class'))
+        # Get the class we need to instantiate
+        cls = getattr(module, value['class'])
+
+        # Get the kwargs we need to pass to the class constructor
         kwargs = {}
         for k, v in value.items():
-            kwargs[k] = _process_key(k, v)
+            # We already handled this key
+            if k != 'class':
+                kwargs[k] = _process_key(k, v)
+
+        # Instantiate the class
         return cls(**kwargs)
     # Our key points to primitive data
     else:
@@ -220,7 +231,8 @@ def _process_key(key, value):
 
 
 class ParallelConfig():
-    def __init__(self, parallel_config=None, action_executor_mapping={}):
+    def __init__(self, parallel_config=None, action_executor_mapping={},
+                 __test__=False):
         """Tell QIIME 2 how to parsl from the Python API
 
         action_executor_mapping: maps actions to executors. All unmapped
@@ -232,9 +244,13 @@ class ParallelConfig():
         parallel_config: Specifies which executors should be created and how
         they should be created. If this is None, it will use the default
         config.
+
+        __test__: Set to true when writing a unit test that is fine with only a
+        ThreadPool executor.
         """
         self.parallel_config = parallel_config
         self.action_executor_mapping = action_executor_mapping
+        self.__test__ = __test__
 
     def __enter__(self):
         """Set this to be our Parsl config on the current thread local
@@ -246,7 +262,7 @@ class ParallelConfig():
         PARALLEL_CONFIG.parallel_config = self.parallel_config
         PARALLEL_CONFIG.action_executor_mapping = self.action_executor_mapping
 
-        _setup_parallel()
+        _setup_parallel(__test__=self.__test__)
 
     def __exit__(self, *args):
         """Set our Parsl config back to whatever it was before this one

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -75,7 +75,7 @@ module_paths = {
 }
 
 
-def _setup_parallel(config_fp=None, ):
+def _setup_parallel(config_fp=None):
     """Sets the parsl config and action executor mapping from a file at a given
     path or looks through several default paths if no path is provided and
     loads a vendored config as a last resort

--- a/qiime2/sdk/tests/data/default_config.toml
+++ b/qiime2/sdk/tests/data/default_config.toml
@@ -4,12 +4,12 @@ strategy = "None"
 [[parsl.executors]]
 class = "ThreadPoolExecutor"
 label = "default"
-max_workers = 1
+max_threads = 1
 
 [[parsl.executors]]
-class = "HighThroughputExecutor"
-label = "htex"
-max_workers = 1
+class = "_TEST_EXECUTOR_"
+label = "test"
+max_threads = 1
 
-[parsl.executors.provider]
-class = "LocalProvider"
+[parsl.executor_mapping]
+list_of_ints = "test"

--- a/qiime2/sdk/tests/data/default_config.toml
+++ b/qiime2/sdk/tests/data/default_config.toml
@@ -4,12 +4,12 @@ strategy = "None"
 [[parsl.executors]]
 class = "ThreadPoolExecutor"
 label = "default"
-max_threads = 6
+max_workers = 1
 
 [[parsl.executors]]
 class = "HighThroughputExecutor"
 label = "htex"
-max_workers = 6
+max_workers = 1
 
 [parsl.executors.provider]
 class = "LocalProvider"

--- a/qiime2/sdk/tests/data/mapping_config.toml
+++ b/qiime2/sdk/tests/data/mapping_config.toml
@@ -7,12 +7,9 @@ label = "default"
 max_threads = 1
 
 [[parsl.executors]]
-class = "HighThroughputExecutor"
-label = "htex"
-max_workers = 1
-
-[parsl.executors.provider]
-class = "LocalProvider"
+class = "_TEST_EXECUTOR_"
+label = "test"
+max_threads = 1
 
 [parsl.executor_mapping]
-list_of_ints = "htex"
+list_of_ints = "test"

--- a/qiime2/sdk/tests/data/mapping_config.toml
+++ b/qiime2/sdk/tests/data/mapping_config.toml
@@ -4,12 +4,12 @@ strategy = "None"
 [[parsl.executors]]
 class = "ThreadPoolExecutor"
 label = "default"
-max_threads = 6
+max_threads = 1
 
 [[parsl.executors]]
 class = "HighThroughputExecutor"
 label = "htex"
-max_workers = 6
+max_workers = 1
 
 [parsl.executors.provider]
 class = "LocalProvider"

--- a/qiime2/sdk/tests/data/mapping_only_config.toml
+++ b/qiime2/sdk/tests/data/mapping_only_config.toml
@@ -1,4 +1,4 @@
 [parsl]
 
 [parsl.executor_mapping]
-list_of_ints = "htex"
+list_of_ints = "test"

--- a/qiime2/sdk/tests/data/mapping_only_config.toml
+++ b/qiime2/sdk/tests/data/mapping_only_config.toml
@@ -1,0 +1,4 @@
+[parsl]
+
+[parsl.executor_mapping]
+list_of_ints = "htex"

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -18,7 +18,7 @@ from qiime2 import Artifact, Cache
 from qiime2.core.util import load_action_yaml
 from qiime2.core.testing.type import SingleInt
 from qiime2.core.testing.util import get_dummy_plugin
-from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, _MaskCondaEnv,
+from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, _MASK_CONDA_ENV_,
                                         ParallelConfig, _TEST_EXECUTOR_,
                                         get_config_from_file)
 
@@ -179,7 +179,7 @@ class TestConfig(unittest.TestCase):
             self.method.parallel(self.art)
 
     def test_no_vendored_fp(self):
-        with _MaskCondaEnv():
+        with _MASK_CONDA_ENV_():
             with ParallelConfig():
                 with self.cache:
                     future = self.pipeline.parallel(self.art, self.art)

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -21,7 +21,7 @@ from qiime2.core.util import load_action_yaml
 from qiime2.core.testing.type import SingleInt
 from qiime2.core.testing.util import get_dummy_plugin
 from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, _MaskCondaEnv,
-                                        ParallelConfig, get_config)
+                                        ParallelConfig, get_config_from_file)
 
 
 class TestConfig(unittest.TestCase):
@@ -103,7 +103,7 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(PARALLEL_CONFIG.action_executor_mapping, {})
 
     def test_mapping_from_config(self):
-        config, mapping = get_config(self.mapping_config_fp)
+        config, mapping = get_config_from_file(self.mapping_config_fp)
 
         with self.cache:
             with ParallelConfig(config, mapping):
@@ -120,7 +120,7 @@ class TestConfig(unittest.TestCase):
 
     def test_mapping_only_config(self):
         # This file only contains a mapping, we should get the default config
-        _, mapping = get_config(self.mapping_only_config_fp)
+        _, mapping = get_config_from_file(self.mapping_only_config_fp)
 
         with self.cache:
             with ParallelConfig(action_executor_mapping=mapping):
@@ -153,7 +153,7 @@ class TestConfig(unittest.TestCase):
 
     def test_parallel_configs(self):
         with self.cache:
-            with ParallelConfig(self.tpool_default):
+            with ParallelConfig(__test__=True):
                 future = self.pipeline.parallel(self.art, self.art)
                 list_return, dict_return = future._result()
 
@@ -189,8 +189,8 @@ class TestConfig(unittest.TestCase):
         with self.cache:
             with self.assertRaisesRegex(
                     ValueError, 'cannot nest ParallelConfigs'):
-                with ParallelConfig(self.tpool_default):
-                    with ParallelConfig(self.htex_default):
+                with ParallelConfig(__test__=True):
+                    with ParallelConfig(__test__=True):
                         pass
 
     def test_parallel_non_pipeline(self):
@@ -200,7 +200,7 @@ class TestConfig(unittest.TestCase):
 
     def test_no_vendored_fp(self):
         with _MaskCondaEnv():
-            with ParallelConfig():
+            with ParallelConfig(__test__=True):
                 with self.cache:
                     future = self.pipeline.parallel(self.art, self.art)
                     list_return, dict_return = future._result()

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -113,7 +113,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(PARALLEL_CONFIG.action_executor_mapping, {})
 
     def test_mapping_from_config(self):
-        config, mapping= get_config(self.config_fp)
+        config, mapping = get_config(self.config_fp)
 
         with self.cache:
             with ParallelConfig(config, mapping):
@@ -129,7 +129,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(dict_execution_contexts, self.tpool_expected)
 
     def test_mapping_only_config(self):
-        _, mapping= get_config(self.config_fp)
+        _, mapping = get_config(self.config_fp)
 
         with self.cache:
             with ParallelConfig(action_executor_mapping=mapping):

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -25,80 +25,85 @@ from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, ParallelConfig,
 
 
 class TestConfig(unittest.TestCase):
+    # Get actions
+    plugin = get_dummy_plugin()
+    pipeline = plugin.pipelines['resumable_pipeline']
+    method = plugin.methods['list_of_ints']
+
+    # Create configs
+    config = parsl.Config(
+        executors=[
+            ThreadPoolExecutor(
+                max_threads=1,
+                label='default'
+            ),
+            HighThroughputExecutor(
+                label='htex',
+                max_workers=1,
+                provider=LocalProvider()
+            )
+        ],
+        # AdHoc Clusters should not be setup with scaling strategy.
+        strategy='none',
+    )
+
+    tpool_default = parsl.Config(
+        executors=[
+            ThreadPoolExecutor(
+                max_threads=1,
+                label='default'
+            ),
+            HighThroughputExecutor(
+                label='htex',
+                max_workers=1,
+                provider=LocalProvider()
+            )
+        ],
+        # AdHoc Clusters should not be setup with scaling strategy.
+        strategy='none',
+    )
+
+    htex_default = parsl.Config(
+        executors=[
+            ThreadPoolExecutor(
+                max_threads=1,
+                label='tpool'
+            ),
+            HighThroughputExecutor(
+                label='default',
+                max_workers=1,
+                provider=LocalProvider()
+            )
+        ],
+        # AdHoc Clusters should not be setup with scaling strategy.
+        strategy='none',
+    )
+
+    # Expected provenance based on type of executor used
+    tpool_expected = [{
+        'type': 'parsl', 'parsl_type': 'ThreadPoolExecutor'}, {
+        'type': 'parsl', 'parsl_type': 'ThreadPoolExecutor'}]
+    htex_expected = [{
+        'type': 'parsl', 'parsl_type': 'HighThroughputExecutor'}, {
+        'type': 'parsl', 'parsl_type': 'HighThroughputExecutor'}]
+
     def setUp(self):
         # Ensure default state prior to test
         PARALLEL_CONFIG.parallel_config = None
         PARALLEL_CONFIG.action_executor_mapping = {}
 
-        plugin = get_dummy_plugin()
-        self.pipeline = plugin.pipelines['resumable_pipeline']
-        self.method = plugin.methods['list_of_ints']
-
-        # Create temp test dir
+        # Create temp test dir and cache in dir
         self.test_dir = tempfile.TemporaryDirectory(prefix='qiime2-test-temp-')
+        self.cache = Cache(os.path.join(self.test_dir.name, 'new_cache'))
+
+        # Create artifacts here so we have unique inputs in each test
+        self.art = [Artifact.import_data(SingleInt, 0),
+                    Artifact.import_data(SingleInt, 1)]
+
+        # Get paths to config files
         self.mapping_config_fp = self.get_data_path('mapping_config.toml')
         self.mapping_only_config_fp = self.get_data_path(
             'mapping_only_config.toml')
-
-        # Create artifact and cache
-        self.art = [Artifact.import_data(SingleInt, 0),
-                    Artifact.import_data(SingleInt, 1)]
-        self.cache = Cache(os.path.join(self.test_dir.name, 'new_cache'))
-
-        self.config = parsl.Config(
-            executors=[
-                ThreadPoolExecutor(
-                    max_threads=1,
-                    label='default'
-                ),
-                HighThroughputExecutor(
-                    label='htex',
-                    max_workers=1,
-                    provider=LocalProvider()
-                )
-            ],
-            # AdHoc Clusters should not be setup with scaling strategy.
-            strategy='none',
-        )
-
-        self.tpool_default = parsl.Config(
-            executors=[
-                ThreadPoolExecutor(
-                    max_threads=1,
-                    label='default'
-                ),
-                HighThroughputExecutor(
-                    label='htex',
-                    max_workers=1,
-                    provider=LocalProvider()
-                )
-            ],
-            # AdHoc Clusters should not be setup with scaling strategy.
-            strategy='none',
-        )
-
-        self.htex_default = parsl.Config(
-            executors=[
-                ThreadPoolExecutor(
-                    max_threads=1,
-                    label='tpool'
-                ),
-                HighThroughputExecutor(
-                    label='default',
-                    max_workers=1,
-                    provider=LocalProvider()
-                )
-            ],
-            # AdHoc Clusters should not be setup with scaling strategy.
-            strategy='none',
-        )
-
-        self.tpool_expected = [{
-            'type': 'parsl', 'parsl_type': 'ThreadPoolExecutor'}, {
-            'type': 'parsl', 'parsl_type': 'ThreadPoolExecutor'}]
-        self.htex_expected = [{
-            'type': 'parsl', 'parsl_type': 'HighThroughputExecutor'}, {
-            'type': 'parsl', 'parsl_type': 'HighThroughputExecutor'}]
 
     def tearDown(self):
         self.test_dir.cleanup()


### PR DESCRIPTION
Fixed an issue with not closing opened sockets.

Made it so if QIIME 2 is being run outside of a conda env (usually a Docker thing) we don't try to get a conda_prefix and use that in a filepath.

NOTE: Breaking API changes

Removed `get_mapping` function. `get_config_from_fp` now returns a tuple of a parsl.Config object and a mapping dict.

Now NEED to with in a ParallelConfig before executing in parallel
