### PR TITLE
Pin notebook <7 to prevent ModuleNotFound: notebook.base

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   requires:
     - pytest
     - tornado
-    - notebook
+    - notebook <7
 
   imports:
     - qiime2


### PR DESCRIPTION
Notebook version 7 appears to be the cause of the ModuleNotFound: notebook.base errors. For now at least the best solution is probably to just pin it. I tried looking through the Jupyter Notebook docs, and the docs for versions pre 7 404 when I try to select version 7.0.0. The docs that appear to be for version 7 make no reference to the IPythonHandler we are importing that leads to the errors.