### PR TITLE
MAINT: No more mass aliasing in process pools

### DIFF
--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -379,25 +379,23 @@ class Archiver:
                 cls._futuristic_archive_error(filepath, archive)
 
             archive.mount(path)
-            process_alias, data_path = \
-                cache._rename_to_data(archive.uuid, path)
+            data_path = cache._rename_to_data(archive.uuid, path)
             rec = ArchiveRecord(
                 data_path, data_path / archive.VERSION_FILE, archive.uuid,
                 archive.version, archive.framework_version)
-            ref = cls(data_path, process_alias, Format(rec), cache)
+            ref = cls(data_path, data_path, Format(rec), cache)
             return ref
         # We really just want to kill these paths if anything at all goes wrong
         # Exceptions including keyboard interrupts are re-raised
         except:  # noqa: E722
             cls._destroy_temp_path(archive.uuid)
-            if 'process_alias' in vars():
-                cls._destroy_temp_path(process_alias)
+            if 'data_path' in vars():
+                cls._destroy_temp_path(data_path)
             raise
 
     @classmethod
     def load_raw(cls, filepath, cache):
         archive = cls.get_archive(filepath)
-        process_alias = cache._alias(str(archive.uuid))
 
         Format = cls.get_format_class(archive.version)
         if Format is None:
@@ -406,7 +404,7 @@ class Archiver:
         path = pathlib.Path(filepath)
 
         rec = archive.mount(path)
-        ref = cls(path, process_alias, Format(rec), cache)
+        ref = cls(path, archive.uuid, Format(rec), cache)
 
         return ref
 

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -421,18 +421,18 @@ class Archiver:
             Format.write(rec, type, format, data_initializer,
                          provenance_capture)
 
-            process_alias, data_path = cache._rename_to_data(uuid, path)
+            data_path = cache._rename_to_data(uuid, path)
             rec = ArchiveRecord(data_path, data_path / _Archive.VERSION_FILE,
                                 uuid, cls.CURRENT_FORMAT_VERSION,
                                 qiime2.__version__)
-            ref = cls(data_path, process_alias, Format(rec), cache)
+            ref = cls(data_path, data_path, Format(rec), cache)
             return ref
         # We really just want to kill these paths if anything at all goes wrong
         # Exceptions including keyboard interrupts are re-raised
         except:  # noqa: E722
             cls._destroy_temp_path(uuid)
-            if 'process_alias' in vars():
-                cls._destroy_temp_path(process_alias)
+            if 'data_path' in vars():
+                cls._destroy_temp_path(data_path)
             raise
 
     def __init__(self, path, process_alias, fmt, cache):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1825,6 +1825,7 @@ class Pool:
                 # would be better to create an action that produces the
                 # artifact rather than using make_artifact
                 if 'type' in action and action['type'] == 'import':
+                    os.remove(self.path / alias)
                     continue
 
                 plugin_action = action['plugin'] + ':' + action['action']

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1214,30 +1214,6 @@ class Cache:
         shutil.rmtree(alias)
         return process_alias, dest
 
-    def _alias(self, uuid):
-        """Creates an alias and a symlink for the artifact with the given uuid
-        in both the cache's process pool and its named pool if it has one.
-
-        Parameters
-        ----------
-        uuid : str or uuid4
-            The uuid of the artifact we are aliasing.
-
-        Returns
-        -------
-        str
-            The alias we created for the artifact.
-        """
-        with self.lock:
-            process_alias = self.process_pool._alias(uuid)
-            self.process_pool._make_symlink(uuid, process_alias)
-
-            # Named pool links are not aliased
-            if self.named_pool is not None:
-                self.named_pool._make_symlink(uuid, uuid)
-
-        return process_alias
-
     def _deallocate(self, symlink):
         """Removes a specific symlink from the process pool. This happens when
         an archiver goes out of scope. We remove that archiver's reference to
@@ -1570,46 +1546,6 @@ class Pool:
 
         self.cache._copy_to_data(ref)
         return self.load(ref)
-
-    def _alias(self, uuid):
-        """We may want to create multiple references to a single artifact in a
-        process pool, but we cannot create multiple symlinks with the same
-        name, so we take the uuid and add a random number to the end of it and
-        use uuid.random_number as the name of the symlink. This means when you
-        look in a process pool you may see the same uuid multiple times with
-        different random numbers appended. This means there are multiple
-        references to the artifact with that uuid in the process poole because
-        it was loaded multiple times in the process.
-
-        Parameters
-        ----------
-        uuid : str or uuid4
-            The uuid we are creating an alias for.
-
-        Returns
-        -------
-        str
-            The aliased uuid.
-
-        """
-        MAX_RETRIES = 5
-
-        uuid = str(uuid)
-        with self.cache.lock:
-            for _ in range(MAX_RETRIES):
-                alias = uuid + '.' + str(randint(0, maxsize))
-                path = self.path / alias
-
-                # os.path.exists returns false on broken symlinks
-                if not os.path.exists(path) and not os.path.islink(path):
-                    break
-            else:
-                raise ValueError(f'Too many collisions ({MAX_RETRIES}) '
-                                 'occurred while trying to save artifact '
-                                 f'<{uuid}> to process pool {self.path}. It '
-                                 'is likely you have attempted to load the '
-                                 'same artifact a very large number of times.')
-        return alias
 
     def _allocate(self, uuid):
         """Allocate an empty directory under the process pool to extract to.

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1206,13 +1206,12 @@ class Cache:
             # Create a new alias whether we renamed or not because this is
             # still loading a new reference to the data even if the data is
             # already there
-            process_alias = self._alias(uuid)
 
         # Remove the aliased directory above the one we renamed. We need to do
         # this whether we renamed or not because we aren't renaming this
         # directory but the one beneath it
         shutil.rmtree(alias)
-        return process_alias, dest
+        return dest
 
     def _deallocate(self, symlink):
         """Removes a specific symlink from the process pool. This happens when
@@ -1537,12 +1536,8 @@ class Pool:
         >>> test_dir.cleanup()
         """
         uuid = str(ref.uuid)
-        if self.path == self.cache.process_pool.path:
-            alias = self._alias(uuid)
-        else:
-            alias = uuid
 
-        self._make_symlink(uuid, alias)
+        self._make_symlink(uuid, uuid)
 
         self.cache._copy_to_data(ref)
         return self.load(ref)
@@ -1747,8 +1742,7 @@ class Pool:
                 # Make sure the process that indexed this artifact will still
                 # have access to it if it is otherwise removed from the cache
                 # by retaining a reference to it in our process pool
-                alias = self.cache.process_pool._alias(_uuid)
-                self.cache.process_pool._make_symlink(_uuid, alias)
+                self.cache.process_pool._make_symlink(_uuid, _uuid)
 
                 # Get action.yaml from this artifact's provenance
                 path = self.cache.data / _uuid
@@ -1761,7 +1755,7 @@ class Pool:
                 # would be better to create an action that produces the
                 # artifact rather than using make_artifact
                 if 'type' in action and action['type'] == 'import':
-                    os.remove(self.path / alias)
+                    os.remove(self.path / _uuid)
                     continue
 
                 plugin_action = action['plugin'] + ':' + action['action']

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1213,6 +1213,30 @@ class Cache:
         shutil.rmtree(alias)
         return dest
 
+    def _alias(self, uuid):
+        """Creates an alias and a symlink for the artifact with the given uuid
+        in both the cache's process pool and its named pool if it has one.
+
+        Parameters
+        ----------
+        uuid : str or uuid4
+            The uuid of the artifact we are aliasing.
+
+        Returns
+        -------
+        str
+            The alias we created for the artifact.
+        """
+        with self.lock:
+            process_alias = self.process_pool._alias(uuid)
+            self.process_pool._make_symlink(uuid, process_alias)
+
+            # Named pool links are not aliased
+            if self.named_pool is not None:
+                self.named_pool._make_symlink(uuid, uuid)
+
+        return process_alias
+
     def _deallocate(self, symlink):
         """Removes a specific symlink from the process pool. This happens when
         an archiver goes out of scope. We remove that archiver's reference to
@@ -1541,6 +1565,46 @@ class Pool:
 
         self.cache._copy_to_data(ref)
         return self.load(ref)
+
+    def _alias(self, uuid):
+        """We may want to create multiple references to a single artifact in a
+        process pool, but we cannot create multiple symlinks with the same
+        name, so we take the uuid and add a random number to the end of it and
+        use uuid.random_number as the name of the symlink. This means when you
+        look in a process pool you may see the same uuid multiple times with
+        different random numbers appended. This means there are multiple
+        references to the artifact with that uuid in the process poole because
+        it was loaded multiple times in the process.
+
+        Parameters
+        ----------
+        uuid : str or uuid4
+            The uuid we are creating an alias for.
+
+        Returns
+        -------
+        str
+            The aliased uuid.
+
+        """
+        MAX_RETRIES = 5
+
+        uuid = str(uuid)
+        with self.cache.lock:
+            for _ in range(MAX_RETRIES):
+                alias = uuid + '.' + str(randint(0, maxsize))
+                path = self.path / alias
+
+                # os.path.exists returns false on broken symlinks
+                if not os.path.exists(path) and not os.path.islink(path):
+                    break
+            else:
+                raise ValueError(f'Too many collisions ({MAX_RETRIES}) '
+                                 'occurred while trying to save artifact '
+                                 f'<{uuid}> to process pool {self.path}. It '
+                                 'is likely you have attempted to load the '
+                                 'same artifact a very large number of times.')
+        return alias
 
     def _allocate(self, uuid):
         """Allocate an empty directory under the process pool to extract to.


### PR DESCRIPTION
I don't think we should need to keep around multiple aliases for a given artifact in a process pool anymore now that we are no longer scoping Contexts 
