### PR TITLE
MAINT: update parse_type for py3.9

### DIFF
--- a/qiime2/core/type/parse.py
+++ b/qiime2/core/type/parse.py
@@ -44,7 +44,7 @@ def _expr(expr):
         return _build_predicate(expr.func.id, args, kwargs)
 
     if node is ast.Subscript:
-        field_expr = expr.slice.value
+        field_expr = expr.slice
 
         if type(field_expr) is ast.Tuple:
             field_expr = field_expr.elts


### PR DESCRIPTION
To reproduce the errors, downloaded `[Conda Channel] Rebuilt packages` from https://github.com/qiime2/distributions/actions/runs/8807196476?pr=229

Then I unzipped the rebuilt packages into a directory and used that directory as a conda channel for the following command:

```
conda create -n q2-py39 -c ./Downloads/py39-channel/ -c conda-forge -c bioconda qiime2-amplicon
```

Then I activated `q2-py39` and ran
```
make dev
```
on the repo I cared about.
