### PR TITLE
DEPR: addressing pandas FutureWarning on .replace

### DIFF
--- a/qiime2/metadata/io.py
+++ b/qiime2/metadata/io.py
@@ -362,7 +362,7 @@ class MetadataReader:
         return series.replace([''], [None])
 
     def _to_numeric(self, series):
-        series = series.replace('', np.nan)
+        series = series.replace('', np.nan).infer_objects(copy=False)
         is_numeric = series.apply(self._is_numeric)
         if is_numeric.all():
             return pd.to_numeric(series, errors='raise')


### PR DESCRIPTION
fixes the following FutureWarning:
```
/Users/elizabethgehret/miniconda3/envs/q2dev-amplicon/lib/python3.9/site-packages/qiime2/metadata/io.py:365: 
FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version.
To retain the old behavior, explicitly call `result.infer_objects(copy=False)`.
To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
series = series.replace('', np.nan)
```