### PR TITLE
DEP: moves lxml from test reqs to run reqs

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -32,13 +32,13 @@ requirements:
     - parsl {{ parsl }}
     - appdirs
     - tomlkit
+    - lxml
 
 test:
   requires:
     - pytest
     - tornado
     - notebook <7
-    - lxml
 
   imports:
     - qiime2


### PR DESCRIPTION
moving the lxml dep from test -> run reqs so that [this helper](https://github.com/qiime2/qiime2/pull/735) can be used w/the required deps across diff plugins when a distro build occurs