### PR TITLE
Change error message

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   requires:
     - pytest
     - tornado
-    - notebook
+    - notebook <7
 
   imports:
     - qiime2

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -381,5 +381,5 @@ class PluginManager:
                 return artifact_class_record.format
 
         raise TypeError(
-            "Semantic type %r does not have a compatible directory format."
+            "Semantic type %r is not a registered semantic type."
             % semantic_type)

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -380,6 +380,11 @@ class PluginManager:
             if semantic_type <= artifact_class_record.semantic_type:
                 return artifact_class_record.format
 
+        # TODO: We need a good way to tell if a semantic type is registered but
+        # does not have a directory format. The previous error was causing a
+        # lot of confusion, but this one is also not entirely accurate.
+        #
+        # Reference: https://github.com/qiime2/qiime2/issues/514
         raise TypeError(
             "Semantic type %r is not a registered semantic type."
             % semantic_type)

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -382,7 +382,7 @@ class PluginManager:
 
         # TODO: We need a good way to tell if a semantic type is registered but
         # does not have a directory format. The previous error was causing a
-        # lot of confusion, but this one is also not entirely accurate.
+        # lot of confusion.
         #
         # Reference: https://github.com/qiime2/qiime2/issues/514
         raise TypeError(

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -386,5 +386,6 @@ class PluginManager:
         #
         # Reference: https://github.com/qiime2/qiime2/issues/514
         raise TypeError(
-            "Semantic type %r is not a registered semantic type."
+            "Semantic type %r is invalid, either because it doesn't have a "
+            "compatible directory format, or because it's not registered."
             % semantic_type)


### PR DESCRIPTION
Closes #514 by making the error message say the semantic type is not registered instead of saying it does not have a registered format.

Here's the thing about this. This error is being raised when a semantic type does not exist AND when a semantic type does not have a directory format. Currently, there does not seem to be a good way to tell if a semantic type has been registered without a corresponding format.

In other words, the previous error message was lying when the type itself wasn't registered. This one is lying when the type is registered but has no format. There doesn't seem to currently be a good way to distinguish between the two situations. I believe this error message will generally be less confusing in the scenarios where it is likely to be encountered.
