### PR TITLE
BUG: `Artifact.import_data` doesn't store checksums when the `view_type` is a `FormatBase`

### DIFF
--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -322,7 +322,9 @@ class Artifact(Result):
 
         format_ = None
         md5sums = None
-        if is_format:
+        if is_format and issubclass(view_type, qiime2.core.format.FormatBase):
+            path = pathlib.Path(str(view))
+        elif is_format:
             path = pathlib.Path(view)
             if path.is_file():
                 md5sums = {path.name: util.md5sum(path)}

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -322,10 +322,12 @@ class Artifact(Result):
 
         format_ = None
         md5sums = None
-        if is_format and issubclass(view_type, qiime2.core.format.FormatBase):
-            path = pathlib.Path(str(view))
-        elif is_format:
-            path = pathlib.Path(view)
+        if is_format:
+            if issubclass(view_type, qiime2.core.format.FormatBase):
+                path = pathlib.Path(str(view))
+            else:
+                path = pathlib.Path(view)
+
             if path.is_file():
                 md5sums = {path.name: util.md5sum(path)}
             elif path.is_dir():

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -297,6 +297,11 @@ class Artifact(Result):
         if isinstance(view_type, str):
             view_type = qiime2.sdk.parse_format(view_type)
             is_format = True
+        # This ensures that when view_type is provided as a python class
+        # or base class, the checksum is still performed
+        elif (isinstance(view_type, type) and
+              issubclass(view_type, qiime2.core.format.FormatBase)):
+            is_format = True
 
         if view_type is None:
             if type(view) is str or isinstance(view, pathlib.PurePath):

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -132,9 +132,10 @@ class TestImports(unittest.TestCase):
         # If the checksum is not stored, this will raise a KeyError
         action = load_action_yaml(ff2._archiver.path)['action']['manifest']
         self.assertIn('md5sum', action[0].keys())
-        # This ensures that the checksum is the standard 32 character length
-        # and will catch empty strings or other weird values that could arise
-        self.assertEqual(len(action[0]['md5sum']), 32)
+        # This ensures that the checksum is exactly what we expect and will
+        # catch empty strings or other weird values that could arise
+        self.assertEqual(action[0]['md5sum'],
+                         'c0710d6b4f15dfa88f600b0e6b624077')
 
 
 class TestArtifactAPIUsage(unittest.TestCase):

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -129,8 +129,12 @@ class TestImports(unittest.TestCase):
         ff2 = Artifact.import_data(IntSequence2, ff,
                                    view_type=IntSequenceFormat)
 
+        # If the checksum is not stored, this will raise a KeyError
         action = load_action_yaml(ff2._archiver.path)['action']['manifest']
         self.assertIn('md5sum', action[0].keys())
+        # This ensures that the checksum is the standard 32 character length
+        # and will catch empty strings or other weird values that could arise
+        self.assertEqual(len(action[0]['md5sum']), 32)
 
 
 class TestArtifactAPIUsage(unittest.TestCase):

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -127,7 +127,7 @@ class TestImports(unittest.TestCase):
 
         ff = transform([1, 2, 3,], to_type=IntSequenceFormat)
         ff2 = Artifact.import_data(IntSequence2, ff,
-                                   view_type='IntSequenceFormat')
+                                   view_type=IntSequenceFormat)
 
         action = load_action_yaml(ff2._archiver.path)['action']['manifest']
         self.assertIn('md5sum', action[0].keys())

--- a/qiime2/tests/test_artifact_api.py
+++ b/qiime2/tests/test_artifact_api.py
@@ -118,6 +118,20 @@ class TestImports(unittest.TestCase):
         with self.assertRaises(ImportError):
             importlib.reload(qiime2.plugins.dummy_plugin)
 
+    def test_import_base_format_stores_checksums(self):
+        from qiime2 import Artifact
+        from qiime2.core.testing.type import IntSequence2
+        from qiime2.core.testing.format import IntSequenceFormat
+        from qiime2.core.util import load_action_yaml
+        from qiime2.plugin.util import transform
+
+        ff = transform([1, 2, 3,], to_type=IntSequenceFormat)
+        ff2 = Artifact.import_data(IntSequence2, ff,
+                                   view_type='IntSequenceFormat')
+
+        action = load_action_yaml(ff2._archiver.path)['action']['manifest']
+        self.assertIn('md5sum', action[0].keys())
+
 
 class TestArtifactAPIUsage(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
fixes #756 

Still needs tests added. cc @ebolyen @Oddant1 does this seem reasonable?