### PR TITLE
MAINT: convert_dtype param deprecation

### DIFF
--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -415,7 +415,7 @@ class MetadataWriter:
 
             df = md.to_dataframe(encode_missing=True)
             df.fillna('', inplace=True)
-            df = df.applymap(self._format)
+            df = df.map(self._format)
             tsv_writer.writerows(df.itertuples(index=True))
 
     def _non_default_missing(self, missing_directive):

--- a/qiime2/metadata/metadata.py
+++ b/qiime2/metadata/metadata.py
@@ -1286,7 +1286,7 @@ class CategoricalMetadataColumn(MetadataColumn):
                     "%r of type %r in column %r." %
                     (cls.__name__, value, type(value), series.name))
 
-        norm_series = series.apply(normalize, convert_dtype=False)
+        norm_series = series.apply(normalize).astype(object)
         norm_series.index = norm_series.index.str.strip()
         norm_series.name = norm_series.name.strip()
         return norm_series


### PR DESCRIPTION
updates from pandas 2.1.0 on `Series.apply()`.
changelog [here](https://pandas.pydata.org/docs/whatsnew/v2.1.0.html), open issue [here](https://github.com/pandas-dev/pandas/issues/52140).