### PR TITLE
BUG: composite semantic-type in `TypeMap` where child-type has properties; breaks CLI

### DIFF
--- a/qiime2/core/type/parse.py
+++ b/qiime2/core/type/parse.py
@@ -219,7 +219,14 @@ def ast_to_type(json_ast, scope=None):
 
         name = json_ast['name']
         if not json_ast['builtin']:
-            base_template = semantic.SemanticType(name).template
+            base_template = semantic.SemanticType(
+                name,
+                field_names=['field' + str(i) for i in range(len(fields))],
+                field_members={
+                    ('field' + str(i)):
+                    [child] for i, child in enumerate(fields)
+                },
+            ).template
         elif name == 'Visualization':
             return visualization.Visualization
         elif name in {'List', 'Set', 'Tuple', 'Collection'}:

--- a/qiime2/core/type/tests/test_parse.py
+++ b/qiime2/core/type/tests/test_parse.py
@@ -100,7 +100,7 @@ class TestParsing(unittest.TestCase):
         self.assertIs(W1.mapping, X1.mapping)
 
     def test_TypeMap_with_properties(self):
-        inp, _ = TypeMap({
+        I, OU = TypeMap({
             C1[Foo % Properties(['A', 'B', 'C'])]: Str,
             C1[Foo % Properties(['A', 'B'])]: Str,
             C1[Foo % Properties(['A', 'C'])]: Str,
@@ -110,10 +110,18 @@ class TestParsing(unittest.TestCase):
             C1[Foo % Properties(['C'])]: Str,
         })
 
-        try:
-            inp = ast_to_type(inp.to_ast(), scope={})
-        except Exception as e:
-            self.fail(f"Raised exception: {e}")
+        scope = {}
+        i = ast_to_type(I.to_ast(), scope=scope)
+        o = ast_to_type(OU.to_ast(), scope=scope)
+
+        self.assertEqual(scope[id(I.mapping)], [i, o])
+        self.assertEqual(len(scope), 1)
+
+        # Assert mapping is the same after ast_to_type call
+        self.assertEqual(I.mapping.lifted, i.mapping.lifted)
+
+        # Assert that the mapping object is the same in both i and o
+        self.assertIs(i.mapping, o.mapping)
 
     def test_syntax_error(self):
         with self.assertRaisesRegex(ValueError, "could not be parsed"):

--- a/qiime2/core/type/tests/test_parse.py
+++ b/qiime2/core/type/tests/test_parse.py
@@ -99,6 +99,22 @@ class TestParsing(unittest.TestCase):
         self.assertIs(V1.mapping, W1.mapping)
         self.assertIs(W1.mapping, X1.mapping)
 
+    def test_TypeMap_with_properties(self):
+        inp, _ = TypeMap({
+            C1[Foo % Properties(['A', 'B', 'C'])]: Str,
+            C1[Foo % Properties(['A', 'B'])]: Str,
+            C1[Foo % Properties(['A', 'C'])]: Str,
+            C1[Foo % Properties(['B', 'C'])]: Str,
+            C1[Foo % Properties(['A'])]: Str,
+            C1[Foo % Properties(['B'])]: Str,
+            C1[Foo % Properties(['C'])]: Str,
+        })
+
+        try:
+            inp = ast_to_type(inp.to_ast(), scope={})
+        except Exception as e:
+            self.fail(f"Raised exception: {e}")
+
     def test_syntax_error(self):
         with self.assertRaisesRegex(ValueError, "could not be parsed"):
             string_to_ast('$')


### PR DESCRIPTION
Closes #748. Look there for a detailed description of the bug and the proposed solution. 
