### PR TITLE
IMP: Ensure default args are captured when index checking

### DIFF
--- a/qiime2/core/testing/method.py
+++ b/qiime2/core/testing/method.py
@@ -172,8 +172,10 @@ def list_params(ints: list) -> int:
     return ints
 
 
-def varied_method(ints1: int, ints2: list, int1: int, string: str) -> \
-                  (int, list, int):
+def varied_method(ints1: int, ints2: list, int1: int = None,
+                  string: str = "NO") -> (int, list, int):
+    if int1 is None:
+        int1 = 1
     assert isinstance(ints1, list)
     assert isinstance(ints2, qiime2.sdk.result.ResultCollection)
     assert isinstance(int1, int)

--- a/qiime2/core/testing/pipeline.py
+++ b/qiime2/core/testing/pipeline.py
@@ -102,8 +102,9 @@ def resumable_pipeline(ctx, int_list, int_dict, fail=False):
     return list_return, dict_return
 
 
-def resumable_varied_pipeline(ctx, ints1, ints2, int1, string, metadata,
-                              fail=False):
+# Either both int1 and string should be default or neither should be
+def resumable_varied_pipeline(ctx, ints1, ints2, metadata, int1=None,
+                              string='None', fail=False):
     varied_method = ctx.get_action('dummy_plugin', 'varied_method')
     list_of_ints = ctx.get_action('dummy_plugin', 'list_of_ints')
     dict_of_ints = ctx.get_action('dummy_plugin', 'dict_of_ints')
@@ -111,8 +112,11 @@ def resumable_varied_pipeline(ctx, ints1, ints2, int1, string, metadata,
                                             'identity_with_metadata')
     most_common_viz = ctx.get_action('dummy_plugin', 'most_common_viz')
 
-    ints1_ret, ints2_ret, int1_ret = varied_method(
-        ints1, ints2, int1, string)
+    if int1 is None and string == 'None':
+        ints1_ret, ints2_ret, int1_ret = varied_method(ints1, ints2)
+    else:
+        ints1_ret, ints2_ret, int1_ret = varied_method(
+            ints1, ints2, int1, string)
 
     list_ret, = list_of_ints(ints1_ret)
     dict_ret, = dict_of_ints(ints1)
@@ -141,8 +145,9 @@ def resumable_varied_pipeline(ctx, ints1, ints2, int1, string, metadata,
             viz_ret)
 
 
-def resumable_nested_varied_pipeline(ctx, ints1, ints2, int1, string, metadata,
-                                     fail=False):
+# Either both int1 and string should be default or neither should be
+def resumable_nested_varied_pipeline(ctx, ints1, ints2, metadata, int1=None,
+                                     string='None', fail=False):
     internal_pipeline = ctx.get_action('dummy_plugin',
                                        'internal_fail_pipeline')
     list_of_ints = ctx.get_action('dummy_plugin', 'list_of_ints')
@@ -159,8 +164,12 @@ def resumable_nested_varied_pipeline(ctx, ints1, ints2, int1, string, metadata,
     viz_ret, = most_common_viz(ints2[1])
 
     try:
-        ints1_ret, ints2_ret, int1_ret = internal_pipeline(
-            ints1, ints2, int1, string, fail)._result()
+        if int1 is None and string == 'None':
+            ints1_ret, ints2_ret, int1_ret = internal_pipeline(
+                ints1, ints2, fail=fail)._result()
+        else:
+            ints1_ret, ints2_ret, int1_ret = internal_pipeline(
+                ints1, ints2, int1, string, fail=fail)._result()
     except PipelineError as e:
         uuids = [uuid for uuid in e.uuids]
 
@@ -177,11 +186,17 @@ def resumable_nested_varied_pipeline(ctx, ints1, ints2, int1, string, metadata,
             viz_ret)
 
 
-def internal_fail_pipeline(ctx, ints1, ints2, int1, string, fail=False):
+# Either both int1 and string should be default or neither should be
+def internal_fail_pipeline(ctx, ints1, ints2, int1=None, string='None',
+                           fail=False):
     varied_method = ctx.get_action('dummy_plugin', 'varied_method')
 
-    ints1_ret, ints2_ret, int1_ret = varied_method(
-        ints1, ints2, int1, string)
+    if int1 is None and string == 'None':
+        ints1_ret, ints2_ret, int1_ret = varied_method(
+            ints1, ints2)
+    else:
+        ints1_ret, ints2_ret, int1_ret = varied_method(
+            ints1, ints2, int1, string)
 
     if fail:
         uuids = []

--- a/qiime2/core/tests/test_pipeline_resumption.py
+++ b/qiime2/core/tests/test_pipeline_resumption.py
@@ -123,7 +123,7 @@ class TestPipelineResumption(unittest.TestCase):
             self.assertNotEqual(identity_uuid, complete_identity_uuid)
             self.assertNotEqual(viz_uuid, complete_viz_uuid)
 
-    def test_resumable_pipeline_OLD(self):
+    def test_resumable_pipeline(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
                 self.pipeline(

--- a/qiime2/core/tests/test_pipeline_resumption.py
+++ b/qiime2/core/tests/test_pipeline_resumption.py
@@ -96,7 +96,7 @@ class TestPipelineResumption(unittest.TestCase):
         with self.cache:
             with self.assertRaises(PipelineError) as e:
                 self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                     fail=True)
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
@@ -104,7 +104,7 @@ class TestPipelineResumption(unittest.TestCase):
 
             ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, identity_ret, \
                 viz_ret = self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1)
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi')
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -123,11 +123,11 @@ class TestPipelineResumption(unittest.TestCase):
             self.assertNotEqual(identity_uuid, complete_identity_uuid)
             self.assertNotEqual(viz_uuid, complete_viz_uuid)
 
-    def test_resumable_pipeline(self):
+    def test_resumable_pipeline_OLD(self):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
                 self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                     fail=True)
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
@@ -135,7 +135,7 @@ class TestPipelineResumption(unittest.TestCase):
 
             ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                 identity_ret, viz_ret = self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1)
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi')
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -161,7 +161,7 @@ class TestPipelineResumption(unittest.TestCase):
             with self.assertRaises(PipelineError) as e:
                 with ParallelConfig():
                     future = self.pipeline.parallel(
-                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                         fail=True)
                     future._result()
 
@@ -170,7 +170,7 @@ class TestPipelineResumption(unittest.TestCase):
 
             with ParallelConfig():
                 future = self.pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1)
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi')
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                     identity_ret, viz_ret = future._result()
 
@@ -197,7 +197,7 @@ class TestPipelineResumption(unittest.TestCase):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
                 self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                     fail=True)
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
@@ -206,7 +206,7 @@ class TestPipelineResumption(unittest.TestCase):
             # Pass int2 instead of int1
             ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                 identity_ret, viz_ret = self.pipeline(
-                    self.ints1, self.ints2, self.int2, 'Hi', self.md1)
+                    self.ints1, self.ints2, self.md1, self.int2, 'Hi')
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -232,7 +232,7 @@ class TestPipelineResumption(unittest.TestCase):
             with self.assertRaises(PipelineError) as e:
                 with ParallelConfig():
                     future = self.pipeline.parallel(
-                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                         fail=True)
                     future._result()
 
@@ -242,7 +242,7 @@ class TestPipelineResumption(unittest.TestCase):
             # Pass int2 instead of int1
             with ParallelConfig():
                 future = self.pipeline.parallel(
-                    self.ints1, self.ints2, self.int2, 'Hi', self.md1)
+                    self.ints1, self.ints2, self.md1, self.int2, 'Hi')
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                     identity_ret, viz_ret = future._result()
 
@@ -269,7 +269,7 @@ class TestPipelineResumption(unittest.TestCase):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
                 self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                     fail=True)
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
@@ -278,7 +278,7 @@ class TestPipelineResumption(unittest.TestCase):
             # Pass ints1_2 instead of ints1
             ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                 identity_ret, viz_ret = self.pipeline(
-                    self.ints1_2, self.ints2, self.int1, 'Hi', self.md1)
+                    self.ints1_2, self.ints2, self.md1, self.int1, 'Hi')
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -304,7 +304,7 @@ class TestPipelineResumption(unittest.TestCase):
             with self.assertRaises(PipelineError) as e:
                 with ParallelConfig():
                     future = self.pipeline.parallel(
-                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                         fail=True)
                     future._result()
 
@@ -314,7 +314,7 @@ class TestPipelineResumption(unittest.TestCase):
             # Pass ints1_2 instead of ints1
             with ParallelConfig():
                 future = self.pipeline.parallel(
-                    self.ints1_2, self.ints2, self.int2, 'Hi', self.md1)
+                    self.ints1_2, self.ints2, self.md1, self.int2, 'Hi')
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                     identity_ret, viz_ret = future._result()
 
@@ -341,7 +341,7 @@ class TestPipelineResumption(unittest.TestCase):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
                 self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                     fail=True)
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
@@ -350,7 +350,7 @@ class TestPipelineResumption(unittest.TestCase):
             # Pass in Bye instead of Hi
             ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                 identity_ret, viz_ret = self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Bye', self.md1)
+                    self.ints1, self.ints2, self.md1, self.int1, 'Bye')
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -376,7 +376,7 @@ class TestPipelineResumption(unittest.TestCase):
             with self.assertRaises(PipelineError) as e:
                 with ParallelConfig():
                     future = self.pipeline.parallel(
-                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                         fail=True)
                     future._result()
 
@@ -386,7 +386,7 @@ class TestPipelineResumption(unittest.TestCase):
             # Pass in Bye instead of Hi
             with ParallelConfig():
                 future = self.pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Bye', self.md1)
+                    self.ints1, self.ints2, self.md1, self.int1, 'Bye')
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                     identity_ret, viz_ret = future._result()
 
@@ -413,7 +413,7 @@ class TestPipelineResumption(unittest.TestCase):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
                 self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                     fail=True)
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
@@ -422,7 +422,7 @@ class TestPipelineResumption(unittest.TestCase):
             # Pass in md2 instead of md1
             ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                 identity_ret, viz_ret = self.pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md2)
+                    self.ints1, self.ints2, self.md2, self.int1, 'Hi')
 
             complete_ints1_uuids = _load_alias_uuids(ints1_ret)
             complete_ints2_uuids = _load_alias_uuids(ints2_ret)
@@ -448,7 +448,7 @@ class TestPipelineResumption(unittest.TestCase):
             with self.assertRaises(PipelineError) as e:
                 with ParallelConfig():
                     future = self.pipeline.parallel(
-                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                         fail=True)
                     future._result()
 
@@ -458,7 +458,7 @@ class TestPipelineResumption(unittest.TestCase):
             # Pass in md2 instead of md1
             with ParallelConfig():
                 future = self.pipeline.parallel(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md2)
+                    self.ints1, self.ints2, self.md2, self.int1, 'Hi')
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                     identity_ret, viz_ret = future._result()
 
@@ -485,7 +485,7 @@ class TestPipelineResumption(unittest.TestCase):
         with self.pool:
             with self.assertRaises(PipelineError) as e:
                 self.nested_pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                     fail=True)
 
             ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
@@ -495,7 +495,7 @@ class TestPipelineResumption(unittest.TestCase):
             # returns from varied_method
             ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                 identity_ret, viz_ret = self.nested_pipeline(
-                    self.ints1, self.ints2, self.int1, 'Hi', self.md1)
+                    self.ints1, self.ints2, self.md1, self.int1, 'Hi')
 
             complete_ints1_uuids = _load_nested_alias_uuids(
                 ints1_ret, self.cache)
@@ -523,7 +523,7 @@ class TestPipelineResumption(unittest.TestCase):
             with self.assertRaises(PipelineError) as e:
                 with ParallelConfig():
                     future = self.nested_pipeline.parallel(
-                        self.ints1, self.ints2, self.int1, 'Hi', self.md1,
+                        self.ints1, self.ints2, self.md1, self.int1, 'Hi',
                         fail=True)
                     future._result()
 
@@ -532,7 +532,151 @@ class TestPipelineResumption(unittest.TestCase):
 
             with ParallelConfig():
                 future = self.nested_pipeline.parallel(
-                        self.ints1, self.ints2, self.int1, 'Hi', self.md1)
+                        self.ints1, self.ints2, self.md1, self.int1, 'Hi')
+                ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                    identity_ret, viz_ret = future._result()
+
+            complete_ints1_uuids = _load_nested_alias_uuids(
+                ints1_ret, self.cache)
+            complete_ints2_uuids = _load_nested_alias_uuids(
+                ints2_ret, self.cache)
+            complete_int1_uuid = _load_nested_alias_uuid(int1_ret, self.cache)
+            complete_list_uuids = _load_alias_uuids(list_ret)
+            complete_dict_uuids = _load_alias_uuids(dict_ret)
+            complete_identity_uuid = _load_alias_uuid(identity_ret)
+            complete_viz_uuid = _load_alias_uuid(viz_ret)
+
+            # Assert that the artifacts returned by the completed run of the
+            # pipeline are aliases of the artifacts created by the first failed
+            # run
+            self.assertEqual(ints1_uuids, complete_ints1_uuids)
+            self.assertEqual(ints2_uuids, complete_ints2_uuids)
+            self.assertEqual(int1_uuid, complete_int1_uuid)
+            self.assertEqual(list_uuids, complete_list_uuids)
+            self.assertEqual(dict_uuids, complete_dict_uuids)
+            self.assertEqual(identity_uuid, complete_identity_uuid)
+            self.assertEqual(viz_uuid, complete_viz_uuid)
+
+    def test_resumable_pipeline_default_args(self):
+        with self.pool:
+            with self.assertRaises(PipelineError) as e:
+                self.pipeline(
+                    self.ints1, self.ints2, self.md1,
+                    fail=True)
+
+            ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
+                identity_uuid, viz_uuid = e.exception.uuids
+
+            ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                identity_ret, viz_ret = self.pipeline(
+                    self.ints1, self.ints2, self.md1)
+
+            complete_ints1_uuids = _load_alias_uuids(ints1_ret)
+            complete_ints2_uuids = _load_alias_uuids(ints2_ret)
+            complete_int1_uuid = _load_alias_uuid(int1_ret)
+            complete_list_uuids = _load_alias_uuids(list_ret)
+            complete_dict_uuids = _load_alias_uuids(dict_ret)
+            complete_identity_uuid = _load_alias_uuid(identity_ret)
+            complete_viz_uuid = _load_alias_uuid(viz_ret)
+
+            # Assert that the artifacts returned by the completed run of
+            # the pipeline are aliases of the artifacts created by the
+            # first failed run
+            self.assertEqual(ints1_uuids, complete_ints1_uuids)
+            self.assertEqual(ints2_uuids, complete_ints2_uuids)
+            self.assertEqual(int1_uuid, complete_int1_uuid)
+            self.assertEqual(list_uuids, complete_list_uuids)
+            self.assertEqual(dict_uuids, complete_dict_uuids)
+            self.assertEqual(identity_uuid, complete_identity_uuid)
+            self.assertEqual(viz_uuid, complete_viz_uuid)
+
+    def test_resumable_pipeline_default_args_parallel(self):
+        with self.pool:
+            with self.assertRaises(PipelineError) as e:
+                with ParallelConfig():
+                    future = self.pipeline.parallel(
+                        self.ints1, self.ints2, self.md1,
+                        fail=True)
+                    future._result()
+
+            ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
+                identity_uuid, viz_uuid = e.exception.uuids
+
+            with ParallelConfig():
+                future = self.pipeline.parallel(
+                    self.ints1, self.ints2, self.md1)
+                ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                    identity_ret, viz_ret = future._result()
+
+            complete_ints1_uuids = _load_alias_uuids(ints1_ret)
+            complete_ints2_uuids = _load_alias_uuids(ints2_ret)
+            complete_int1_uuid = _load_alias_uuid(int1_ret)
+            complete_list_uuids = _load_alias_uuids(list_ret)
+            complete_dict_uuids = _load_alias_uuids(dict_ret)
+            complete_identity_uuid = _load_alias_uuid(identity_ret)
+            complete_viz_uuid = _load_alias_uuid(viz_ret)
+
+            # Assert that the artifacts returned by the completed run of
+            # the pipeline are aliases of the artifacts created by the
+            # first failed run
+            self.assertEqual(ints1_uuids, complete_ints1_uuids)
+            self.assertEqual(ints2_uuids, complete_ints2_uuids)
+            self.assertEqual(int1_uuid, complete_int1_uuid)
+            self.assertEqual(list_uuids, complete_list_uuids)
+            self.assertEqual(dict_uuids, complete_dict_uuids)
+            self.assertEqual(identity_uuid, complete_identity_uuid)
+            self.assertEqual(viz_uuid, complete_viz_uuid)
+
+    def test_nested_resumable_pipeline_default_args(self):
+        with self.pool:
+            with self.assertRaises(PipelineError) as e:
+                self.nested_pipeline(
+                    self.ints1, self.ints2, self.md1, fail=True)
+
+            ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
+                identity_uuid, viz_uuid = e.exception.uuids
+
+            # We now run the not nested version. This will be able to reuse the
+            # returns from varied_method
+            ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
+                identity_ret, viz_ret = self.nested_pipeline(
+                    self.ints1, self.ints2, self.md1)
+
+            complete_ints1_uuids = _load_nested_alias_uuids(
+                ints1_ret, self.cache)
+            complete_ints2_uuids = _load_nested_alias_uuids(
+                ints2_ret, self.cache)
+            complete_int1_uuid = _load_nested_alias_uuid(int1_ret, self.cache)
+            complete_list_uuids = _load_alias_uuids(list_ret)
+            complete_dict_uuids = _load_alias_uuids(dict_ret)
+            complete_identity_uuid = _load_alias_uuid(identity_ret)
+            complete_viz_uuid = _load_alias_uuid(viz_ret)
+
+            # Assert that the artifacts returned by the completed run of the
+            # pipeline are aliases of the artifacts created by the first failed
+            # run
+            self.assertEqual(ints1_uuids, complete_ints1_uuids)
+            self.assertEqual(ints2_uuids, complete_ints2_uuids)
+            self.assertEqual(int1_uuid, complete_int1_uuid)
+            self.assertEqual(list_uuids, complete_list_uuids)
+            self.assertEqual(dict_uuids, complete_dict_uuids)
+            self.assertEqual(identity_uuid, complete_identity_uuid)
+            self.assertEqual(viz_uuid, complete_viz_uuid)
+
+    def test_nested_resumable_pipeline_parallel_default_args(self):
+        with self.pool:
+            with self.assertRaises(PipelineError) as e:
+                with ParallelConfig():
+                    future = self.nested_pipeline.parallel(
+                        self.ints1, self.ints2, self.md1, fail=True)
+                    future._result()
+
+            ints1_uuids, ints2_uuids, int1_uuid, list_uuids, dict_uuids, \
+                identity_uuid, viz_uuid = e.exception.uuids
+
+            with ParallelConfig():
+                future = self.nested_pipeline.parallel(
+                        self.ints1, self.ints2, self.md1)
                 ints1_ret, ints2_ret, int1_ret, list_ret, dict_ret, \
                     identity_ret, viz_ret = future._result()
 

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -238,9 +238,17 @@ class PipelineSignature:
                 signature_order)
 
     def collate_inputs(self, *args, **kwargs):
-        collated_inputs = {name: value for value, name in
-                           zip(args, self.signature_order)}
-        collated_inputs.update(kwargs)
+        # Collate positional inputs
+        collated_inputs = {name: value for name, value in
+                           zip(self.signature_order, args)}
+
+        # Collate keyword inputs
+        for name, param in self.signature_order.items():
+            if name in kwargs:
+                collated_inputs[name] = kwargs[name]
+            # Make sure to track default values for params not provided
+            elif name not in collated_inputs:
+                collated_inputs[name] = param.default
 
         return collated_inputs
 

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -241,15 +241,7 @@ class PipelineSignature:
         # Collate positional inputs
         collated_inputs = {name: value for name, value in
                            zip(self.signature_order, args)}
-
-        # Collate keyword inputs
-        for name, param in self.signature_order.items():
-            if name in kwargs:
-                collated_inputs[name] = kwargs[name]
-            # Make sure to track default values for params not provided
-            elif name not in collated_inputs:
-                collated_inputs[name] = param.default
-
+        collated_inputs.update(kwargs)
         return collated_inputs
 
     def _assert_valid_inputs(self, inputs):

--- a/qiime2/sdk/context.py
+++ b/qiime2/sdk/context.py
@@ -64,6 +64,9 @@ class Context:
         # We return this callable which determines whether to return cached
         # results or to run the action requested.
         def deferred_action(*args, **kwargs):
+            # The function is the first arg, we ditch that
+            args = args[1:]
+
             # If we have a named_pool, we need to check for cached results that
             # we can reuse.
             #
@@ -140,6 +143,9 @@ class Context:
             return action_obj._bind(
                 lambda: Context(parent=self))(*args, **kwargs)
 
+        deferred_action = action_obj._rewrite_wrapper_signature(
+            deferred_action)
+        action_obj._set_wrapper_properties(deferred_action)
         return deferred_action
 
     def _contains_proxies(self, *args, **kwargs):


### PR DESCRIPTION
When doing pipeline resumption default values are not being captured correctly for indexing causing artifacts that could be recycled to be regenerated.