### PR TITLE
Allow Collection[Visualization]

### DIFF
--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -302,7 +302,8 @@ class PipelineSignature:
 
         for output_name, spec in outputs.items():
             if not (is_semantic_type(spec.qiime_type) or
-                    spec.qiime_type == Visualization or spec.qiime_type == Collection[Visualization]):
+                    spec.qiime_type == Visualization or
+                    spec.qiime_type == Collection[Visualization]):
                 raise TypeError(
                     "Output %r must be a semantic QIIME type or "
                     "Visualization, not %r"

--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -302,7 +302,7 @@ class PipelineSignature:
 
         for output_name, spec in outputs.items():
             if not (is_semantic_type(spec.qiime_type) or
-                    spec.qiime_type == Visualization):
+                    spec.qiime_type == Visualization or spec.qiime_type == Collection[Visualization]):
                 raise TypeError(
                     "Output %r must be a semantic QIIME type or "
                     "Visualization, not %r"


### PR DESCRIPTION
Allow `Collection[Visualization]` as a valid output type, this is necessary for [q2-boots](https://github.com/qiime2/q2-boots). 

Note: This is still pending usage changes both here in the framework and most likely in the cli and perhaps also mystery-stew