### PR TITLE
No conda

### DIFF
--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -82,7 +82,6 @@ def setup_parallel(config_fp=None):
         # already have a loaded config
         if config_dict == {} and PARALLEL_CONFIG.parallel_config is None:
             config_fp = _get_vendored_config()
-<<<<<<< HEAD
             config_dict = get_config(config_fp)
 
         # Now if we actually have a config dict, we want to load the config. We
@@ -91,16 +90,6 @@ def setup_parallel(config_fp=None):
         if config_dict != {}:
             processed_config = _process_config(config_dict)
             config = Config(**processed_config)
-=======
-            parallel_config, _ = get_config(config_fp)
-    # If we do not have a config_fp or loaded config here, then they did not
-    # give us an fp and _get_vendored config returned None, so as a last resort
-    # we load the VENDORED_CONFIG directly
-    elif config_fp is None and PARALLEL_CONFIG.parallel_config is None:
-        parallel_config_dict = VENDORED_CONFIG.get('parsl')
-        processed_parallel_config_dict = _process_config(parallel_config_dict)
-        parallel_config = parsl.Config(**processed_parallel_config_dict)
->>>>>>> df43986... Refactor behavior with no conda env and test
 
     # We only want to clear the config if the config we are trying to load is
     # actually different. If we clear the config then load the same config
@@ -138,30 +127,6 @@ def get_mapping(config_dict):
 
 
 def _get_vendored_config():
-<<<<<<< HEAD
-    conda_prefix = os.environ.get('CONDA_PREFIX')
-
-    if conda_prefix is None:
-        VENDORED_FP = None
-    else:
-        VENDORED_FP = os.path.join(
-            os.environ.get('CONDA_PREFIX'), 'etc', 'qiime2_config.toml')
-
-    VENDORED_CONFIG = {
-        'parsl': {
-            'strategy': 'None',
-            'executors': [
-                {'class': 'ThreadPoolExecutor', 'label': 'default',
-                'max_threads': max(psutil.cpu_count() - 1, 1)},
-                {'class': 'HighThroughputExecutor', 'label': 'htex',
-                'max_workers': max(psutil.cpu_count() - 1, 1),
-                'provider': {'class': 'LocalProvider'}}
-                ]
-            }
-        }
-
-=======
->>>>>>> df43986... Refactor behavior with no conda env and test
     # 1. Check envvar
     config_fp = os.environ.get('QIIME2_CONFIG')
 

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -236,8 +236,17 @@ class ParallelConfig():
         PARALLEL_CONFIG.action_executor_mapping = self.backup_map
 
 
+def _check_env(cls):
+    if 'QIIMETEST' not in os.environ:
+        raise ValueError(
+            f"Do not instantiate the class '{cls}' when not testing")
+
+
 # Used to test config loading behavior when outside of a conda environment
 class _MASK_CONDA_ENV_():
+    def __init__(self):
+        _check_env(self.__class__)
+
     def __enter__(self):
         global CONDA_PREFIX, VENDORED_FP
 

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -237,7 +237,7 @@ class ParallelConfig():
 
 
 # Used to test config loading behavior when outside of a conda environment
-class _MASK_CONDA_ENV_):
+class _MASK_CONDA_ENV_():
     def __enter__(self):
         global CONDA_PREFIX, VENDORED_FP
 

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -88,7 +88,7 @@ def setup_parallel(config_fp=None):
             processed_config = _process_config(config_dict)
             config = parsl.Config(**processed_config)
     # If we do not have a config_fp or loaded config here, then they did not
-    # give us an fp and _get_vendored config returned None, so as a last resort
+    # give us an fp and _get_vendored_config returned None, so as a last resort
     # we load the VENDORED_CONFIG directly.
     elif config_fp is None and PARALLEL_CONFIG.parallel_config is None:
         config_dict = VENDORED_CONFIG.get('parsl')

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -237,7 +237,7 @@ class ParallelConfig():
 
 
 # Used to test config loading behavior when outside of a conda environment
-class _MaskCondaEnv():
+class _MASK_CONDA_ENV_):
     def __enter__(self):
         global CONDA_PREFIX, VENDORED_FP
 

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -14,9 +14,6 @@ import tomlkit
 import threading
 import importlib
 
-from parsl.config import Config
-
-
 PARALLEL_CONFIG = threading.local()
 PARALLEL_CONFIG.parallel_config = None
 PARALLEL_CONFIG.action_executor_mapping = {}
@@ -89,7 +86,14 @@ def setup_parallel(config_fp=None):
         # mapping while already having a config set up.
         if config_dict != {}:
             processed_config = _process_config(config_dict)
-            config = Config(**processed_config)
+            config = parsl.Config(**processed_config)
+    # If we do not have a config_fp or loaded config here, then they did not
+    # give us an fp and _get_vendored config returned None, so as a last resort
+    # we load the VENDORED_CONFIG directly.
+    elif config_fp is None and PARALLEL_CONFIG.parallel_config is None:
+        config_dict = VENDORED_CONFIG.get('parsl')
+        processed_config = _process_config(config_dict)
+        config = parsl.Config(**processed_config)
 
     # We only want to clear the config if the config we are trying to load is
     # actually different. If we clear the config then load the same config

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -37,21 +37,6 @@ module_paths = {
     'providers': 'parsl.providers'
 }
 
-VENDORED_FP = os.path.join(
-    os.environ.get('CONDA_PREFIX'), 'etc', 'qiime2_config.toml')
-VENDORED_CONFIG = {
-    'parsl': {
-        'strategy': 'None',
-        'executors': [
-            {'class': 'ThreadPoolExecutor', 'label': 'default',
-             'max_threads': max(psutil.cpu_count() - 1, 1)},
-            {'class': 'HighThroughputExecutor', 'label': 'htex',
-             'max_workers': max(psutil.cpu_count() - 1, 1),
-             'provider': {'class': 'LocalProvider'}}
-            ]
-        }
-    }
-
 
 def setup_parallel(config_fp=None):
     """Sets the parsl config and action executor mapping from a file at a given
@@ -122,6 +107,27 @@ def get_mapping(config_dict):
 
 
 def _get_vendored_config():
+    conda_prefix = os.environ.get('CONDA_PREFIX')
+
+    if conda_prefix is None:
+        VENDORED_FP = None
+    else:
+        VENDORED_FP = os.path.join(
+            os.environ.get('CONDA_PREFIX'), 'etc', 'qiime2_config.toml')
+
+    VENDORED_CONFIG = {
+        'parsl': {
+            'strategy': 'None',
+            'executors': [
+                {'class': 'ThreadPoolExecutor', 'label': 'default',
+                'max_threads': max(psutil.cpu_count() - 1, 1)},
+                {'class': 'HighThroughputExecutor', 'label': 'htex',
+                'max_workers': max(psutil.cpu_count() - 1, 1),
+                'provider': {'class': 'LocalProvider'}}
+                ]
+            }
+        }
+
     # 1. Check envvar
     config_fp = os.environ.get('QIIME2_CONFIG')
 
@@ -140,11 +146,11 @@ def _get_vendored_config():
             config_fp = fp_
         # 4. Check in conda env
         # ~/miniconda3/env/{env_name}/conf
-        elif os.path.exists(fp_ := VENDORED_FP):
+        elif VENDORED_FP is not None and os.path.exists(fp_ := VENDORED_FP):
             config_fp = fp_
         # 5. Write the vendored config to the vendored location and use
         # that
-        else:
+        elif VENDORED_FP is not None:
             with open(VENDORED_FP, 'w') as fh:
                 tomlkit.dump(VENDORED_CONFIG, fh)
             config_fp = VENDORED_FP

--- a/qiime2/sdk/parallel_config.py
+++ b/qiime2/sdk/parallel_config.py
@@ -21,6 +21,26 @@ PARALLEL_CONFIG = threading.local()
 PARALLEL_CONFIG.parallel_config = None
 PARALLEL_CONFIG.action_executor_mapping = {}
 
+# We write a default config to a location in the conda env if there is an
+# active conda env. If there is not an active conda env (most likely because we
+# are using Docker) then the path we want to write the default to will not
+# exist, so we will not write a default, we will just load it from memory
+CONDA_PREFIX = os.environ.get('CONDA_PREFIX', '')
+VENDORED_FP = os.path.join(CONDA_PREFIX, 'etc', 'qiime2_config.toml')
+
+VENDORED_CONFIG = {
+    'parsl': {
+        'strategy': 'None',
+        'executors': [
+            {'class': 'ThreadPoolExecutor', 'label': 'default',
+                'max_threads': max(psutil.cpu_count() - 1, 1)},
+            {'class': 'HighThroughputExecutor', 'label': 'htex',
+                'max_workers': max(psutil.cpu_count() - 1, 1),
+                'provider': {'class': 'LocalProvider'}}
+            ]
+        }
+    }
+
 # Directs keys in the config whose values need to be objects to the module that
 # contains the class they need to instantiate
 module_paths = {
@@ -57,11 +77,12 @@ def setup_parallel(config_fp=None):
         config_dict = get_config(config_fp)
         mapping = get_mapping(config_dict)
 
-        # If config_dict is empty now, they gave a file that only contained a
+        # If we don't have a config now, they gave a file that only contained a
         # mapping, so we want to load a default config assuming they do not
         # already have a loaded config
         if config_dict == {} and PARALLEL_CONFIG.parallel_config is None:
             config_fp = _get_vendored_config()
+<<<<<<< HEAD
             config_dict = get_config(config_fp)
 
         # Now if we actually have a config dict, we want to load the config. We
@@ -70,6 +91,16 @@ def setup_parallel(config_fp=None):
         if config_dict != {}:
             processed_config = _process_config(config_dict)
             config = Config(**processed_config)
+=======
+            parallel_config, _ = get_config(config_fp)
+    # If we do not have a config_fp or loaded config here, then they did not
+    # give us an fp and _get_vendored config returned None, so as a last resort
+    # we load the VENDORED_CONFIG directly
+    elif config_fp is None and PARALLEL_CONFIG.parallel_config is None:
+        parallel_config_dict = VENDORED_CONFIG.get('parsl')
+        processed_parallel_config_dict = _process_config(parallel_config_dict)
+        parallel_config = parsl.Config(**processed_parallel_config_dict)
+>>>>>>> df43986... Refactor behavior with no conda env and test
 
     # We only want to clear the config if the config we are trying to load is
     # actually different. If we clear the config then load the same config
@@ -107,6 +138,7 @@ def get_mapping(config_dict):
 
 
 def _get_vendored_config():
+<<<<<<< HEAD
     conda_prefix = os.environ.get('CONDA_PREFIX')
 
     if conda_prefix is None:
@@ -128,6 +160,8 @@ def _get_vendored_config():
             }
         }
 
+=======
+>>>>>>> df43986... Refactor behavior with no conda env and test
     # 1. Check envvar
     config_fp = os.environ.get('QIIME2_CONFIG')
 
@@ -144,13 +178,14 @@ def _get_vendored_config():
         elif os.path.exists(fp_ := os.path.join(
                 appdirs.site_config_dir('qiime2'), 'qiime2_config.toml')):
             config_fp = fp_
+        # NOTE: These next two are dependent on us being in a conda environment
         # 4. Check in conda env
         # ~/miniconda3/env/{env_name}/conf
-        elif VENDORED_FP is not None and os.path.exists(fp_ := VENDORED_FP):
+        elif CONDA_PREFIX != '' and os.path.exists(fp_ := VENDORED_FP):
             config_fp = fp_
         # 5. Write the vendored config to the vendored location and use
         # that
-        elif VENDORED_FP is not None:
+        elif CONDA_PREFIX != '':
             with open(VENDORED_FP, 'w') as fh:
                 tomlkit.dump(VENDORED_CONFIG, fh)
             config_fp = VENDORED_FP
@@ -230,3 +265,21 @@ class ParallelConfig():
         """
         PARALLEL_CONFIG.parallel_config = self.backup_config
         PARALLEL_CONFIG.action_executor_mapping = self.backup_map
+
+
+# Used to test config loading behavior when outside of a conda environment
+class _MaskCondaEnv():
+    def __enter__(self):
+        global CONDA_PREFIX, VENDORED_FP
+
+        self.old_prefix = CONDA_PREFIX
+        self.old_fp = VENDORED_FP
+
+        CONDA_PREFIX = ''
+        VENDORED_FP = None
+
+    def __exit__(self, *args):
+        global CONDA_PREFIX, VENDORED_FP
+
+        CONDA_PREFIX = self.old_prefix
+        VENDORED_FP = self.old_fp

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -220,7 +220,7 @@ class TestConfig(unittest.TestCase):
             self.method.parallel(self.art)
 
     def test_no_vendored_fp(self):
-        with _MaskCondaEnv():
+        with _MASK_CONDA_ENV_):
             with self.cache:
                 future = self.pipeline.parallel(self.art, self.art)
                 list_return, dict_return = future._result()

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -21,7 +21,7 @@ from qiime2 import Artifact, Cache
 from qiime2.core.util import load_action_yaml
 from qiime2.core.testing.type import SingleInt
 from qiime2.core.testing.util import get_dummy_plugin
-from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, _MaskCondaEnv,
+from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, _MASK_CONDA_ENV_,
                                         ParallelConfig, setup_parallel)
 
 

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -21,8 +21,14 @@ from qiime2 import Artifact, Cache
 from qiime2.core.util import load_action_yaml
 from qiime2.core.testing.type import SingleInt
 from qiime2.core.testing.util import get_dummy_plugin
+<<<<<<< HEAD
 from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, ParallelConfig,
                                         setup_parallel)
+=======
+from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, _MaskCondaEnv,
+                                        ParallelConfig, setup_parallel,
+                                        get_config)
+>>>>>>> df43986... Refactor behavior with no conda env and test
 
 
 class TestConfig(unittest.TestCase):
@@ -218,6 +224,20 @@ class TestConfig(unittest.TestCase):
         with self.assertRaisesRegex(
                 ValueError, 'Only pipelines may be run in parallel'):
             self.method.parallel(self.art)
+
+    def test_no_vendored_fp(self):
+        with _MaskCondaEnv():
+            with self.cache:
+                future = self.pipeline.parallel(self.art, self.art)
+                list_return, dict_return = future._result()
+
+            list_execution_contexts = self._load_alias_execution_contexts(
+                list_return)
+            dict_execution_contexts = self._load_alias_execution_contexts(
+                dict_return)
+
+            self.assertEqual(list_execution_contexts, self.tpool_expected)
+            self.assertEqual(dict_execution_contexts, self.tpool_expected)
 
     def _load_alias_execution_contexts(self, collection):
         execution_contexts = []

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -21,14 +21,8 @@ from qiime2 import Artifact, Cache
 from qiime2.core.util import load_action_yaml
 from qiime2.core.testing.type import SingleInt
 from qiime2.core.testing.util import get_dummy_plugin
-<<<<<<< HEAD
-from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, ParallelConfig,
-                                        setup_parallel)
-=======
 from qiime2.sdk.parallel_config import (PARALLEL_CONFIG, _MaskCondaEnv,
-                                        ParallelConfig, setup_parallel,
-                                        get_config)
->>>>>>> df43986... Refactor behavior with no conda env and test
+                                        ParallelConfig, setup_parallel)
 
 
 class TestConfig(unittest.TestCase):

--- a/qiime2/sdk/tests/test_config.py
+++ b/qiime2/sdk/tests/test_config.py
@@ -220,7 +220,7 @@ class TestConfig(unittest.TestCase):
             self.method.parallel(self.art)
 
     def test_no_vendored_fp(self):
-        with _MASK_CONDA_ENV_):
+        with _MASK_CONDA_ENV_():
             with self.cache:
                 future = self.pipeline.parallel(self.art, self.art)
                 list_return, dict_return = future._result()


### PR DESCRIPTION
Handle the case where we try to parallelize things when running QIIME 2 outside of a conda environment (usually involves Docker). Previously we were reliant on the conda_prefix to get a path to the vendored config. Now if there is no conda_prefix we just load the vendored config directly from memory.