### PR TITLE
Refactor locking

### DIFF
--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1256,7 +1256,7 @@ class Cache:
         Returns
         -------
         set[str]
-            All of the keys in the cache. Just the names now what they refer
+            All of the keys in the cache. Just the names not what they refer
             to.
         """
         return set(os.listdir(self.keys))

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -695,9 +695,9 @@ class Cache:
         return Pool(self, reuse=True)
 
     def _create_collection_pool(self, ref_collection, key):
-        pool = Pool(self, name=key, reuse=False)
         self._register_key(
             key, key, pool=True, collection=ref_collection)
+        pool = Pool(self, name=key, reuse=False)
 
         return pool
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -823,21 +823,22 @@ class Cache:
         current_process_pools = self.get_processes()
         # We need to get the keys last. This ensures that when we go through
         # the data we got and remove any unreferenced data we aren't removing
-        # data that was added by keys we didn't see
-        current_keys = self.get_keys()
+        # data that was added by keys we didn't see/
+        #
+        # This is the only part of the process that does need to lock to ensure
+        # the keys we get are consistent. It locks inside of get_and_read_keys
+        current_keys = self.get_and_read_keys()
 
         for key in current_keys:
-            loaded_key = self.read_key(key)
-
-            if (data := loaded_key.get('data')) is not None:
+            if (data := key.get('data')) is not None:
                 referenced_data.add(data)
-            elif (pool := loaded_key.get('pool')) is not None:
+            elif (pool := key.get('pool')) is not None:
                 referenced_pools.add(pool)
             # This really should never be happening unless someone messes
             # with things manually
             else:
-                raise ValueError(f"The key '{key}' in the cache '{self.path}'"
-                                 " does not point to anything")
+                raise ValueError(f"The key '{key.get('origin')}' in the cache"
+                                 f" '{self.path}' does not point to anything")
 
         # Add references to data in process pools
         for process_pool in current_process_pools:
@@ -1334,6 +1335,25 @@ class Cache:
             to.
         """
         return set(os.listdir(self.keys))
+
+    def get_and_read_keys(self):
+        """Returns a list of all of the keys in the cache read with
+        yaml.safe_load
+
+        Returns
+        -------
+        list[dict]
+            All of the read keys in the cache
+        """
+        read_keys = []
+
+        with self.lock:
+            keys = self.get_keys()
+            for key in keys:
+                read_key = self.read_key(key)
+                read_keys.append(read_key)
+
+        return read_keys
 
     @property
     def lockfile(self):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -716,28 +716,14 @@ class Cache:
             self._register_key(key, pool_name, pool=True)
 
     def garbage_collection(self):
-        """Runs garbage collection on the cache in the following steps:
+        """Locks the cache then runs garbage collection ensuring all cache
+        entries that can be safely removed are safely removed.
 
-        **1.** Iterate over all keys and log all data and pools referenced by
-        the keys.
-
-        **2.** Iterate over all named pools and delete any that were not
-        referred to by a key while logging all data in pools that were referred
-        to by keys.
-
-        **3.** Iterate over all process pools and log all data they refer to.
-
-        **4.** Iterate over all data and remove any that was not referenced.
-
-        This process destroys data and named pools that do not have keys along
-        with process pools older than the process_pool_lifespan on the cache
-        which defaults to 45 days.
-
-        It removes keys and warns the user about the removal if the data
-        referenced by the keys does not exist.
-
-        We lock out other processes and threads from accessing the cache while
-        garbage collecting to ensure the cache remains in a consistent state.
+        Note
+        ----
+        Can potentially hog the lock for a very long time. In general,
+        quick_garbage_collection should be preferred for automatic collection,
+        and this should only be run manually.
         """
         # NOTE: The only real addition the locked version gives us is removal
         # of dangling references. Other than that, the quick version ought to
@@ -771,7 +757,7 @@ class Cache:
         current_process_pools = self._get_processes()
 
         # This is the only part of the process that does need to lock to ensure
-        # the keys we get are consistent. It locks inside of get_and_read_keys
+        # the keys we get are consistent. It locks inside of get_and_read_keys.
         current_keys = self.get_and_read_keys()
 
         self._garbage_collection(current_keys, current_pools,
@@ -780,6 +766,30 @@ class Cache:
 
     def _garbage_collection(self, current_keys, current_pools,
                             current_process_pools, current_data, locked):
+        """Runs garbage collection on the cache in the following steps:
+
+        **1.** Iterate over all keys and log all data and pools referenced by
+        the keys.
+
+        **2.** Iterate over all named pools and delete any that were not
+        referred to by a key while logging all data in pools that were referred
+        to by keys.
+
+        **3.** Iterate over all process pools and log all data they refer to.
+        Remove any that are older than the indicated lifespan.
+
+        **4.** Iterate over all data and remove any that was not referenced.
+
+        This process destroys data and named pools that do not have keys along
+        with process pools older than the process_pool_lifespan on the cache
+        which defaults to 45 days.
+
+        Locked Differences
+        ------------------
+
+        When locked, it removes keys and warns the user about the removal if
+        the data referenced by the keys does not exist. Same for pool symlinks
+        """
         referenced_data = set()
         referenced_pools = set()
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -243,7 +243,7 @@ def _exit_cleanup():
                 cache.lock.__exit__()
 
         if removed:
-            cache.unlocked_garbage_collection()
+            cache.quick_garbage_collection()
 
 
 def monitor_thread(cache_dir, is_done):
@@ -801,7 +801,7 @@ class Cache:
                     set_permissions(target, None, USER_GROUP_RWX)
                     shutil.rmtree(target)
 
-    def unlocked_garbage_collection(self):
+    def quick_garbage_collection(self):
         """ Runs a stripped down best effort garbage collection without
         locking. This garbage collection may not get everything that needs
         collected, but it won't trash anything it shouldn't and it won't hog
@@ -1150,7 +1150,7 @@ class Cache:
         >>> # in memory, but it does have the same uuid as "saved_artifact."
         >>> cache.get_data() == set([str(artifact.uuid)])
         True
-        >>> cache.unlocked_garbage_collection()
+        >>> cache.quick_garbage_collection()
         >>> # Now it is gone
         >>> cache.get_data() == set()
         True
@@ -1163,7 +1163,7 @@ class Cache:
                 raise KeyError(f"The cache '{self.path}' does not contain the"
                                f" key '{key}'") from e
 
-            self.unlocked_garbage_collection()
+            self.quick_garbage_collection()
 
     def clear_lock(self):
         """Clears the flufl lock on the cache. This exists in case something
@@ -1797,7 +1797,7 @@ class Pool:
         >>> # in memory, but it does have the same uuid as "pool_artifact."
         >>> cache.get_data() == set([str(artifact.uuid)])
         True
-        >>> cache.unlocked_garbage_collection()
+        >>> cache.quick_garbage_collection()
         >>> # Now it is gone
         >>> cache.get_data() == set()
         True
@@ -1816,7 +1816,7 @@ class Pool:
                     os.remove(target)
                 else:
                     shutil.rmtree(target)
-                self.cache.unlocked_garbage_collection()
+                self.cache.quick_garbage_collection()
 
     def get_data(self):
         """Returns a set of all data in the pool.

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1356,7 +1356,7 @@ class Cache:
         keys = self._get_keys()
         for key in keys:
             try:
-                read_key = self.read_key(key)
+                read_key = self._read_key(key)
             except KeyError:
                 # If we aren't locked we don't care if the key didn't exist.
                 # Could happen since we didn't lock

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -729,7 +729,7 @@ class Cache:
         # of dangling references. Other than that, the quick version ought to
         # be just about equivalent...
         with self.lock:
-            current_keys = self.get_and_read_keys()
+            current_keys = self._get_and_read_keys(locked=True)
             current_pools = self._get_pools()
             current_process_pools = self._get_processes()
             current_data = self._get_data()
@@ -755,10 +755,7 @@ class Cache:
         current_data = self._get_data()
         current_pools = self._get_pools()
         current_process_pools = self._get_processes()
-
-        # This is the only part of the process that does need to lock to ensure
-        # the keys we get are consistent. It locks inside of get_and_read_keys.
-        current_keys = self.get_and_read_keys()
+        current_keys = self._get_and_read_keys(locked=False)
 
         self._garbage_collection(current_keys, current_pools,
                                  current_process_pools, current_data,
@@ -1004,12 +1001,15 @@ class Cache:
             If the key does not exists in the cache.
         """
         with self.lock:
-            try:
-                with open(self.keys / key) as fh:
-                    return yaml.safe_load(fh)
-            except FileNotFoundError as e:
-                raise KeyError(f"The cache '{self.path}' does not contain the "
-                               f"key '{key}'") from e
+            return self._read_key(key)
+
+    def _read_key(self, key):
+        try:
+            with open(self.keys / key) as fh:
+                return yaml.safe_load(fh)
+        except FileNotFoundError as e:
+            raise KeyError(f"The cache '{self.path}' does not contain the "
+                           f"key '{key}'") from e
 
     def load(self, key):
         """Loads the data pointed to by a key. Will defer to
@@ -1342,7 +1342,7 @@ class Cache:
         """
         return set(os.listdir(self.keys))
 
-    def get_and_read_keys(self):
+    def _get_and_read_keys(self, locked):
         """Returns a list of all of the keys in the cache read with
         yaml.safe_load
 
@@ -1353,10 +1353,16 @@ class Cache:
         """
         read_keys = []
 
-        with self.lock:
-            keys = self.get_keys()
-            for key in keys:
+        keys = self._get_keys()
+        for key in keys:
+            try:
                 read_key = self.read_key(key)
+            except KeyError:
+                # If we aren't locked we don't care if the key didn't exist.
+                # Could happen since we didn't lock
+                if locked:
+                    raise
+            else:
                 read_keys.append(read_key)
 
         return read_keys

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -669,8 +669,9 @@ class Cache:
         True
         >>> test_dir.cleanup()
         """
-        pool = Pool(self, name=key, reuse=reuse)
-        self._register_key(key, key, pool=True)
+        with self.lock:
+            self._register_key(key, key, pool=True)
+            pool = Pool(self, name=key, reuse=reuse)
 
         return pool
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -783,6 +783,12 @@ class Cache:
         referenced_data = set()
         referenced_pools = set()
 
+        # If we aren't locked we can ignore rmtree errors. We may have tried to
+        # remove something someone else already removed. Don't care. If we are
+        # locked then we do care because no one else should be removing things
+        # we have kept track of
+        ignore_rmtree_errors = not locked
+
         # Walk over all keys and gather references
         for key in current_keys:
             # We do not check for dangling references here if we are unlocked
@@ -805,7 +811,8 @@ class Cache:
         # Walk over all pools and remove any that were not referenced
         for pool in current_pools:
             if pool not in referenced_pools:
-                shutil.rmtree(self.pools / pool, ignore_errors=not locked)
+                shutil.rmtree(self.pools / pool,
+                              ignore_errors=ignore_rmtree_errors)
             else:
                 for data in os.listdir(self.pools / pool):
                     # We still can't check for dangling references here when
@@ -832,7 +839,8 @@ class Cache:
 
             if time.time() - create_time >= self.process_pool_lifespan:
                 shutil.rmtree(
-                    self.processes / process_pool, ignore_errors=not locked)
+                    self.processes / process_pool,
+                    ignore_errors=ignore_rmtree_errors)
             else:
                 for data in os.listdir(self.processes / process_pool):
                     referenced_data.add(data.split('.')[0])
@@ -846,7 +854,7 @@ class Cache:
                 target = self.data / data
 
                 set_permissions(target, None, USER_GROUP_RWX)
-                shutil.rmtree(target, ignore_errors=not locked)
+                shutil.rmtree(target, ignore_errors=ignore_rmtree_errors)
 
     def _check_dangling_reference(self, data_path, key_path):
         """ If the data specified does not exist then we have a dangling

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1242,8 +1242,7 @@ class Cache:
             All of the data in the cache in the form of the top level
             directories which will be the uuids of the artifacts.
         """
-        with self.lock:
-            return set(os.listdir(self.data))
+        return set(os.listdir(self.data))
 
     @property
     def keys(self):
@@ -1260,8 +1259,7 @@ class Cache:
             All of the keys in the cache. Just the names now what they refer
             to.
         """
-        with self.lock:
-            return set(os.listdir(self.keys))
+        return set(os.listdir(self.keys))
 
     @property
     def lockfile(self):
@@ -1283,8 +1281,7 @@ class Cache:
         set[str]
             The names of all of the named pools in the cache.
         """
-        with self.lock:
-            return set(os.listdir(self.pools))
+        return set(os.listdir(self.pools))
 
     @property
     def processes(self):
@@ -1300,8 +1297,7 @@ class Cache:
         set[str]
             The names of all of the process pools in the cache.
         """
-        with self.lock:
-            return set(os.listdir(self.processes))
+        return set(os.listdir(self.processes))
 
     @property
     def version(self):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -222,6 +222,7 @@ def _exit_cleanup():
     """
     for cache in USED_CACHES:
         target = cache.processes / os.path.basename(cache.process_pool.path)
+        removed = False
 
         # There are several legitimate reasons the path could not exist. It
         # happens during our cache tests when the entire cache is nuked in the
@@ -237,9 +238,12 @@ def _exit_cleanup():
             try:
                 if os.path.exists(target):
                     shutil.rmtree(target)
-                    cache.unlocked_garbage_collection()
+                    removed = True
             finally:
                 cache.lock.__exit__()
+
+        if removed:
+            cache.unlocked_garbage_collection()
 
 
 def monitor_thread(cache_dir, is_done):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -695,9 +695,10 @@ class Cache:
         return Pool(self, reuse=True)
 
     def _create_collection_pool(self, ref_collection, key):
-        self._register_key(
-            key, key, pool=True, collection=ref_collection)
-        pool = Pool(self, name=key, reuse=False)
+        with self.lock:
+            self._register_key(
+                key, key, pool=True, collection=ref_collection)
+            pool = Pool(self, name=key, reuse=False)
 
         return pool
 
@@ -712,8 +713,9 @@ class Cache:
         keys : List[str]
             A list of all the keys to create referring to the pool.
         """
-        for key in keys:
-            self._register_key(key, pool_name, pool=True)
+        with self.lock:
+            for key in keys:
+                self._register_key(key, pool_name, pool=True)
 
     def garbage_collection(self):
         """Locks the cache then runs garbage collection ensuring all cache
@@ -929,7 +931,7 @@ class Cache:
             self._register_key(key, str(ref.uuid))
             self._copy_to_data(ref)
 
-        return self.load(key)
+            return self.load(key)
 
     def save_collection(self, ref_collection, key):
         """Saves a Collection to a pool in the cache with the given key. This

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -237,7 +237,7 @@ def _exit_cleanup():
             try:
                 if os.path.exists(target):
                     shutil.rmtree(target)
-                    cache.garbage_collection()
+                    cache.unlocked_garbage_collection()
             finally:
                 cache.lock.__exit__()
 
@@ -797,6 +797,76 @@ class Cache:
                     set_permissions(target, None, USER_GROUP_RWX)
                     shutil.rmtree(target)
 
+    def unlocked_garbage_collection(self):
+        """ Runs a stripped down best effort garbage collection without
+        locking. This garbage collection may not get everything that needs
+        collected, but it won't trash anything it shouldn't and it won't hog
+        the lock.
+
+        It is possible to run this safely without locking because we get the
+        data, then we get the pools, then we get the process pools, and THEN we
+        get the keys last. Since we always add the key to the pool/data before
+        adding the pool/data itself we may end seeing keys for data that has
+        not yet been added, but we will not see data that has not yet been
+        keyed.
+        """
+        referenced_data = set()
+        referenced_pools = set()
+
+        # The order here matters
+        current_data = self.get_data()
+        current_pools = self.get_pools()
+        current_process_pools = self.get_processes()
+        # We need to get the keys last. This ensures that when we go through
+        # the data we got and remove any unreferenced data we aren't removing
+        # data that was added by keys we didn't see
+        current_keys = self.get_keys()
+
+        for key in current_keys:
+            loaded_key = self.read_key(key)
+
+            if (data := loaded_key.get('data')) is not None:
+                referenced_data.add(data)
+            elif (pool := loaded_key.get('pool')) is not None:
+                referenced_pools.add(pool)
+            # This really should never be happening unless someone messes
+            # with things manually
+            else:
+                raise ValueError(f"The key '{key}' in the cache '{self.path}'"
+                                 " does not point to anything")
+
+        # Add references to data in process pools
+        for process_pool in current_process_pools:
+            # Pick the creation time out of the pool name of format
+            # <process-id>-<process-create-time>@<user>
+            create_time = float(process_pool.split('-')[1].split('@')[0])
+
+            if time.time() - create_time >= self.process_pool_lifespan:
+                shutil.rmtree(
+                    self.processes / process_pool, ignore_errors=True)
+            else:
+                for data in os.listdir(self.processes / process_pool):
+                    referenced_data.add(data.split('.')[0])
+
+        # Walk over all pools and remove any that were not referenced
+        for pool in current_pools:
+            if pool not in referenced_pools:
+                shutil.rmtree(self.pools / pool, ignore_errors=True)
+            else:
+                for data in os.listdir(self.pools / pool):
+                    referenced_data.add(data)
+
+        # Walk over all data and remove any that was not referenced
+        for data in current_data:
+            # If this assert is ever tripped something real bad happened
+            assert is_uuid4(data)
+
+            if data not in referenced_data:
+                target = self.data / data
+
+                set_permissions(target, None, USER_GROUP_RWX)
+                shutil.rmtree(target, ignore_errors=True)
+
     def _check_dangling_reference(self, data_path, key_path):
         """ If the data specified does not exist then we have a dangling
         reference and we warn them about it and remove the reference.
@@ -1075,7 +1145,7 @@ class Cache:
         >>> # in memory, but it does have the same uuid as "saved_artifact."
         >>> cache.get_data() == set([str(artifact.uuid)])
         True
-        >>> cache.garbage_collection()
+        >>> cache.unlocked_garbage_collection()
         >>> # Now it is gone
         >>> cache.get_data() == set()
         True
@@ -1088,7 +1158,7 @@ class Cache:
                 raise KeyError(f"The cache '{self.path}' does not contain the"
                                f" key '{key}'") from e
 
-            self.garbage_collection()
+            self.unlocked_garbage_collection()
 
     def clear_lock(self):
         """Clears the flufl lock on the cache. This exists in case something
@@ -1703,7 +1773,7 @@ class Pool:
         >>> # in memory, but it does have the same uuid as "pool_artifact."
         >>> cache.get_data() == set([str(artifact.uuid)])
         True
-        >>> cache.garbage_collection()
+        >>> cache.unlocked_garbage_collection()
         >>> # Now it is gone
         >>> cache.get_data() == set()
         True
@@ -1722,7 +1792,7 @@ class Pool:
                     os.remove(target)
                 else:
                     shutil.rmtree(target)
-                self.cache.garbage_collection()
+                self.cache.unlocked_garbage_collection()
 
     def get_data(self):
         """Returns a set of all data in the pool.

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -739,67 +739,18 @@ class Cache:
         We lock out other processes and threads from accessing the cache while
         garbage collecting to ensure the cache remains in a consistent state.
         """
-        referenced_pools = set()
-        referenced_data = set()
-
-        # Walk over keys and track all pools and data referenced
-        # This needs to be locked so we ensure that we don't have other threads
-        # or processes writing refs that we don't see leading to us deleting
-        # their data
+        # NOTE: The only real addition the locked version gives us is removal
+        # of dangling references. Other than that, the quick version ought to
+        # be just about equivalent...
         with self.lock:
-            for key in self.get_keys():
-                loaded_key = self.read_key(key)
+            current_keys = self.get_and_read_keys()
+            current_pools = self._get_pools()
+            current_process_pools = self._get_processes()
+            current_data = self._get_data()
 
-                # If the data/pool referenced by the key actually exists then
-                # track it. Otherwise remove the dangling reference
-                if (data := loaded_key.get('data')) is not None:
-                    if not self._check_dangling_reference(
-                            self.data / data, self.keys / key):
-                        referenced_data.add(data)
-                elif (pool := loaded_key.get('pool')) is not None:
-                    if not self._check_dangling_reference(
-                            self.pools / pool, self.keys / key):
-                        referenced_pools.add(pool)
-                # This really should never be happening unless someone messes
-                # with things manually
-                else:
-                    raise ValueError(f"The key '{key}' in the cache"
-                                     f" '{self.path}' does not point to"
-                                     " anything")
-
-            # Walk over pools and remove any that were not referred to by keys
-            # while tracking all data within those that were referenced
-            for pool in self.get_pools():
-                if pool not in referenced_pools:
-                    shutil.rmtree(self.pools / pool)
-                else:
-                    for data in os.listdir(self.pools / pool):
-                        if not self._check_dangling_reference(
-                                self.data / data, self.pools / pool / data):
-                            referenced_data.add(data)
-
-            # Add references to data in process pools
-            for process_pool in self.get_processes():
-                # Pick the creation time out of the pool name of format
-                # <process-id>-<process-create-time>@<user>
-                create_time = float(process_pool.split('-')[1].split('@')[0])
-
-                if time.time() - create_time >= self.process_pool_lifespan:
-                    shutil.rmtree(self.processes / process_pool)
-                else:
-                    for data in os.listdir(self.processes / process_pool):
-                        referenced_data.add(data.split('.')[0])
-
-            # Walk over all data and remove any that was not referenced
-            for data in self.get_data():
-                # If this assert is ever tripped something real bad happened
-                assert is_uuid4(data)
-
-                if data not in referenced_data:
-                    target = self.data / data
-
-                    set_permissions(target, None, USER_GROUP_RWX)
-                    shutil.rmtree(target)
+            self._garbage_collection(current_keys, current_pools,
+                                     current_process_pools, current_data,
+                                     locked=True)
 
     def quick_garbage_collection(self):
         """ Runs a stripped down best effort garbage collection without
@@ -810,37 +761,70 @@ class Cache:
         It is possible to run this safely without locking because we get the
         data, then we get the pools, then we get the process pools, and THEN we
         get the keys last. Since we always add the key to the pool/data before
-        adding the pool/data itself we may end seeing keys for data that has
+        adding the pool/data itself we may end up seeing keys for data that has
         not yet been added, but we will not see data that has not yet been
         keyed.
         """
-        referenced_data = set()
-        referenced_pools = set()
-
         # The order here matters
-        current_data = self.get_data()
-        current_pools = self.get_pools()
-        current_process_pools = self.get_processes()
-        # We need to get the keys last. This ensures that when we go through
-        # the data we got and remove any unreferenced data we aren't removing
-        # data that was added by keys we didn't see/
-        #
+        current_data = self._get_data()
+        current_pools = self._get_pools()
+        current_process_pools = self._get_processes()
+
         # This is the only part of the process that does need to lock to ensure
         # the keys we get are consistent. It locks inside of get_and_read_keys
         current_keys = self.get_and_read_keys()
 
+        self._garbage_collection(current_keys, current_pools,
+                                 current_process_pools, current_data,
+                                 locked=False)
+
+    def _garbage_collection(self, current_keys, current_pools,
+                            current_process_pools, current_data, locked):
+        referenced_data = set()
+        referenced_pools = set()
+
+        # Walk over all keys and gather references
         for key in current_keys:
+            # We do not check for dangling references here if we are unlocked
+            # because we could very easily see a key that does not yet have its
+            # data written since we write keys before linking data.
             if (data := key.get('data')) is not None:
-                referenced_data.add(data)
+                if not locked or not self._check_dangling_reference(
+                        self.data / data, self.keys / key.get('origin')):
+                    referenced_data.add(data)
             elif (pool := key.get('pool')) is not None:
-                referenced_pools.add(pool)
+                if not locked or not self._check_dangling_reference(
+                        self.pools / pool, self.keys / key.get('origin')):
+                    referenced_pools.add(pool)
             # This really should never be happening unless someone messes
             # with things manually
             else:
                 raise ValueError(f"The key '{key.get('origin')}' in the cache"
                                  f" '{self.path}' does not point to anything")
 
+        # Walk over all pools and remove any that were not referenced
+        for pool in current_pools:
+            if pool not in referenced_pools:
+                shutil.rmtree(self.pools / pool, ignore_errors=not locked)
+            else:
+                for data in os.listdir(self.pools / pool):
+                    # We still can't check for dangling references here when
+                    # not locked because the data could have been linked into
+                    # the pool and the data dir after we got the data dir
+                    if not locked or not self._check_dangling_reference(
+                            self.data / data, self.pools / pool / data):
+                        referenced_data.add(data)
+
         # Add references to data in process pools
+        #
+        # NOTE: It is conceivable in the quick GC that the process pool removal
+        # will happen while something is being written to the process pool. In
+        # theory we could remove a process pool out from under a process in
+        # fully locking GC as well. This shouldn't matter though because by
+        # default the process pool is only deleted like this after 45 days. If
+        # you have a process running longer than that
+        # 1. God help you
+        # 2. Increase the lifespan
         for process_pool in current_process_pools:
             # Pick the creation time out of the pool name of format
             # <process-id>-<process-create-time>@<user>
@@ -848,18 +832,10 @@ class Cache:
 
             if time.time() - create_time >= self.process_pool_lifespan:
                 shutil.rmtree(
-                    self.processes / process_pool, ignore_errors=True)
+                    self.processes / process_pool, ignore_errors=not locked)
             else:
                 for data in os.listdir(self.processes / process_pool):
                     referenced_data.add(data.split('.')[0])
-
-        # Walk over all pools and remove any that were not referenced
-        for pool in current_pools:
-            if pool not in referenced_pools:
-                shutil.rmtree(self.pools / pool, ignore_errors=True)
-            else:
-                for data in os.listdir(self.pools / pool):
-                    referenced_data.add(data)
 
         # Walk over all data and remove any that was not referenced
         for data in current_data:
@@ -870,7 +846,7 @@ class Cache:
                 target = self.data / data
 
                 set_permissions(target, None, USER_GROUP_RWX)
-                shutil.rmtree(target, ignore_errors=True)
+                shutil.rmtree(target, ignore_errors=not locked)
 
     def _check_dangling_reference(self, data_path, key_path):
         """ If the data specified does not exist then we have a dangling
@@ -1317,6 +1293,12 @@ class Cache:
             All of the data in the cache in the form of the top level
             directories which will be the uuids of the artifacts.
         """
+        with self.lock:
+            return self._get_data()
+
+    def _get_data(self):
+        """Get data without locking.
+        """
         return set(os.listdir(self.data))
 
     @property
@@ -1333,6 +1315,12 @@ class Cache:
         set[str]
             All of the keys in the cache. Just the names not what they refer
             to.
+        """
+        with self.lock:
+            return self._get_keys()
+
+    def _get_keys(self):
+        """Get keys without locking.
         """
         return set(os.listdir(self.keys))
 
@@ -1375,6 +1363,12 @@ class Cache:
         set[str]
             The names of all of the named pools in the cache.
         """
+        with self.lock:
+            return self._get_pools()
+
+    def _get_pools(self):
+        """Get pools without locking.
+        """
         return set(os.listdir(self.pools))
 
     @property
@@ -1390,6 +1384,12 @@ class Cache:
         -------
         set[str]
             The names of all of the process pools in the cache.
+        """
+        with self.lock:
+            return self._get_processes()
+
+    def _get_processes(self):
+        """Get process pools without locking.
         """
         return set(os.listdir(self.processes))
 


### PR DESCRIPTION
Create a minimal locking version of GC and refactor locking in the cache in general.

@misialq ran into an issue [on the forum](https://forum.qiime2.org/t/notlockederror-with-assemble-megahit-and-parsl/31831/9) that seems to be as a result of his very large cache on an NFS taking more than 10 minutes to run garbage collection.

That prompted this PR which seeks to reduce the amount of locking required by garbage collection and the cache in general. We will leave around the fully locked version of GC for deeper cleaning, but the version that runs frequently during normal execution will work on a more "best effort" basis removing some of the things that need removed while ensuring nothing that shouldn't be removed is deleted and the lock is held as briefly as possible.