### PR TITLE
Result collection fixes

### DIFF
--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -561,8 +561,8 @@ class ResultCollection:
         elif isinstance(other, ResultCollection):
             return self.collection == other.collection
         else:
-            raise TypeError(f'Equality between {type(other)} and '
-                            'ResultCollection is undefined.')
+            raise TypeError(f"Equality between '{type(other)}' and "
+                            "ResultCollection is undefined.")
 
     def __len__(self):
         return len(self.collection)

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -548,9 +548,12 @@ class ResultCollection:
         if collection is None:
             self.collection = {}
         elif isinstance(collection, dict):
+            if any(not isinstance(key, str) for key in collection.keys()):
+                raise TypeError('All ResultCollection keys must be strings')
+
             self.collection = collection
         else:
-            self.collection = {k: v for k, v in enumerate(collection)}
+            self.collection = {str(k): v for k, v in enumerate(collection)}
 
     def __contains__(self, item):
         return item in self.collection
@@ -601,7 +604,6 @@ class ResultCollection:
 
         with open(os.path.join(directory, '.order'), 'w') as fh:
             for name, result in self.collection.items():
-                name = str(name)
                 result_fp = os.path.join(directory, name)
                 result.save(result_fp)
                 fh.write(f'{name}\n')

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -548,7 +548,7 @@ class ResultCollection:
         if collection is None:
             self.collection = {}
         elif isinstance(collection, dict):
-            if any(not isinstance(key, str) for key in collection.keys()):
+            if not all(isinstance(key, str) for key in collection.keys()):
                 raise TypeError('All ResultCollection keys must be strings')
 
             self.collection = collection

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -558,8 +558,11 @@ class ResultCollection:
     def __eq__(self, other):
         if isinstance(other, dict):
             return self.collection == other
-
-        return self.collection == other.collection
+        elif isinstance(other, ResultCollection):
+            return self.collection == other.collection
+        else:
+            raise TypeError(f'Equality between {type(other)} and '
+                            'ResultCollection is undefined.')
 
     def __len__(self):
         return len(self.collection)

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -601,6 +601,7 @@ class ResultCollection:
 
         with open(os.path.join(directory, '.order'), 'w') as fh:
             for name, result in self.collection.items():
+                name = str(name)
                 result_fp = os.path.join(directory, name)
                 result.save(result_fp)
                 fh.write(f'{name}\n')

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -552,6 +552,9 @@ class ResultCollection:
         else:
             self.collection = {k: v for k, v in enumerate(collection)}
 
+    def __contains__(self, item):
+        return item in self.collection
+
     def __eq__(self, other):
         if isinstance(other, dict):
             return self.collection == other

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -582,6 +582,11 @@ class TestResultCollection(unittest.TestCase):
                             "order file but does not exist"):
             ResultCollection.load(self.output_fp)
 
+    def test_collection_non_str_keys(self):
+        with self.assertRaisesRegex(
+                TypeError, 'All ResultCollection keys must be strings'):
+            ResultCollection({1: 0})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add dunder contains to ResultCollection

Raise error if equality tested between a ResultCollection and anything but another ResultCollection or a dict

Ensure keys are strings in constructor

(various ResultCollection improvements/fixes)
