### PR TITLE
MAINT: Update jupyter server command

### DIFF
--- a/qiime2/jupyter/template.py
+++ b/qiime2/jupyter/template.py
@@ -38,7 +38,7 @@ url = baseURL + url;
 fetch(url).then(function(res) {
     if (res.status === 404) {
         div.innerHTML = 'Install QIIME 2 Jupyter extension with:<br />' +
-                        '<code>jupyter serverextension enable --py qiime2' +
+                        '<code>jupyter server extension enable --py qiime2' +
                         ' --sys-prefix</code><br />then restart your server.' +
                         '<br /><br />(Interactive output not available on ' +
                         'static notebook viewer services like nbviewer.)';


### PR DESCRIPTION
`jupyter serverextension` has been deprecated. I noticed this while working with a new QIIME2 installation:

```
(qiime2) yoshiki:~$ jupyter serverextension enable --py qiime2 --sys-prefix
usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
               [--paths] [--json] [--debug]
               [subcommand]

Jupyter: Interactive Computing

positional arguments:
  subcommand     the subcommand to launch

optional arguments:
  -h, --help     show this help message and exit
  --version      show the versions of core jupyter packages and exit
  --config-dir   show Jupyter config dir
  --data-dir     show Jupyter data dir
  --runtime-dir  show Jupyter runtime dir
  --paths        show all Jupyter paths. Add --json for machine-readable
                 format.
  --json         output paths as machine-readable json
  --debug        output debug information about paths

Available subcommands: dejavu events execute kernel kernelspec lab
labextension labhub migrate nbclassic nbconvert notebook run server
troubleshoot trust

Jupyter command `jupyter-serverextension` not found.
```

The correct command is now `jupyter server extension ...`.