### PR TITLE
MAINT: update test URL to non-deprecated address

### DIFF
--- a/qiime2/sdk/tests/test_usage.py
+++ b/qiime2/sdk/tests/test_usage.py
@@ -481,7 +481,7 @@ class TestExecutionUsage(TestCaseUsage):
             use.init_artifact_from_url('a', metadata_url)
 
     def test_init_metadata_from_url_error_on_non_metadata(self):
-        url = 'https://www.qiime2.org/'
+        url = 'https://docs.qiime2.org/'
         use = usage.ExecutionUsage()
 
         with self.assertRaisesRegex(ValueError, "Could not.*\n.*nized ID"):


### PR DESCRIPTION
The `test_init_metadata_from_url_error_on_non_metadata` test is failing due to https://www.qiime2.org/ no longer being an active URL. I've replaced the inactive link with the user docs URL.