### PR TITLE
Validate result collection keys

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   requires:
     - pytest
     - tornado
-    - notebook
+    - notebook <7
 
   imports:
     - qiime2

--- a/qiime2/core/type/primitive.py
+++ b/qiime2/core/type/primitive.py
@@ -225,7 +225,7 @@ class Choices(_PrimitivePredicateBase):
         return hash(type(self)) ^ hash(frozenset(self.choices))
 
     def __eq__(self, other):
-        return (type(self) == type(other)
+        return (type(self) is type(other)
                 and set(self.choices) == set(other.choices))
 
     def __repr__(self):

--- a/qiime2/core/type/util.py
+++ b/qiime2/core/type/util.py
@@ -247,7 +247,7 @@ def parse_primitive(t, value):
     if homogeneous:
         all_matching = False
         for member in allowed:
-            if all(type(x) == _COERCION_MAPPER[member].pytype
+            if all(type(x) is _COERCION_MAPPER[member].pytype
                    for x in result):
                 all_matching = True
                 break

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -551,8 +551,7 @@ class ResultCollection:
             if not all(isinstance(key, str) for key in collection.keys()):
                 raise TypeError('All ResultCollection keys must be strings')
 
-            for key in collection.keys():
-                qiime2.sdk.util.validate_result_collection_key(key)
+            qiime2.sdk.util.validate_result_collection_keys(*collection.keys())
 
             self.collection = collection
         else:
@@ -577,7 +576,7 @@ class ResultCollection:
         yield self.collection.__iter__()
 
     def __setitem__(self, key, item):
-        qiime2.sdk.util.validate_result_collection_key(key)
+        qiime2.sdk.util.validate_result_collection_keys(key)
         self.collection[key] = item
 
     def __getitem__(self, key):

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import re
 import os
 import shutil
 import warnings
@@ -551,6 +552,9 @@ class ResultCollection:
             if not all(isinstance(key, str) for key in collection.keys()):
                 raise TypeError('All ResultCollection keys must be strings')
 
+            for key in collection.keys():
+                _validate_result_collection_key(key)
+
             self.collection = collection
         else:
             self.collection = {str(k): v for k, v in enumerate(collection)}
@@ -574,6 +578,7 @@ class ResultCollection:
         yield self.collection.__iter__()
 
     def __setitem__(self, key, item):
+        _validate_result_collection_key(key)
         self.collection[key] = item
 
     def __getitem__(self, key):
@@ -628,3 +633,9 @@ class ResultCollection:
         """ Noop to provide standardized interface with ProxyResultCollection.
         """
         return self
+
+
+def _validate_result_collection_key(key):
+    if not bool(re.match('^[a-zA-Z0-9+-_.]+$', key)):
+        raise KeyError('Result Collection keys may only contain the following'
+                       ' characters: A-Z, a-z, 0-9, +, -, _, and .')

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -548,9 +548,6 @@ class ResultCollection:
         if collection is None:
             self.collection = {}
         elif isinstance(collection, dict):
-            if not all(isinstance(key, str) for key in collection.keys()):
-                raise TypeError('All ResultCollection keys must be strings')
-
             qiime2.sdk.util.validate_result_collection_keys(*collection.keys())
 
             self.collection = collection

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -170,7 +170,7 @@ class Result:
         # ensure (as best as we can) that the UUIDs we are comparing are linked
         # to the same type of QIIME 2 object.
         return (
-            type(self) == type(other) and
+            type(self) is type(other) and
             self.uuid == other.uuid
         )
 

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -6,7 +6,6 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import re
 import os
 import shutil
 import warnings
@@ -553,7 +552,7 @@ class ResultCollection:
                 raise TypeError('All ResultCollection keys must be strings')
 
             for key in collection.keys():
-                _validate_result_collection_key(key)
+                qiime2.sdk.util.validate_result_collection_key(key)
 
             self.collection = collection
         else:
@@ -578,7 +577,7 @@ class ResultCollection:
         yield self.collection.__iter__()
 
     def __setitem__(self, key, item):
-        _validate_result_collection_key(key)
+        qiime2.sdk.util.validate_result_collection_key(key)
         self.collection[key] = item
 
     def __getitem__(self, key):
@@ -633,9 +632,3 @@ class ResultCollection:
         """ Noop to provide standardized interface with ProxyResultCollection.
         """
         return self
-
-
-def _validate_result_collection_key(key):
-    if not bool(re.match('^[a-zA-Z0-9+-_.]+$', key)):
-        raise KeyError('Result Collection keys may only contain the following'
-                       ' characters: A-Z, a-z, 0-9, +, -, _, and .')

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -591,7 +591,7 @@ class TestResultCollection(unittest.TestCase):
         with self.assertRaisesRegex(
                 KeyError,
                 'ResultCollection keys may only contain the following'
-                ' characters:.*'):
+                ' characters:.*valid key'):
             ResultCollection({'not a valid key': 0})
 
     def test_invalid_key_added(self):
@@ -600,7 +600,7 @@ class TestResultCollection(unittest.TestCase):
         with self.assertRaisesRegex(
                 KeyError,
                 'ResultCollection keys may only contain the following'
-                ' characters:.*'):
+                ' characters:.*valid key'):
             collection['not a valid key'] = 0
 
 

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -584,14 +584,15 @@ class TestResultCollection(unittest.TestCase):
 
     def test_collection_non_str_keys(self):
         with self.assertRaisesRegex(
-                TypeError, 'All ResultCollection keys must be strings'):
+                KeyError, 'ResultCollection keys must be strings and may only '
+                'contain the following characters:.*1'):
             ResultCollection({1: 0})
 
     def test_invalid_key_init(self):
         with self.assertRaisesRegex(
                 KeyError,
-                'ResultCollection keys may only contain the following'
-                ' characters:.*valid key'):
+                'ResultCollection keys must be strings and may only contain '
+                'the following characters:.*valid key'):
             ResultCollection({'not a valid key': 0})
 
     def test_invalid_key_added(self):
@@ -599,8 +600,8 @@ class TestResultCollection(unittest.TestCase):
 
         with self.assertRaisesRegex(
                 KeyError,
-                'ResultCollection keys may only contain the following'
-                ' characters:.*valid key'):
+                'ResultCollection keys must be strings and may only contain '
+                'the following characters:.*valid key'):
             collection['not a valid key'] = 0
 
 

--- a/qiime2/sdk/tests/test_result.py
+++ b/qiime2/sdk/tests/test_result.py
@@ -587,6 +587,22 @@ class TestResultCollection(unittest.TestCase):
                 TypeError, 'All ResultCollection keys must be strings'):
             ResultCollection({1: 0})
 
+    def test_invalid_key_init(self):
+        with self.assertRaisesRegex(
+                KeyError,
+                'ResultCollection keys may only contain the following'
+                ' characters:.*'):
+            ResultCollection({'not a valid key': 0})
+
+    def test_invalid_key_added(self):
+        collection = ResultCollection()
+
+        with self.assertRaisesRegex(
+                KeyError,
+                'ResultCollection keys may only contain the following'
+                ' characters:.*'):
+            collection['not a valid key'] = 0
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qiime2/sdk/tests/test_util.py
+++ b/qiime2/sdk/tests/test_util.py
@@ -11,6 +11,8 @@ import unittest
 import qiime2
 import qiime2.sdk
 
+from qiime2.sdk.util import validate_result_collection_keys
+
 
 class TestUtil(unittest.TestCase):
     def test_artifact_actions(self):
@@ -50,6 +52,39 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(len(obs), 1)
         self.assertEqual(obs[0][0], exp[0][0])
         self.assertCountEqual(obs[0][1], exp[0][1])
+
+    def test_validate_result_collection_keys_valid(self):
+
+        self.assertEqual(validate_result_collection_keys('a'), None)
+
+        good_keys = ['-', '+', '.', '_', 'a', 'x', 'A', 'X', '0', '9',
+                     '90XAxa_.+-']
+        self.assertEqual(validate_result_collection_keys(*good_keys), None)
+
+    def test_validate_result_collection_keys_invalid(self):
+        with self.assertRaisesRegex(KeyError,
+                                    "Invalid.*: @"):
+            validate_result_collection_keys('@')
+
+        with self.assertRaisesRegex(KeyError,
+                                    "Invalid.*: @, a1@"):
+            validate_result_collection_keys('@', 'a1@')
+
+        with self.assertRaisesRegex(KeyError,
+                                    "Invalid.*: @, a1@"):
+            keys = ['@', 'a1@']
+            validate_result_collection_keys(*keys)
+
+        with self.assertRaisesRegex(KeyError,
+                                    "Invalid.*: @, a1@"):
+            validate_result_collection_keys(
+                'good-key', '@', 'a1@')
+
+        bad_keys = ['he llo', ' ', '!', '?']
+        for key in bad_keys:
+            with self.assertRaisesRegex(KeyError,
+                                        f"Invalid.*: {key}"):
+                validate_result_collection_keys(key)
 
 
 if __name__ == '__main__':

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -6,6 +6,8 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import re
+
 import qiime2.sdk
 import qiime2.core.type as qtype
 import qiime2.core.type.parse as _parse
@@ -118,3 +120,9 @@ def actions_by_input_type(string):
                 commands.append((pg, actions))
 
     return commands
+
+
+def validate_result_collection_key(key):
+    if not bool(re.match('^[a-zA-Z0-9+-_.]+$', key)):
+        raise KeyError('Result Collection keys may only contain the following'
+                       ' characters: A-Z, a-z, 0-9, +, -, _, and .')

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -140,5 +140,5 @@ def validate_result_collection_keys(*args):
     if len(invalid_keys) > 0:
         raise KeyError('Invalid key(s) provided for ResultCollection. '
                        'ResultCollection keys may only contain the following '
-                       'characters: A-Z, a-z, 0-9, +, -, _, and .\n'
-                       f'The offending key(s) are: {", ".join(invalid_keys)}')
+                       'characters: A-Z, a-z, 0-9, +, -, ., and _. '
+                       f'Offending keys include: {", ".join(invalid_keys)}')

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -122,7 +122,23 @@ def actions_by_input_type(string):
     return commands
 
 
-def validate_result_collection_key(key):
-    if not bool(re.match('^[a-zA-Z0-9+-_.]+$', key)):
-        raise KeyError('ResultCollection keys may only contain the following'
-                       ' characters: A-Z, a-z, 0-9, +, -, _, and .')
+def validate_result_collection_keys(*args):
+    """Validate one or more strings intended for use as ResultCollection keys.
+
+    This can be called on one or more keys provided as arguments:
+    qiime2.sdk.util.validate_result_collection_keys('@', 'a1@')
+
+    Or on a list, by unpacking it in the call:
+    l = ['@', 'a1@']
+    qiime2.sdk.util.validate_result_collection_keys(*l)
+    """
+    invalid_keys = []
+    for key in args:
+        if bool(re.search(r'[^\w+-.]', key)):
+            invalid_keys.append(key)
+
+    if len(invalid_keys) > 0:
+        raise KeyError('Invalid key(s) provided for ResultCollection. '
+                       'ResultCollection keys may only contain the following '
+                       'characters: A-Z, a-z, 0-9, +, -, _, and .\n'
+                       f'The offending key(s) are: {", ".join(invalid_keys)}')

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -134,14 +134,15 @@ def validate_result_collection_keys(*args):
     """
     invalid_keys = []
     for key in args:
-        if bool(re.search(r'[^\w+-.]', key)):
+        if not isinstance(key, str) or bool(re.search(r'[^\w+-.]', key)):
             invalid_keys.append(key)
 
     if len(invalid_keys) > 0:
         raise KeyError('Invalid key(s) provided for ResultCollection. '
-                       'ResultCollection keys may only contain the following '
-                       'characters: A-Z, a-z, 0-9, +, -, ., and _. '
-                       f'Offending keys include: {", ".join(invalid_keys)}')
+                       'ResultCollection keys must be strings and may only '
+                       'contain the following characters: A-Z, a-z, 0-9, +, '
+                       '-, ., and _. Offending keys include: '
+                       f'{", ".join(map(str, invalid_keys))}')
 
 
 def view_collection(collection, view_type):

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -124,5 +124,5 @@ def actions_by_input_type(string):
 
 def validate_result_collection_key(key):
     if not bool(re.match('^[a-zA-Z0-9+-_.]+$', key)):
-        raise KeyError('Result Collection keys may only contain the following'
+        raise KeyError('ResultCollection keys may only contain the following'
                        ' characters: A-Z, a-z, 0-9, +, -, _, and .')


### PR DESCRIPTION
Ensure that result collection keys only contain the following characters: `A-Z`, `a-z`, `0-9`, `+`, `-`, `_`, and `.`.

Close #699 
