### PR TITLE
IMP: Artifact.import_data now has validate_level

### DIFF
--- a/qiime2/core/testing/transformer.py
+++ b/qiime2/core/testing/transformer.py
@@ -47,7 +47,7 @@ def _7(data: list) -> IntSequenceFormat:
     ff = IntSequenceFormat()
     with ff.open() as fh:
         for int_ in data:
-            fh.write('%d\n' % int_)
+            fh.write(f'{int_}\n')
     return ff
 
 

--- a/qiime2/core/tests/test_util.py
+++ b/qiime2/core/tests/test_util.py
@@ -6,12 +6,15 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import shutil
 import unittest
 import tempfile
 import pathlib
 import collections
 import datetime
 import dateutil.relativedelta as relativedelta
+
+import pytest
 
 import qiime2.core.util as util
 from qiime2.core.testing.type import Foo, Bar, Baz
@@ -209,6 +212,10 @@ class TestMD5SumDirectory(unittest.TestCase):
 
             self.assertEqual(exp, obs)
 
+    @pytest.mark.skipif(
+        shutil.which('md5sum') is None,
+        reason='md5sum executable is required'
+    )
     def test_single_file_md5sum_native(self):
         with tempfile.TemporaryDirectory() as tempdir:
             fp = pathlib.Path(tempdir) / 'test.txt'
@@ -216,11 +223,8 @@ class TestMD5SumDirectory(unittest.TestCase):
                 fh.write('contents\n')
 
             exp = 'e66545a2155380046fce3fdbd32a6b4f'
-            try:
-                obs = util.md5sum_native(fp)
-                self.assertEqual(exp, obs)
-            except FileNotFoundError:
-                pass  # md5sum executable not available
+            obs = util.md5sum_native(fp)
+            self.assertEqual(exp, obs)
 
     def test_single_file_nested(self):
         nested_dir = self.test_path / 'bar'

--- a/qiime2/core/tests/test_util.py
+++ b/qiime2/core/tests/test_util.py
@@ -198,6 +198,30 @@ class TestMD5SumDirectory(unittest.TestCase):
                 ('foobarbaz.txt', '93b048d0202e4b06b658f3aef1e764d3')
             ]))
 
+    def test_single_file_md5sum_python(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            fp = pathlib.Path(tempdir) / 'test.txt'
+            with open(fp, 'w') as fh:
+                fh.write('contents\n')
+
+            exp = 'e66545a2155380046fce3fdbd32a6b4f'
+            obs = util.md5sum_python(fp)
+
+            self.assertEqual(exp, obs)
+
+    def test_single_file_md5sum_native(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            fp = pathlib.Path(tempdir) / 'test.txt'
+            with open(fp, 'w') as fh:
+                fh.write('contents\n')
+
+            exp = 'e66545a2155380046fce3fdbd32a6b4f'
+            try:
+                obs = util.md5sum_native(fp)
+                self.assertEqual(exp, obs)
+            except FileNotFoundError:
+                pass  # md5sum executable not available
+
     def test_single_file_nested(self):
         nested_dir = self.test_path / 'bar'
         nested_dir.mkdir()

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -284,8 +284,11 @@ class Artifact(Result):
             return False
 
     @classmethod
-    def import_data(cls, type, view, view_type=None):
+    def import_data(cls, type, view, view_type=None, validate_level='max'):
         type_, type = type, __builtins__['type']
+
+        if validate_level not in ('min', 'max'):
+            raise ValueError("Expected 'min' or 'max' for `validate_level`.")
 
         is_format = False
         if isinstance(type_, str):
@@ -327,7 +330,7 @@ class Artifact(Result):
 
         provenance_capture = archive.ImportProvenanceCapture(format_, md5sums)
         return cls._from_view(type_, view, view_type, provenance_capture,
-                              validate_level='max')
+                              validate_level=validate_level)
 
     @classmethod
     def _from_view(cls, type, view, view_type, provenance_capture,


### PR DESCRIPTION
TODO: 
 - [x] write tests with a sacrificial format with hidden errors
 - [x] ? swap out md5sum implementation when host has a faster binary available
 - [x] md5sum tests