### PR TITLE
BUG: [Issue 738] dangling recycle references

### DIFF
--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -695,7 +695,10 @@ class Cache:
 
         This process destroys data and named pools that do not have keys along
         with process pools older than the process_pool_lifespan on the cache
-        which defaults to 45 days. It never removes keys.
+        which defaults to 45 days.
+
+        It removes keys and warns the user about the removal if the data
+        referenced by the keys does not exist.
 
         We lock out other processes and threads from accessing the cache while
         garbage collecting to ensure the cache remains in a consistent state.
@@ -761,7 +764,21 @@ class Cache:
                     shutil.rmtree(target)
 
     def _check_dangling_reference(self, data_path, key_path):
-        """ If the data specified does not exist then remove the key
+        """ If the data specified does not exist then we have a dangling
+        reference and we warn them about it and remove the reference.
+
+        Parameters
+        ----------
+        data_path : pathlib.Path
+            The path we are expecting to see the data at.
+        key_path : pathlib.Path
+            The path to the key referencing the data path that will be removed
+            if the data is missing.
+
+        Returns
+        -------
+        Boolean
+            True if reference was dangling False if not
         """
         if not os.path.exists(data_path):
             warnings.warn(f"Dangling reference {key_path}. Data at {data_path}"

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -713,17 +713,20 @@ class Cache:
 
                 if (data := loaded_key.get('data')) is not None:
                     referenced_data.add(data)
+
+                    if not os.path.exists(self.data / data):
+                        os.remove(self.keys / key)
                 elif (pool := loaded_key.get('pool')) is not None:
                     referenced_pools.add(pool)
+
+                    if not os.path.exists(self.pools / pool):
+                        os.remove(self.keys / key)
                 # This really should never be happening unless someone messes
                 # with things manually
                 else:
                     raise ValueError(f"The key '{key}' in the cache"
                                      f" '{self.path}' does not point to"
                                      " anything")
-
-                if (data and not os.path.exists(self.data / data)) and (pool and not os.path.exists(self.pools / pool)):
-                    os.remove(self.keys / key)
 
             # Walk over pools and remove any that were not referred to by keys
             # while tracking all data within those that were referenced
@@ -747,11 +750,7 @@ class Cache:
                     shutil.rmtree(self.processes / process_pool)
                 else:
                     for data in os.listdir(self.processes / process_pool):
-                        # data = data.split('.')[0]
-                        if os.path.exists(self.processes / process_pool / data.split('.')[0]):
-                            referenced_data.add(data)
-                        else:
-                            os.remove(self.processes / process_pool / data)
+                        referenced_data.add(data.split('.')[0])
 
             # Walk over all data and remove any that was not referenced
             for data in self.get_data():
@@ -1731,11 +1730,11 @@ class Pool:
 
                 # NOTE: The error Liz saw was raised right here.
                 #
-                # Possibly create centralized method for reading out of data dir
-                # that is resistant to missing data. It would probably need to
-                # remove the ref and warn the user
+                # Possibly create centralized method for reading out of data
+                # dir that is resistant to missing data. It would probably need
+                # to remove the ref and warn the user
                 #
-                # We can potentially also be poking the actual data under the ref
+                # We can potentially also be poking the actual data under there
                 # every time we read the ref (in gc for instance)
                 action_yaml = load_action_yaml(path)
                 action = action_yaml['action']

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -714,6 +714,8 @@ class Cache:
             for key in self.get_keys():
                 loaded_key = self.read_key(key)
 
+                # If the data/pool referenced by the key actually exists then
+                # track it. Otherwise remove the dangling reference
                 if (data := loaded_key.get('data')) is not None:
                     if not self._check_dangling_reference(
                             self.data / data, self.keys / key):
@@ -1749,15 +1751,6 @@ class Pool:
 
                 # Get action.yaml from this artifact's provenance
                 path = self.cache.data / _uuid
-
-                # NOTE: The error Liz saw was raised right here.
-                #
-                # Possibly create centralized method for reading out of data
-                # dir that is resistant to missing data. It would probably need
-                # to remove the ref and warn the user
-                #
-                # We can potentially also be poking the actual data under there
-                # every time we read the ref (in gc for instance)
                 action_yaml = load_action_yaml(path)
                 action = action_yaml['action']
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -765,8 +765,8 @@ class Cache:
         """
         if not os.path.exists(data_path):
             warnings.warn(f"Dangling reference {key_path}. Data at {data_path}"
-                          " does not exist. Reference will be removed")
-            os.path.remove(data_path)
+                          " does not exist. Reference will be removed.")
+            os.path.remove(key_path)
 
             return True
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -785,7 +785,7 @@ class Cache:
         if not os.path.exists(data_path):
             warnings.warn(f"Dangling reference {key_path}. Data at {data_path}"
                           " does not exist. Reference will be removed.")
-            os.path.remove(key_path)
+            os.remove(key_path)
 
             return True
 

--- a/qiime2/sdk/context.py
+++ b/qiime2/sdk/context.py
@@ -11,6 +11,7 @@ from qiime2.core.type import HashableInvocation
 from qiime2.core.cache import get_cache
 import qiime2.sdk
 from qiime2.sdk.parallel_config import PARALLEL_CONFIG
+import warnings
 
 
 class Context:
@@ -116,7 +117,7 @@ class Context:
 
                     return qiime2.sdk.Results(
                         loaded_outputs.keys(), loaded_outputs.values())
-
+            warnings.warn(f"MISS {plugin} {action} {args} {kwargs}")
             # If we didn't have cached results to reuse, we need to execute the
             # action.
             #

--- a/qiime2/sdk/context.py
+++ b/qiime2/sdk/context.py
@@ -11,7 +11,6 @@ from qiime2.core.type import HashableInvocation
 from qiime2.core.cache import get_cache
 import qiime2.sdk
 from qiime2.sdk.parallel_config import PARALLEL_CONFIG
-import warnings
 
 
 class Context:
@@ -117,7 +116,7 @@ class Context:
 
                     return qiime2.sdk.Results(
                         loaded_outputs.keys(), loaded_outputs.values())
-            warnings.warn(f"MISS {plugin} {action} {args} {kwargs}")
+
             # If we didn't have cached results to reuse, we need to execute the
             # action.
             #


### PR DESCRIPTION
Closes #738. At this point the changes to GC are a bit of a cludge to solve the specific problem the issue was created for. The change to indexing makes that specific code resistant to failure when backing data has been spontaneously deleted which makes some amount of sense since that's probably the only place where we will reliably be able to continue if data is missing.
