### PR TITLE
MAINT: `pkg_resources` deprecation

### DIFF
--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -10,7 +10,8 @@ import os
 import time
 import collections
 import collections.abc
-import pkg_resources
+import platform
+import importlib.metadata
 import uuid
 import copy
 import shutil
@@ -373,8 +374,14 @@ class ProvenanceCapture:
         return ForwardRef('environment:plugins:' + plugin.name)
 
     def capture_env(self):
-        return collections.OrderedDict(
-            (d.project_name, d.version) for d in pkg_resources.working_set)
+        env = collections.OrderedDict()
+
+        for pkg_list in importlib.metadata.packages_distributions().values():
+            for pkg in pkg_list:
+                version = importlib.metadata.version(pkg)
+                env[pkg] = version
+
+        return env
 
     def transformation_recorder(self, name):
         section = self.transformers[name] = []
@@ -453,7 +460,7 @@ class ProvenanceCapture:
 
     def make_env_section(self):
         env = collections.OrderedDict()
-        env['platform'] = pkg_resources.get_build_platform()
+        env['platform'] = platform.platform()
         # There is a trailing whitespace in sys.version, strip so that YAML can
         # use literal formatting.
         env['python'] = LiteralString('\n'.join(line.strip() for line in

--- a/qiime2/core/archive/provenance.py
+++ b/qiime2/core/archive/provenance.py
@@ -374,14 +374,10 @@ class ProvenanceCapture:
         return ForwardRef('environment:plugins:' + plugin.name)
 
     def capture_env(self):
-        env = collections.OrderedDict()
-
-        for pkg_list in importlib.metadata.packages_distributions().values():
-            for pkg in pkg_list:
-                version = importlib.metadata.version(pkg)
-                env[pkg] = version
-
-        return env
+        return collections.OrderedDict(
+            (d.metadata["Name"], d.metadata["Version"]) for d in
+            importlib.metadata.distributions()
+        )
 
     def transformation_recorder(self, name):
         section = self.transformers[name] = []
@@ -468,7 +464,13 @@ class ProvenanceCapture:
         env['framework'] = self.make_software_entry(
             qiime2.__version__, qiime2.__website__, self._framework_citations)
         env['plugins'] = self.plugins
-        env['python-packages'] = self.capture_env()
+
+        # sort pkgs alphabetically, ignoring upper/lower casing
+        unsorted_packages = self.capture_env()
+        sorted_packages = collections.OrderedDict(
+            sorted(unsorted_packages.items(), key=lambda x: x[0].lower())
+        )
+        env['python-packages'] = sorted_packages
 
         return env
 

--- a/qiime2/core/archive/provenance_lib/replay.py
+++ b/qiime2/core/archive/provenance_lib/replay.py
@@ -10,7 +10,7 @@ from bibtexparser.bwriter import BibTexWriter
 import networkx as nx
 import os
 import pathlib
-import pkg_resources
+import importlib.resources
 import shutil
 import tempfile
 from uuid import uuid4
@@ -1370,10 +1370,8 @@ def dedupe_citations(citations: List[Dict]) -> List[Dict]:
 
         if 'framework|qiime2' in citation_id:
             if not is_framework_cited:
-                root = pkg_resources.resource_filename('qiime2', '.')
-                root = os.path.abspath(root)
-                path = os.path.join(root, 'citations.bib')
-                with open(path) as bibtex_file:
+                with importlib.resources.open_text(
+                        'qiime2', 'citations.bib') as bibtex_file:
                     q2_entry = bp.load(bibtex_file).entries.pop()
 
                 q2_entry['ID'] = citation_id

--- a/qiime2/core/archive/provenance_lib/usage_drivers.py
+++ b/qiime2/core/archive/provenance_lib/usage_drivers.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 from datetime import datetime
 from importlib.metadata import metadata
-import pkg_resources
+import importlib.resources
 import textwrap
 from typing import Any, Callable, List
 
@@ -116,14 +116,14 @@ def build_footer(dag: ProvDAG, boundary: str) -> List[str]:
 class ReplayPythonUsage(ArtifactAPIUsage):
     shebang = '#!/usr/bin/env python'
     header_boundary = '# ' + ('-' * 77)
-    copyright = pkg_resources.resource_string(
-        'qiime2.core.archive.provenance_lib',
-        'assets/copyright_note.txt'
-    ).decode('utf-8').split('\n')
-    how_to = pkg_resources.resource_string(
-        'qiime2.core.archive.provenance_lib',
-        'assets/python_howto.txt'
-    ).decode('utf-8').split('\n')
+    copyright = importlib.resources.read_text(
+        'qiime2.core.archive.provenance_lib.assets',
+        'copyright_note.txt'
+        ).split('\n')
+    how_to = importlib.resources.read_text(
+        'qiime2.core.archive.provenance_lib.assets',
+        'python_howto.txt'
+        ).split('\n')
 
     def __init__(
         self,

--- a/qiime2/core/cite.py
+++ b/qiime2/core/cite.py
@@ -8,7 +8,7 @@
 
 import os
 from typing import Union, Optional, IO
-import pkg_resources
+import importlib.resources
 import collections
 
 import bibtexparser as bp
@@ -56,16 +56,17 @@ class Citations(collections.OrderedDict):
         -------
         Citations
         """
-        if package is not None:
-            root = pkg_resources.resource_filename(package, '.')
-            root = os.path.abspath(root)
-            path = os.path.join(root, path)
-
         parser = bp.bparser.BibTexParser()
         # Downstream tooling is much easier with unicode. For actual latex
         # users, use the modern biber backend instead of bibtex
         parser.customization = bp.customization.convert_to_unicode
-        with open(path) as fh:
+
+        if package is not None:
+            file = importlib.resources.open_text(package, path)
+        else:
+            file = open(path)
+
+        with file as fh:
             try:
                 db = bp.load(fh, parser=parser)
             except Exception as e:

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -8,7 +8,7 @@
 
 import collections
 import os
-import pkg_resources
+import importlib.metadata
 import enum
 
 import qiime2.core.type
@@ -42,7 +42,7 @@ class PluginManager:
         yielded.
 
         """
-        for entry_point in pkg_resources.iter_entry_points(
+        for entry_point in importlib.metadata.entry_points(
                 group=cls.entry_point_group):
             if 'QIIMETEST' in os.environ:
                 if entry_point.name in ('dummy-plugin', 'other-plugin'):
@@ -100,8 +100,8 @@ class PluginManager:
             # These are all dependent loops, each requires the loop above it to
             # be completed.
             for entry_point in self.iter_entry_points():
-                project_name = entry_point.dist.project_name
-                package = entry_point.module_name.split('.')[0]
+                project_name = entry_point.name
+                package = entry_point.value.split('.')[0]
                 plugin = entry_point.load()
 
                 self.add_plugin(plugin, package, project_name,

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import re
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 from typing import Dict, TYPE_CHECKING
 
 import qiime2.sdk
@@ -181,6 +181,6 @@ def get_available_usage_drivers() -> Dict[str, 'UsageDriver']:
         themselves).
     '''
     return {
-        entry_point.name: entry_point.resolve() for entry_point in
-        iter_entry_points(group='qiime2.usage_drivers')
+        entry_point.name: entry_point.load() for entry_point in
+        entry_points(group='qiime2.usage_drivers')
     }


### PR DESCRIPTION
first pass at removing `pkg_resources` from the framework and replacing it with the `importlib.*` equivalent actions.