### PR TITLE
Handle os.link being unsupported in duplicate

### DIFF
--- a/qiime2/tests/test_util.py
+++ b/qiime2/tests/test_util.py
@@ -15,6 +15,7 @@ import unittest.mock as mock
 import qiime2.util as util
 
 EXDEV = OSError(errno.EXDEV, "Invalid cross-device link")
+ENOTSUP = OSError(errno.ENOTSUP, "Operation not supported")
 EPERM = PermissionError(errno.EPERM, "unsafe operation e.g. using link wrong")
 EACCES = PermissionError(errno.EACCES, "insufficient r/w permissions")
 SECRET = "this is a secret for testing, don't tell anyone!"
@@ -71,6 +72,15 @@ class TestDuplicate(unittest.TestCase):
 
     @mock.patch('qiime2.util.os.link', side_effect=EPERM)
     def test_perm_error_EPERM(self, mocked_link):
+        util.duplicate(self.src, self.dst1)
+
+        assert mocked_link.called
+        assert os.path.exists(self.dst1)
+        with open(self.dst1) as fh:
+            self.assertEqual(fh.read(), SECRET)
+
+    @mock.patch('qiime2.util.os.link', side_effect=ENOTSUP)
+    def test_operation_not_supported(self, mocked_link):
         util.duplicate(self.src, self.dst1)
 
         assert mocked_link.called

--- a/qiime2/util.py
+++ b/qiime2/util.py
@@ -110,5 +110,7 @@ def duplicate(src, dst):
             shutil.copyfile(src, dst)
         elif e.errno == errno.EPERM:  # Permissions/ownership error
             shutil.copyfile(src, dst)
+        elif e.errno == errno.ENOTSUP:  # Operation not supported
+            shutil.copyfile(src, dst)
         else:
             raise


### PR DESCRIPTION
[Forum xref](https://forum.qiime2.org/t/qiime2-tmpdir-errno-45/31082/4)

Some file systems particularly on removable storage devices don't support symlinks. Duplicate needs to handle this and copy instead.
