### PR TITLE
expose get_cache as qiime2.get_cache

### DIFF
--- a/qiime2/__init__.py
+++ b/qiime2/__init__.py
@@ -10,7 +10,7 @@ from qiime2.sdk import Artifact, Visualization, ResultCollection
 from qiime2.metadata import (Metadata, MetadataColumn,
                              CategoricalMetadataColumn, NumericMetadataColumn)
 from qiime2.plugin import Citations
-from qiime2.core.cache import Cache, Pool
+from qiime2.core.cache import Cache, Pool, get_cache
 
 try:
     from ._version import __version__
@@ -26,7 +26,7 @@ __website__ = 'https://qiime2.org'
 
 __all__ = ['Artifact', 'Visualization', 'ResultCollection', 'Metadata',
            'MetadataColumn', 'CategoricalMetadataColumn',
-           'NumericMetadataColumn', 'Cache', 'Pool']
+           'NumericMetadataColumn', 'Cache', 'Pool', 'get_cache']
 
 
 # Used by `jupyter serverextension enable`

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -17,7 +17,6 @@ from qiime2.core.type import (
     is_semantic_type, is_primitive_type, is_collection_type, is_metadata_type,
     is_visualization_type, interrogate_collection_type, parse_primitive,
     is_union, is_metadata_column_type, is_parallel_type)
-import qiime2.core.cache as core_cache
 
 if TYPE_CHECKING:
     from qiime2.sdk.usage import UsageDriver
@@ -185,10 +184,3 @@ def get_available_usage_drivers() -> Dict[str, 'UsageDriver']:
         entry_point.name: entry_point.load() for entry_point in
         entry_points(group='qiime2.usage_drivers')
     }
-
-
-def get_cache():
-    '''
-    This is an alias of qiime2.core.cache.get_cache to be used by plugin devs.
-    '''
-    return core_cache.get_cache()

--- a/qiime2/sdk/util.py
+++ b/qiime2/sdk/util.py
@@ -17,6 +17,7 @@ from qiime2.core.type import (
     is_semantic_type, is_primitive_type, is_collection_type, is_metadata_type,
     is_visualization_type, interrogate_collection_type, parse_primitive,
     is_union, is_metadata_column_type, is_parallel_type)
+import qiime2.core.cache as core_cache
 
 if TYPE_CHECKING:
     from qiime2.sdk.usage import UsageDriver
@@ -184,3 +185,10 @@ def get_available_usage_drivers() -> Dict[str, 'UsageDriver']:
         entry_point.name: entry_point.load() for entry_point in
         entry_points(group='qiime2.usage_drivers')
     }
+
+
+def get_cache():
+    '''
+    This is an alias of qiime2.core.cache.get_cache to be used by plugin devs.
+    '''
+    return core_cache.get_cache()


### PR DESCRIPTION
`get_cache` is a useful function for people outside the framework to call; it should be exposed outside of core.