### PR TITLE
ENH: allow typing.Union in action outputs

### DIFF
--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -11,6 +11,7 @@ import inspect
 import copy
 import itertools
 import tempfile
+from typing import get_origin, Union, get_args
 
 import qiime2.sdk
 import qiime2.core.type as qtype
@@ -484,6 +485,25 @@ class PipelineSignature:
                         name=name, key=key, idx=idx, size=size)
                     output[key] = self._create_output_artifact(
                         provenance, collection_name, scope, spec, view)
+            elif isinstance(get_origin(spec.view_type), type(Union)):
+                union_resolved = False
+                for arg in get_args(spec.view_type):
+                    if isinstance(output_view, arg):
+                        # we need a new spec with the correct view type
+                        spec = ParameterSpec(
+                            qiime_type=spec.qiime_type, view_type=arg,
+                            default=spec.default, description=spec.description
+                        )
+                        output = self._create_output_artifact(
+                            provenance, name, scope, spec, output_view
+                        )
+                        union_resolved = True
+                        break
+                if not union_resolved:
+                    raise TypeError(
+                        "Expected output view type to be one of %r, received %r" %
+                        ([x.__name__ for x in get_args(spec.view_type)],
+                         type(output_view).__name__))
             elif type(output_view) is not spec.view_type:
                 raise TypeError(
                     "Expected output view type %r, received %r" %


### PR DESCRIPTION
Hey @ebolyen, @lizgehret,

It's been bugging me for a while now that a single action cannot output artifacts of different semantic types if their output data type indicated on the function signature differs. For example, in the use case I recently posted on the forum I'd like to produce the following two kinds of outputs:
1. `SampleData[BLAST6]` -> `SeedOrthologDirFmt`
2. `FeatureData[BLAST6]` -> `BLAST6DirectoryFormat`

I cannot do that, since the two directory formats are different (and they are not easily "transformable"). I tried adapting the SDK to enable this by using a Union of output types (see below), similarly to how it was done for the input unions. Does this makes sense to you? If yes, I'd love to add some tests - it would be super-helpful if you could point me as to where they should live as I cannot really find a good spot 😅 
