### PR TITLE
Ensure filepath is str in Result.save

### DIFF
--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -222,6 +222,8 @@ class Result:
 
         # This accounts for edge cases in the filename extension
         # and ensures that there is only a single period in the ext.
+        # Caste to str incase we received a pathlib.Path or similar
+        filepath = str(filepath)
         filepath = filepath.rstrip('.')
         ext = '.' + ext.lstrip('.')
 

--- a/qiime2/sdk/tests/test_artifact.py
+++ b/qiime2/sdk/tests/test_artifact.py
@@ -256,6 +256,26 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
         self.assertEqual(artifact1.view(list),
                          artifact2.view(list))
 
+    def test_roundtrip_pathlib(self):
+        fp1 = pathlib.Path(os.path.join(self.test_dir.name, 'artifact1.qza'))
+        fp2 = pathlib.Path(os.path.join(self.test_dir.name, 'artifact2.qza'))
+        artifact = Artifact.import_data(FourInts, [-1, 42, 0, 43])
+
+        artifact.save(fp1)
+
+        artifact1 = Artifact.load(fp1)
+        artifact1.save(fp2)
+        artifact2 = Artifact.load(fp2)
+
+        self.assertEqual(artifact1.type, artifact2.type)
+        self.assertEqual(artifact1.format, artifact2.format)
+        self.assertEqual(artifact1.uuid, artifact2.uuid)
+        self.assertEqual(artifact1.view(list),
+                         artifact2.view(list))
+        # double view to make sure multiple views can be taken
+        self.assertEqual(artifact1.view(list),
+                         artifact2.view(list))
+
     def test_load_with_archive_filepath_modified(self):
         # Save an artifact for use in the following test case.
         fp = os.path.join(self.test_dir.name, 'artifact.qza')


### PR DESCRIPTION
Closes qiime2/qiime2#704 by casting the filepath to a string before trying to do string manipulations to it.