### PR TITLE
MAINT: Index save to process pool

### DIFF
--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -268,7 +268,7 @@ tm = object
 
 
 class MEGALock(tm):
-    """ We need to lock out other processes with flufl, but we also need to
+    """We need to lock out other processes with flufl, but we also need to
     lock out other threads with a Python thread lock (because parsl
     threadpools), so we put them together in one MEGALock(tm)
     """

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1681,6 +1681,13 @@ class Pool:
 
         with self.cache.lock:
             for _uuid in self.get_data():
+                # Make sure the process that indexed this artifact will still
+                # have access to it if it is otherwise removed from the cache
+                # by retaining a reference to it in our process pool
+                alias = self.cache.process_pool._alias(_uuid)
+                self.cache.process_pool._make_symlink(_uuid, alias)
+
+                # Get action.yaml from this artifact's provenance
                 path = self.cache.data / _uuid
                 action_yaml = load_action_yaml(path)
                 action = action_yaml['action']


### PR DESCRIPTION
Artifacts are now saved to the action's process pool while the action is indexing the cache ensuring that if an action has indexed an artifact that artifact will be around until the action exits.

Also added docstrings to the indexing methods because I noticed they didn't exist yet.