### PR TITLE
Better cache creation

### DIFF
--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -461,11 +461,10 @@ class Cache:
                     self._create_cache_contents()
                 # Otherwise just leave it alone
                 else:
-                    raise ValueError(f"Path: \'{self.path}\' already exists"
-                                     " and is not a cache.")
-            else:
-                if not Cache.is_cache(self.path):
-                    self._create_cache_contents()
+                    raise ValueError(f"Path: '{self.path}' already exists and"
+                                     " is not a cache.")
+            elif not Cache.is_cache(self.path):
+                self._create_cache_contents()
 
         # Make our process pool.
         self.process_pool = self._create_process_pool()

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -431,13 +431,21 @@ class Cache:
         if not os.path.exists(self.path):
             # We could have another thread/process creating the cache at this
             # directory in which case the above check might say it does not
-            # exist then it could be created elsewhere before we get here
+            # exist then it could be created elsewhere before we get here. We
+            # cannot lock this, because we don't have a place to put the lock
+            # yet, and it isn't really a big enough deal to create a new lock
+            # elsewhere just for this because we don't really care if another
+            # instance makes the path out from under us
             try:
                 os.makedirs(self.path)
             except FileExistsError:
                 pass
-            else:
-                created_path = True
+
+            # We don't actually care if this is the specific thread/process
+            # that created the path, we only care that some instance of QIIME 2
+            # must  have just done it. Now any instance should treat it as a
+            # QIIME 2 created path
+            created_path = True
 
         self.lock = \
             MEGALock(str(self.lockfile), lifetime=timedelta(minutes=10))

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -443,7 +443,7 @@ class Cache:
 
             # We don't actually care if this is the specific thread/process
             # that created the path, we only care that some instance of QIIME 2
-            # must  have just done it. Now any instance should treat it as a
+            # must have just done it. Now any instance should treat it as a
             # QIIME 2 created path
             created_path = True
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -448,7 +448,7 @@ class Cache:
         with self.lock:
             # If the path already existed and wasn't a cache then we don't want
             # to create the cache contents here
-            if Cache.is_cache(self.path) and not created_path:
+            if not Cache.is_cache(self.path) and not created_path:
                 # We own the temp_cache_path, so we can recreate it if there
                 # was something wrong with it
                 if self.path == temp_cache_path:

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -461,13 +461,13 @@ class Cache:
                 # We own the temp_cache_path, so we can recreate it if there
                 # was something wrong with it
                 if self.path == temp_cache_path:
-                    warnings.warn(
-                        "Your temporary cache was found to be in an "
-                        "inconsistent state. It has been recreated.")
                     set_permissions(self.path, USER_GROUP_RWX,
                                     USER_GROUP_RWX, skip_root=True)
                     self._remove_cache_contents()
                     self._create_cache_contents()
+                    warnings.warn(
+                        "Your temporary cache was found to be in an "
+                        "inconsistent state. It has been recreated.")
                 # Otherwise just leave it alone
                 else:
                     raise ValueError(f"Path: '{self.path}' already exists and"

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -432,7 +432,7 @@ class Cache:
             # We could have another thread/process creating the cache at this
             # directory in which case the above check might say it does not
             # exist then it could be created elsewhere before we get here. We
-            # cannot lock this, because we don't have a place to put the lock
+            # cannot lock this because we don't have a place to put the lock
             # yet, and it isn't really a big enough deal to create a new lock
             # elsewhere just for this because we don't really care if another
             # instance makes the path out from under us

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -474,6 +474,7 @@ class Cache:
                                      " is not a cache.")
             elif not Cache.is_cache(self.path):
                 self._create_cache_contents()
+            # else: it was a cache with the contents already in it
 
         # Make our process pool.
         self.process_pool = self._create_process_pool()

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -468,7 +468,6 @@ class Cache:
                     warnings.warn(
                         "Your temporary cache was found to be in an "
                         "inconsistent state. It has been recreated.")
-                # Otherwise just leave it alone
                 else:
                     raise ValueError(f"Path: '{self.path}' already exists and"
                                      " is not a cache.")
@@ -476,7 +475,6 @@ class Cache:
                 self._create_cache_contents()
             # else: it was a cache with the contents already in it
 
-        # Make our process pool.
         self.process_pool = self._create_process_pool()
         # Lifespan is supplied in days and converted to seconds for internal
         # use

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -434,9 +434,10 @@ class Cache:
             # exist then it could be created elsewhere before we get here
             try:
                 os.makedirs(self.path)
-                created_path = True
             except FileExistsError:
                 pass
+            else:
+                created_path = True
 
         self.lock = \
             MEGALock(str(self.lockfile), lifetime=timedelta(minutes=10))

--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -592,3 +592,8 @@ class TestCache(unittest.TestCase):
         observed = _load_outputs(output)
 
         self.assertEqual(observed, expected)
+
+    def test_cache_existing_dir(self):
+        with self.assertRaisesRegex(
+                ValueError, f"Path: '{self.not_cache_path}' already exists"):
+            Cache(self.not_cache_path)


### PR DESCRIPTION
Minor breaking change, do a better job of ensuring creating a cache doesn't write cache contents into an existing non-cache directory. It was previously possible to get the cache to write cache contents to a directory that already existed. This refactor should prevent that.
