### PR TITLE
Disallow List output registration

### DIFF
--- a/qiime2/core/type/signature.py
+++ b/qiime2/core/type/signature.py
@@ -309,6 +309,11 @@ class PipelineSignature:
                     "Visualization, not %r"
                     % (output_name, spec.qiime_type))
 
+            if spec.qiime_type.name == "List":
+                raise TypeError(
+                    f"Output '{output_name}' has been registered as a 'List', "
+                    "please register it as a 'Collection'")
+
             if not isinstance(spec.qiime_type, (TypeVarExp, TypeExp)):
                 raise TypeError(
                     "Output %r must be a complete type expression, not %r"

--- a/qiime2/plugin/tests/test_plugin.py
+++ b/qiime2/plugin/tests/test_plugin.py
@@ -430,6 +430,24 @@ class TestPlugin(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 assert_no_nans_in_tables(fh)
 
+    def test_register_list_output(self):
+        def bad_function() -> list:
+            pass
+
+        with self.assertRaisesRegex(TypeError,
+                                    "'bad_output'.*'List'.*'Collection'.*"):
+            self.plugin.methods.register_function(
+                function=bad_function,
+                inputs={},
+                parameters={},
+                outputs={
+                    'bad_output': qiime2.plugin.List[IntSequence1]
+                },
+                name='Output is registered as returning a List which is bad.',
+                description='Output is registered as returning a List which is'
+                            ' bad.'
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Registering a `List` return type is meaningless because we will always write a `Collection` in the end. Disallowing this fell through the cracks before.

bokulich-lab/q2-moshpit#205
