### PR TITLE
MAINT: Remove multiple aliases from process pools

### DIFF
--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -291,8 +291,8 @@ class Archiver:
         from qiime2.core.cache import get_cache
 
         cache = get_cache()
-        path = cache.process_pool._allocate(uuid)
-        return path, cache
+        path, created = cache.process_pool._allocate(uuid)
+        return path, cache, created
 
     # TODO: I think we may want to remove this method entirely
     @classmethod
@@ -372,19 +372,29 @@ class Archiver:
     @classmethod
     def load(cls, filepath):
         archive = cls.get_archive(filepath)
-        path, cache = cls._make_temp_path(archive.uuid)
+        path, cache, created = cls._make_temp_path(archive.uuid)
 
-        Format = cls.get_format_class(archive.version)
-        if Format is None:
-            cls._futuristic_archive_error(filepath, archive)
+        with cache.lock:
+            try:
+                Format = cls.get_format_class(archive.version)
+                if Format is None:
+                    cls._futuristic_archive_error(filepath, archive)
 
-        archive.mount(path)
-        data_path = cache._rename_to_data(archive.uuid, path)
-        rec = ArchiveRecord(
-            data_path, data_path / archive.VERSION_FILE, archive.uuid,
-            archive.version, archive.framework_version)
-        ref = cls(data_path, archive.uuid, Format(rec), cache)
-        return ref
+                archive.mount(path)
+                data_path = cache._rename_to_data(archive.uuid, path)
+                rec = ArchiveRecord(
+                    data_path, data_path / archive.VERSION_FILE, archive.uuid,
+                    archive.version, archive.framework_version)
+                ref = cls(data_path, archive.uuid, Format(rec), cache)
+                return ref
+            # If we created the path, we really just want to kill it if
+            # anything at all goes wrong. Exceptions including keyboard
+            # interrupts are re-raised
+            except:  # noqa: E722
+                if created:
+                    cls._destroy_temp_path(archive.uuid)
+                raise
+
 
     @classmethod
     def load_raw(cls, filepath, cache):
@@ -405,21 +415,31 @@ class Archiver:
     @classmethod
     def from_data(cls, type, format, data_initializer, provenance_capture):
         uuid = _uuid.uuid4()
-        path, cache = cls._make_temp_path(uuid)
+        path, cache, created = cls._make_temp_path(uuid)
 
-        rec = _Archive.setup(uuid, path, cls.CURRENT_FORMAT_VERSION,
-                             qiime2.__version__)
+        with cache.lock:
+            try:
+                rec = _Archive.setup(uuid, path, cls.CURRENT_FORMAT_VERSION,
+                                    qiime2.__version__)
 
-        Format = cls.get_format_class(cls.CURRENT_FORMAT_VERSION)
-        Format.write(rec, type, format, data_initializer,
-                     provenance_capture)
+                Format = cls.get_format_class(cls.CURRENT_FORMAT_VERSION)
+                Format.write(rec, type, format, data_initializer,
+                            provenance_capture)
 
-        data_path = cache._rename_to_data(uuid, path)
-        rec = ArchiveRecord(data_path, data_path / _Archive.VERSION_FILE,
-                            uuid, cls.CURRENT_FORMAT_VERSION,
-                            qiime2.__version__)
-        ref = cls(data_path, uuid, Format(rec), cache)
-        return ref
+                data_path = cache._rename_to_data(uuid, path)
+                rec = ArchiveRecord(data_path,
+                                    data_path / _Archive.VERSION_FILE,
+                                    uuid, cls.CURRENT_FORMAT_VERSION,
+                                    qiime2.__version__)
+                ref = cls(data_path, uuid, Format(rec), cache)
+                return ref
+            # If we created the path, we really just want to kill it if
+            # anything at all goes wrong. Exceptions including keyboard
+            # interrupts are re-raised
+            except:  # noqa: E722
+                if created:
+                    cls._destroy_temp_path(uuid)
+                raise
 
     def __init__(self, path, process_alias, fmt, cache):
         self.path = path

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -14,6 +14,7 @@ import zipfile
 import importlib
 import os
 import io
+import shutil
 
 import qiime2
 import qiime2.core.cite as cite
@@ -294,6 +295,7 @@ class Archiver:
         path = cache.process_pool._allocate(uuid)
         return path, cache
 
+    # TODO: I think we may want to remove this method entirely
     @classmethod
     def _destroy_temp_path(cls, process_alias):
         from qiime2.core.cache import get_cache
@@ -379,19 +381,17 @@ class Archiver:
                 cls._futuristic_archive_error(filepath, archive)
 
             archive.mount(path)
-            process_alias, data_path = \
-                cache._rename_to_data(archive.uuid, path)
+            data_path = cache._rename_to_data(archive.uuid, path)
+            shutil.rmtree(path)
             rec = ArchiveRecord(
                 data_path, data_path / archive.VERSION_FILE, archive.uuid,
                 archive.version, archive.framework_version)
-            ref = cls(data_path, process_alias, Format(rec), cache)
+            ref = cls(data_path, archive.uuid, Format(rec), cache)
             return ref
         # We really just want to kill these paths if anything at all goes wrong
         # Exceptions including keyboard interrupts are re-raised
         except:  # noqa: E722
             cls._destroy_temp_path(archive.uuid)
-            if 'process_alias' in vars():
-                cls._destroy_temp_path(process_alias)
             raise
 
     @classmethod
@@ -423,18 +423,16 @@ class Archiver:
             Format.write(rec, type, format, data_initializer,
                          provenance_capture)
 
-            process_alias, data_path = cache._rename_to_data(uuid, path)
+            data_path = cache._rename_to_data(uuid, path)
             rec = ArchiveRecord(data_path, data_path / _Archive.VERSION_FILE,
                                 uuid, cls.CURRENT_FORMAT_VERSION,
                                 qiime2.__version__)
-            ref = cls(data_path, process_alias, Format(rec), cache)
+            ref = cls(data_path, uuid, Format(rec), cache)
             return ref
         # We really just want to kill these paths if anything at all goes wrong
         # Exceptions including keyboard interrupts are re-raised
         except:  # noqa: E722
             cls._destroy_temp_path(uuid)
-            if 'process_alias' in vars():
-                cls._destroy_temp_path(process_alias)
             raise
 
     def __init__(self, path, process_alias, fmt, cache):

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -408,11 +408,11 @@ class Archiver:
         path, cache = cls._make_temp_path(uuid)
 
         rec = _Archive.setup(uuid, path, cls.CURRENT_FORMAT_VERSION,
-                                qiime2.__version__)
+                             qiime2.__version__)
 
         Format = cls.get_format_class(cls.CURRENT_FORMAT_VERSION)
         Format.write(rec, type, format, data_initializer,
-                        provenance_capture)
+                     provenance_capture)
 
         data_path = cache._rename_to_data(uuid, path)
         rec = ArchiveRecord(data_path, data_path / _Archive.VERSION_FILE,

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -375,24 +375,18 @@ class Archiver:
         archive = cls.get_archive(filepath)
         path, cache = cls._make_temp_path(archive.uuid)
 
-        try:
-            Format = cls.get_format_class(archive.version)
-            if Format is None:
-                cls._futuristic_archive_error(filepath, archive)
+        Format = cls.get_format_class(archive.version)
+        if Format is None:
+            cls._futuristic_archive_error(filepath, archive)
 
-            archive.mount(path)
-            data_path = cache._rename_to_data(archive.uuid, path)
-            shutil.rmtree(path)
-            rec = ArchiveRecord(
-                data_path, data_path / archive.VERSION_FILE, archive.uuid,
-                archive.version, archive.framework_version)
-            ref = cls(data_path, archive.uuid, Format(rec), cache)
-            return ref
-        # We really just want to kill these paths if anything at all goes wrong
-        # Exceptions including keyboard interrupts are re-raised
-        except:  # noqa: E722
-            cls._destroy_temp_path(archive.uuid)
-            raise
+        archive.mount(path)
+        data_path = cache._rename_to_data(archive.uuid, path)
+        shutil.rmtree(path)
+        rec = ArchiveRecord(
+            data_path, data_path / archive.VERSION_FILE, archive.uuid,
+            archive.version, archive.framework_version)
+        ref = cls(data_path, archive.uuid, Format(rec), cache)
+        return ref
 
     @classmethod
     def load_raw(cls, filepath, cache):
@@ -415,25 +409,19 @@ class Archiver:
         uuid = _uuid.uuid4()
         path, cache = cls._make_temp_path(uuid)
 
-        try:
-            rec = _Archive.setup(uuid, path, cls.CURRENT_FORMAT_VERSION,
-                                 qiime2.__version__)
-
-            Format = cls.get_format_class(cls.CURRENT_FORMAT_VERSION)
-            Format.write(rec, type, format, data_initializer,
-                         provenance_capture)
-
-            data_path = cache._rename_to_data(uuid, path)
-            rec = ArchiveRecord(data_path, data_path / _Archive.VERSION_FILE,
-                                uuid, cls.CURRENT_FORMAT_VERSION,
+        rec = _Archive.setup(uuid, path, cls.CURRENT_FORMAT_VERSION,
                                 qiime2.__version__)
-            ref = cls(data_path, uuid, Format(rec), cache)
-            return ref
-        # We really just want to kill these paths if anything at all goes wrong
-        # Exceptions including keyboard interrupts are re-raised
-        except:  # noqa: E722
-            cls._destroy_temp_path(uuid)
-            raise
+
+        Format = cls.get_format_class(cls.CURRENT_FORMAT_VERSION)
+        Format.write(rec, type, format, data_initializer,
+                        provenance_capture)
+
+        data_path = cache._rename_to_data(uuid, path)
+        rec = ArchiveRecord(data_path, data_path / _Archive.VERSION_FILE,
+                            uuid, cls.CURRENT_FORMAT_VERSION,
+                            qiime2.__version__)
+        ref = cls(data_path, uuid, Format(rec), cache)
+        return ref
 
     def __init__(self, path, process_alias, fmt, cache):
         self.path = path

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -291,7 +291,6 @@ class Archiver:
         path, created = cache.process_pool._allocate(uuid)
         return path, created
 
-    # TODO: I think we may want to remove this method entirely
     @classmethod
     def _destroy_temp_path(cls, process_alias):
         from qiime2.core.cache import get_cache

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -292,7 +292,7 @@ class Archiver:
 
         cache = get_cache()
         path, created = cache.process_pool._allocate(uuid)
-        return path, cache, created
+        return cache, path, created
 
     # TODO: I think we may want to remove this method entirely
     @classmethod
@@ -372,7 +372,7 @@ class Archiver:
     @classmethod
     def load(cls, filepath):
         archive = cls.get_archive(filepath)
-        path, cache, created = cls._make_temp_path(archive.uuid)
+        cache, path, created = cls._make_temp_path(archive.uuid)
 
         with cache.lock:
             try:
@@ -414,7 +414,7 @@ class Archiver:
     @classmethod
     def from_data(cls, type, format, data_initializer, provenance_capture):
         uuid = _uuid.uuid4()
-        path, cache, created = cls._make_temp_path(uuid)
+        cache, path, created = cls._make_temp_path(uuid)
 
         with cache.lock:
             try:

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -446,8 +446,8 @@ class Archiver:
         self.path = path
         self.process_alias = process_alias
         self._fmt = fmt
-        self._destructor = weakref.finalize(self, cache._deallocate,
-                                            str(self.process_alias))
+        # self._destructor = weakref.finalize(self, cache._deallocate,
+        #                                     str(self.process_alias))
 
     @property
     def uuid(self):

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -14,7 +14,6 @@ import zipfile
 import importlib
 import os
 import io
-import shutil
 
 import qiime2
 import qiime2.core.cite as cite
@@ -381,7 +380,6 @@ class Archiver:
 
         archive.mount(path)
         data_path = cache._rename_to_data(archive.uuid, path)
-        shutil.rmtree(path)
         rec = ArchiveRecord(
             data_path, data_path / archive.VERSION_FILE, archive.uuid,
             archive.version, archive.framework_version)
@@ -391,7 +389,7 @@ class Archiver:
     @classmethod
     def load_raw(cls, filepath, cache):
         archive = cls.get_archive(filepath)
-        process_alias = cache._alias(str(archive.uuid))
+        cache.make_symlinks(str(archive.uuid))
 
         Format = cls.get_format_class(archive.version)
         if Format is None:
@@ -400,7 +398,7 @@ class Archiver:
         path = pathlib.Path(filepath)
 
         rec = archive.mount(path)
-        ref = cls(path, process_alias, Format(rec), cache)
+        ref = cls(path, archive.uuid, Format(rec), cache)
 
         return ref
 

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -395,7 +395,6 @@ class Archiver:
                     cls._destroy_temp_path(archive.uuid)
                 raise
 
-
     @classmethod
     def load_raw(cls, filepath, cache):
         archive = cls.get_archive(filepath)
@@ -420,11 +419,11 @@ class Archiver:
         with cache.lock:
             try:
                 rec = _Archive.setup(uuid, path, cls.CURRENT_FORMAT_VERSION,
-                                    qiime2.__version__)
+                                     qiime2.__version__)
 
                 Format = cls.get_format_class(cls.CURRENT_FORMAT_VERSION)
                 Format.write(rec, type, format, data_initializer,
-                            provenance_capture)
+                             provenance_capture)
 
                 data_path = cache._rename_to_data(uuid, path)
                 rec = ArchiveRecord(data_path,

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -446,8 +446,8 @@ class Archiver:
         self.path = path
         self.process_alias = process_alias
         self._fmt = fmt
-        # self._destructor = weakref.finalize(self, cache._deallocate,
-        #                                     str(self.process_alias))
+        self._destructor = weakref.finalize(self, cache._deallocate,
+                                            str(self.process_alias))
 
     @property
     def uuid(self):

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -284,15 +284,12 @@ class Archiver:
     }
 
     @classmethod
-    def _make_temp_path(cls, uuid):
+    def _make_temp_path(cls, cache, uuid):
         """Allocates a place in the cache for the file to be temporarily
         written. Returns this location and the cache in use.
         """
-        from qiime2.core.cache import get_cache
-
-        cache = get_cache()
         path, created = cache.process_pool._allocate(uuid)
-        return cache, path, created
+        return path, created
 
     # TODO: I think we may want to remove this method entirely
     @classmethod
@@ -371,10 +368,13 @@ class Archiver:
 
     @classmethod
     def load(cls, filepath):
+        from qiime2.core.cache import get_cache
+
         archive = cls.get_archive(filepath)
-        cache, path, created = cls._make_temp_path(archive.uuid)
+        cache = get_cache()
 
         with cache.lock:
+            path, created = cls._make_temp_path(cache, archive.uuid)
             try:
                 Format = cls.get_format_class(archive.version)
                 if Format is None:
@@ -413,10 +413,13 @@ class Archiver:
 
     @classmethod
     def from_data(cls, type, format, data_initializer, provenance_capture):
+        from qiime2.core.cache import get_cache
+
         uuid = _uuid.uuid4()
-        cache, path, created = cls._make_temp_path(uuid)
+        cache = get_cache()
 
         with cache.lock:
+            path, created = cls._make_temp_path(cache, uuid)
             try:
                 rec = _Archive.setup(uuid, path, cls.CURRENT_FORMAT_VERSION,
                                      qiime2.__version__)

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -266,38 +266,45 @@ def monitor_thread(cache_dir, is_done):
 
 
 def gc_thread(process_pool_path, is_done, lock):
-    global queue
+    global references
     references = {}
 
     while not is_done.is_set():
-        with lock:
-            while True:
-                try:
-                    msg = queue.get(block=False)
-                    uuid, direction = msg
-                    uuid = str(uuid)
+        consume_queue(process_pool_path, lock)
+        time.sleep(10)
 
-                    if direction == "+":
-                        if uuid not in references:
-                            references[uuid] = 0
 
-                        references[uuid] += 1
-                    else:
-                        if uuid not in references:
-                            raise ValueError(
-                                "Decrementing non-existent reference")
+def consume_queue(process_pool_path, lock):
+    global queue
+    global references
 
+    with lock:
+        while True:
+            try:
+                msg = queue.get(block=False)
+                uuid, direction = msg
+                uuid = str(uuid)
+
+                if direction == "+":
+                    if uuid not in references:
+                        references[uuid] = 0
+
+                    references[uuid] += 1
+                else:
+                    if uuid in references:
                         references[uuid] -= 1
 
-                    if references[uuid] == 0:
-                        target = process_pool_path / uuid
+                if references[uuid] == 0:
+                    target = process_pool_path / uuid
 
-                        if target.exists():
-                            os.remove(target)
+                    if target.exists():
+                        with open('/home/anthony/src/qiime2/qiime2/trash.txt', 'a') as fh:
+                            fh.write(f'{target}\n')
 
-                except Empty:
-                    break
+                        os.remove(target)
 
+            except Empty:
+                break
 
 
 # This is very important to our trademark
@@ -559,8 +566,7 @@ class Cache:
             weakref.finalize(self, self._gc_thread_is_done.set)
         self._gc_thread = threading.Thread(
             target=gc_thread, args=(
-                self.process_pool.path, self._gc_thread_is_done, self.lock),
-                daemon=True)
+                self.process_pool.path, self._gc_thread_is_done, self.lock))
         self._gc_thread.start()
 
     def __enter__(self):
@@ -843,6 +849,8 @@ class Cache:
         # or processes writing refs that we don't see leading to us deleting
         # their data
         with self.lock:
+            consume_queue(self.process_pool.path, self.lock)
+
             for key in self.get_keys():
                 loaded_key = self.read_key(key)
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -275,9 +275,6 @@ def gc_thread(process_pool_path, is_done, lock):
 
 
 def consume_queue(process_pool_path, lock):
-    global queue
-    global references
-
     with lock:
         while True:
             try:
@@ -296,12 +293,7 @@ def consume_queue(process_pool_path, lock):
 
                 if references[uuid] == 0:
                     target = process_pool_path / uuid
-
-                    if target.exists():
-                        with open('/home/anthony/src/qiime2/qiime2/trash.txt', 'a') as fh:
-                            fh.write(f'{target}\n')
-
-                        os.remove(target)
+                    os.remove(target)
 
             except Empty:
                 break
@@ -1310,7 +1302,6 @@ class Cache:
         # Python's garbage collector and that seems to cause deadlocks when
         # acquiring the thread lock
 
-        global queue
         queue.put([symlink, '-'])
 
     def get_tmp_path(self):
@@ -1681,7 +1672,6 @@ class Pool:
                 os.symlink(src, dest)
 
             if self.is_process_pool:
-                global queue
                 queue.put([uuid, '+'])
 
     def load(self, ref):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1192,8 +1192,6 @@ class Cache:
 
         Returns
         -------
-        str
-            The alias we created for the artifact in the cache's process pool.
         pathlib.Path
             The location we renamed the data into.
         """

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -267,7 +267,6 @@ def monitor_thread(cache_dir, is_done):
 
 def gc_thread(process_pool_path, queue, is_done, lock):
     references = {}
-    time.sleep(10)
 
     while not is_done.is_set():
         with lock:
@@ -289,26 +288,14 @@ def gc_thread(process_pool_path, queue, is_done, lock):
 
                         references[uuid] -= 1
 
-                    with open('/home/anthony/src/qiime2/qiime2/test.txt', 'a') as fh:
-                        fh.write(f'{uuid}\n')
-                        fh.write(f'{direction}\n')
-                        fh.write(f'{references[uuid]}\n')
-                        if references[uuid] == 0:
-                            target = process_pool_path / uuid
-                            fh.write(f'Deallocating {target}\n')
+                    if references[uuid] == 0:
+                        target = process_pool_path / uuid
 
-                            if target.exists():
-                                os.remove(target)
+                        if target.exists():
+                            os.remove(target)
 
                 except Empty:
-                    with open('/home/anthony/src/qiime2/qiime2/test.txt', 'a') as fh:
-                        fh.write(f'BREAKING\n')
                     break
-
-            time.sleep(10)
-
-    with open('/home/anthony/src/qiime2/qiime2/test.txt', 'a') as fh:
-        fh.write(f'QUITTING\n')
 
 
 # This is very important to our trademark

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -820,6 +820,12 @@ class Cache:
                 if time.time() - create_time >= self.process_pool_lifespan:
                     shutil.rmtree(self.processes / process_pool)
                 else:
+                    # NOTE: This split is a result of the fact that older
+                    # versions of QIIME 2 created entries in process pools that
+                    # were <uuid>.<random_string> because we had reason to
+                    # keep multiple references to one artifact in one process.
+                    # The split needs to stay around for backwards
+                    # compatibility
                     for data in os.listdir(self.processes / process_pool):
                         referenced_data.add(data.split('.')[0])
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -546,13 +546,14 @@ class Cache:
             self._thread.start()
 
         # Start thread for gc reference counting
-        self.queue = mp.Queue()
+        global queue
+        queue = mp.Queue()
         self._gc_thread_is_done = threading.Event()
         self._gc_thread_destructor = \
             weakref.finalize(self, self._gc_thread_is_done.set)
         self._gc_thread = threading.Thread(
             target=gc_thread, args=(
-                self.process_pool.path, self.queue, self._gc_thread_is_done,
+                self.process_pool.path, queue, self._gc_thread_is_done,
                 self.lock), daemon=True)
         self._gc_thread.start()
 
@@ -1295,9 +1296,8 @@ class Cache:
         # Python's garbage collector and that seems to cause deadlocks when
         # acquiring the thread lock
 
-        self.queue.put([symlink, '-'])
-        # print(f'PUT: {[symlink, "-"]}')
-
+        global queue
+        queue.put([symlink, '-'])
 
     def get_tmp_path(self):
         """Creates a tmp dir inside of the current process pool and returns a
@@ -1667,8 +1667,8 @@ class Pool:
                 os.symlink(src, dest)
 
             if self.is_process_pool:
-                self.cache.queue.put([uuid, '+'])
-                # print(f'PUT: {[uuid, "+"]}')
+                global queue
+                queue.put([uuid, '+'])
 
     def load(self, ref):
         """Loads a reference to an element in the pool.

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1606,8 +1606,6 @@ class Pool:
         # the same thing to a named pool several times.
         with self.cache.lock:
             if not os.path.lexists(dest):
-                print(os.path.exists(src))
-                print(os.path.exists(dest))
                 os.symlink(src, dest)
 
     def load(self, ref):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -275,28 +275,48 @@ def gc_thread(process_pool_path, is_done, lock):
 
 
 def consume_queue(process_pool_path, lock):
-    with lock:
-        while True:
-            try:
-                msg = queue.get(block=False)
-                uuid, direction = msg
-                uuid = str(uuid)
+    try:
+        with lock:
+            while True:
+                try:
+                    msg = queue.get(block=False)
+                    uuid, direction = msg
+                    uuid = str(uuid)
 
-                if direction == "+":
-                    if uuid not in references:
-                        references[uuid] = 0
+                    if direction == "+":
+                        if uuid not in references:
+                            references[uuid] = 0
 
-                    references[uuid] += 1
-                else:
-                    if uuid in references:
-                        references[uuid] -= 1
+                        references[uuid] += 1
+                    else:
+                        if uuid in references:
+                            references[uuid] -= 1
+                        else:
+                            references[uuid] = 0
 
-                if references[uuid] == 0:
-                    target = process_pool_path / uuid
-                    os.remove(target)
+                    if references[uuid] == 0:
+                        target = process_pool_path / uuid
 
-            except Empty:
-                break
+                        # We don't really care if the thing we're trying to
+                        # remove was already removed by something else. We
+                        # wanted it gone anyway. No reason to complain
+                        try:
+                            os.remove(target)
+                        except FileNotFoundError:
+                            pass
+
+                except Empty:
+                    break
+    except FileNotFoundError as e:
+        if 'LOCK' in str(e):
+            pass
+        else:
+            raise e
+    except OSError as e:
+        if 'handle is closed' in str(e):
+            pass
+        else:
+            raise e
 
 
 # This is very important to our trademark
@@ -322,25 +342,38 @@ class MEGALock(tm):
         thread-safe which is why we need both locks in the first place
         """
         gc.disable()
-        if self.re_entries == 0:
-            self.thread_lock.acquire()
 
-            try:
-                self.flufl_lock.lock()
-            except Exception:
-                self.thread_lock.release()
-                gc.enable()
-                raise
+        try:
+            if self.re_entries == 0:
+                self.thread_lock.acquire()
+
+                try:
+                    self.flufl_lock.lock()
+                except Exception:
+                    self.thread_lock.release()
+                    raise
+        except Exception:
+            gc.enable()
+            raise
 
         self.re_entries += 1
 
     def __exit__(self, *args):
-        if self.re_entries > 0:
-            self.re_entries -= 1
+        try:
+            if self.re_entries > 0:
+                self.re_entries -= 1
 
-        if self.re_entries == 0:
-            self.flufl_lock.unlock()
-            self.thread_lock.release()
+            if self.re_entries == 0:
+                try:
+                    self.flufl_lock.unlock()
+                except Exception:
+                    self.thread_lock.release()
+                    raise
+
+                self.thread_lock.release()
+        except Exception:
+            gc.enable()
+            raise
 
         gc.enable()
 
@@ -558,7 +591,8 @@ class Cache:
             weakref.finalize(self, self._gc_thread_is_done.set)
         self._gc_thread = threading.Thread(
             target=gc_thread, args=(
-                self.process_pool.path, self._gc_thread_is_done, self.lock))
+                self.process_pool.path, self._gc_thread_is_done, self.lock),
+            daemon=True)
         self._gc_thread.start()
 
     def __enter__(self):

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1194,7 +1194,6 @@ class Cache:
         uuid = str(uuid)
 
         dest = self.data / uuid
-        alias = os.path.split(src)[0]
         with self.lock:
             # Rename errors if the destination already exists
             if not os.path.exists(dest):
@@ -1203,10 +1202,6 @@ class Cache:
 
             self.make_symlinks(uuid)
 
-        # Remove the aliased directory above the one we renamed. We need to do
-        # this whether we renamed or not because we aren't renaming this
-        # directory but the one beneath it
-        shutil.rmtree(alias)
         return dest
 
     def make_symlinks(self, uuid):
@@ -1575,16 +1570,15 @@ class Pool:
         """
         uuid = str(uuid)
 
-        # We want to extract artifacts to this thread unique location in the
-        # process pool before using Cache.rename to put them into Cache.data.
-        # We need to do this in order to ensure that if a uuid exists in
-        # Cache.data, it is actually populated with data and is usable as an
-        # artifact. Otherwise it could just be an empty directory (or only
-        # contain part of the artifact) when another thread/process tries to
-        # access it.
+        # We want to extract artifacts to a location in the process pool before
+        # using Cache.rename to put them into Cache.data. We need to do this in
+        # order to ensure that if a uuid exists in Cache.data, it is actually
+        # populated with data and is usable as an artifact. Otherwise it could
+        # just be an empty directory (or only contain part of the artifact)
+        # when another thread/process tries to access it.
         with self.cache.lock:
             allocated_path = self.path / uuid
-            os.makedirs(allocated_path)
+            os.makedirs(allocated_path, exist_ok=True)
 
         return allocated_path
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1567,6 +1567,9 @@ class Pool:
         -------
         pathlib.Path
             The path we allocated to extract the artifact into.
+        boolean
+            True if this method call created the allocated path. False if the
+            allocated path already existed
         """
         uuid = str(uuid)
 
@@ -1578,9 +1581,13 @@ class Pool:
         # when another thread/process tries to access it.
         with self.cache.lock:
             allocated_path = self.path / uuid
-            os.makedirs(allocated_path, exist_ok=True)
+            if not os.path.exists(allocated_path):
+                os.makedirs(allocated_path)
+                created = True
+            else:
+                created = False
 
-        return allocated_path
+        return allocated_path, created
 
     def _make_symlink(self, uuid):
         """Symlinks self.path / uuid to self.cache.data / uuid. This creates a

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1218,11 +1218,6 @@ class Cache:
         ----------
         uuid : str or uuid4
             The uuid of the artifact we are symlinking.
-
-        Returns
-        -------
-        str
-            The alias we created for the artifact.
         """
         with self.lock:
             self.process_pool._make_symlink(uuid)

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -42,8 +42,6 @@ import weakref
 import tempfile
 import warnings
 import threading
-from sys import maxsize
-from random import randint
 from datetime import timedelta
 
 import flufl.lock
@@ -1203,25 +1201,22 @@ class Cache:
                 os.rename(src, dest)
                 set_permissions(dest, READ_ONLY_FILE, READ_ONLY_DIR)
 
-            # Create a new alias whether we renamed or not because this is
-            # still loading a new reference to the data even if the data is
-            # already there
-            process_alias = self._alias(uuid)
+            self.make_symlinks(uuid)
 
         # Remove the aliased directory above the one we renamed. We need to do
         # this whether we renamed or not because we aren't renaming this
         # directory but the one beneath it
         shutil.rmtree(alias)
-        return process_alias, dest
+        return dest
 
-    def _alias(self, uuid):
-        """Creates an alias and a symlink for the artifact with the given uuid
-        in both the cache's process pool and its named pool if it has one.
+    def make_symlinks(self, uuid):
+        """Creates a symlink for the artifact with the given uuid in both the
+        cache's process pool and its named pool if it has one.
 
         Parameters
         ----------
         uuid : str or uuid4
-            The uuid of the artifact we are aliasing.
+            The uuid of the artifact we are symlinking.
 
         Returns
         -------
@@ -1229,14 +1224,10 @@ class Cache:
             The alias we created for the artifact.
         """
         with self.lock:
-            process_alias = self.process_pool._alias(uuid)
-            self.process_pool._make_symlink(uuid, process_alias)
+            self.process_pool._make_symlink(uuid)
 
-            # Named pool links are not aliased
             if self.named_pool is not None:
-                self.named_pool._make_symlink(uuid, uuid)
-
-        return process_alias
+                self.named_pool._make_symlink(uuid)
 
     def _deallocate(self, symlink):
         """Removes a specific symlink from the process pool. This happens when
@@ -1561,60 +1552,16 @@ class Pool:
         >>> test_dir.cleanup()
         """
         uuid = str(ref.uuid)
-        if self.path == self.cache.process_pool.path:
-            alias = self._alias(uuid)
-        else:
-            alias = uuid
 
-        self._make_symlink(uuid, alias)
+        self._make_symlink(uuid)
 
         self.cache._copy_to_data(ref)
         return self.load(ref)
 
-    def _alias(self, uuid):
-        """We may want to create multiple references to a single artifact in a
-        process pool, but we cannot create multiple symlinks with the same
-        name, so we take the uuid and add a random number to the end of it and
-        use uuid.random_number as the name of the symlink. This means when you
-        look in a process pool you may see the same uuid multiple times with
-        different random numbers appended. This means there are multiple
-        references to the artifact with that uuid in the process poole because
-        it was loaded multiple times in the process.
-
-        Parameters
-        ----------
-        uuid : str or uuid4
-            The uuid we are creating an alias for.
-
-        Returns
-        -------
-        str
-            The aliased uuid.
-
-        """
-        MAX_RETRIES = 5
-
-        uuid = str(uuid)
-        with self.cache.lock:
-            for _ in range(MAX_RETRIES):
-                alias = uuid + '.' + str(randint(0, maxsize))
-                path = self.path / alias
-
-                # os.path.exists returns false on broken symlinks
-                if not os.path.exists(path) and not os.path.islink(path):
-                    break
-            else:
-                raise ValueError(f'Too many collisions ({MAX_RETRIES}) '
-                                 'occurred while trying to save artifact '
-                                 f'<{uuid}> to process pool {self.path}. It '
-                                 'is likely you have attempted to load the '
-                                 'same artifact a very large number of times.')
-        return alias
-
     def _allocate(self, uuid):
         """Allocate an empty directory under the process pool to extract to.
-        This directory is of the form alias / uuid and provides a per thread
-        mount location for artifacts.
+        This directory is of the form self.path / uuid and provides a mount
+        location for artifacts.
 
         Parameters
         ----------
@@ -1636,32 +1583,31 @@ class Pool:
         # contain part of the artifact) when another thread/process tries to
         # access it.
         with self.cache.lock:
-            alias = self._alias(uuid)
-            allocated_path = self.path / alias / uuid
+            allocated_path = self.path / uuid
             os.makedirs(allocated_path)
 
         return allocated_path
 
-    def _make_symlink(self, uuid, alias):
-        """Symlinks self.path / alias to self.cache.data / uuid. This creates a
+    def _make_symlink(self, uuid):
+        """Symlinks self.path / uuid to self.cache.data / uuid. This creates a
         reference to the artifact with the given uuid in the cache.
 
         Parameters
         ----------
         uuid : str or uuid4
             The uuid of the artifact we are creating a symlink reference for.
-        alias : str
-            The alias we are using as the actual name of the symlink.
         """
         uuid = str(uuid)
         src = self.cache.data / uuid
-        dest = self.path / alias
+        dest = self.path / uuid
 
         # Symlink will error if the location we are creating the link at
         # already exists. This could happen legitimately from trying to save
         # the same thing to a named pool several times.
         with self.cache.lock:
             if not os.path.lexists(dest):
+                print(os.path.exists(src))
+                print(os.path.exists(dest))
                 os.symlink(src, dest)
 
     def load(self, ref):
@@ -1811,8 +1757,7 @@ class Pool:
                 # Make sure the process that indexed this artifact will still
                 # have access to it if it is otherwise removed from the cache
                 # by retaining a reference to it in our process pool
-                alias = self.cache.process_pool._alias(_uuid)
-                self.cache.process_pool._make_symlink(_uuid, alias)
+                self.cache.process_pool._make_symlink(_uuid)
 
                 # Get action.yaml from this artifact's provenance
                 path = self.cache.data / _uuid

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1588,7 +1588,7 @@ class Pool:
         with self.cache.lock:
             allocated_path = self.path / uuid
             if not os.path.exists(allocated_path):
-                os.makedirs(allocated_path)
+                os.mkdir(allocated_path)
                 created = True
             else:
                 created = False

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -30,6 +30,7 @@ attempt to use as a cache should have been created as a cache by QIIME 2.
 """
 import re
 import os
+import gc
 import stat
 import yaml
 import time
@@ -43,6 +44,9 @@ import tempfile
 import warnings
 import threading
 from datetime import timedelta
+from queue import Empty
+import multiprocessing as mp
+
 
 import flufl.lock
 
@@ -261,6 +265,52 @@ def monitor_thread(cache_dir, is_done):
         time.sleep(60 * 60 * 6)
 
 
+def gc_thread(process_pool_path, queue, is_done, lock):
+    references = {}
+    time.sleep(10)
+
+    while not is_done.is_set():
+        with lock:
+            while True:
+                try:
+                    msg = queue.get(block=False)
+                    uuid, direction = msg
+                    uuid = str(uuid)
+
+                    if direction == "+":
+                        if uuid not in references:
+                            references[uuid] = 0
+
+                        references[uuid] += 1
+                    else:
+                        if uuid not in references:
+                            raise ValueError(
+                                "Decrementing non-existent reference")
+
+                        references[uuid] -= 1
+
+                    with open('/home/anthony/src/qiime2/qiime2/test.txt', 'a') as fh:
+                        fh.write(f'{uuid}\n')
+                        fh.write(f'{direction}\n')
+                        fh.write(f'{references[uuid]}\n')
+                        if references[uuid] == 0:
+                            target = process_pool_path / uuid
+                            fh.write(f'Deallocating {target}\n')
+
+                            if target.exists():
+                                os.remove(target)
+
+                except Empty:
+                    with open('/home/anthony/src/qiime2/qiime2/test.txt', 'a') as fh:
+                        fh.write(f'BREAKING\n')
+                    break
+
+            time.sleep(10)
+
+    with open('/home/anthony/src/qiime2/qiime2/test.txt', 'a') as fh:
+        fh.write(f'QUITTING\n')
+
+
 # This is very important to our trademark
 tm = object
 
@@ -283,6 +333,7 @@ class MEGALock(tm):
         """ We acquire the thread lock first because the flufl lock isn't
         thread-safe which is why we need both locks in the first place
         """
+        gc.disable()
         if self.re_entries == 0:
             self.thread_lock.acquire()
 
@@ -290,6 +341,7 @@ class MEGALock(tm):
                 self.flufl_lock.lock()
             except Exception:
                 self.thread_lock.release()
+                gc.enable()
                 raise
 
         self.re_entries += 1
@@ -301,6 +353,8 @@ class MEGALock(tm):
         if self.re_entries == 0:
             self.flufl_lock.unlock()
             self.thread_lock.release()
+
+        gc.enable()
 
     def __getstate__(self):
         lockless_dict = self.__dict__.copy()
@@ -493,7 +547,7 @@ class Cache:
 
         # Start thread that pokes things in the cache to ensure they aren't
         # culled for being too old (only if we are in a temp cache)
-        if path == temp_cache_path:
+        if self.path == temp_cache_path:
             self._thread_is_done = threading.Event()
             self._thread_destructor = \
                 weakref.finalize(self, self._thread_is_done.set)
@@ -503,6 +557,17 @@ class Cache:
                 daemon=True)
 
             self._thread.start()
+
+        # Start thread for gc reference counting
+        self.queue = mp.Queue()
+        self._gc_thread_is_done = threading.Event()
+        self._gc_thread_destructor = \
+            weakref.finalize(self, self._gc_thread_is_done.set)
+        self._gc_thread = threading.Thread(
+            target=gc_thread, args=(
+                self.process_pool.path, self.queue, self._gc_thread_is_done,
+                self.lock), daemon=True)
+        self._gc_thread.start()
 
     def __enter__(self):
         """Tell QIIME 2 to use this cache in its current invocation (see
@@ -535,6 +600,10 @@ class Cache:
             del threadless_dict['_thread_is_done']
             del threadless_dict['_thread_destructor']
             del threadless_dict['_thread']
+
+        del threadless_dict['_gc_thread_is_done']
+        del threadless_dict['_gc_thread_destructor']
+        del threadless_dict['_gc_thread']
 
         return threadless_dict
 
@@ -1238,10 +1307,10 @@ class Cache:
         # NOTE: Beware locking inside of this method. This method is called by
         # Python's garbage collector and that seems to cause deadlocks when
         # acquiring the thread lock
-        target = self.process_pool.path / symlink
 
-        if target.exists():
-            os.remove(target)
+        self.queue.put([symlink, '-'])
+        # print(f'PUT: {[symlink, "-"]}')
+
 
     def get_tmp_path(self):
         """Creates a tmp dir inside of the current process pool and returns a
@@ -1396,6 +1465,7 @@ class Pool:
         """
         # The pool keeps track of the cache it belongs to
         self.cache = cache
+        self.is_process_pool = False
 
         # If they are creating a named pool, we already have this info
         if name:
@@ -1406,6 +1476,7 @@ class Pool:
         # directory. The name follows the scheme
         # <process-id>-<process-start-time>@<user>
         else:
+            self.is_process_pool = True
             self.name = self._get_process_pool_name()
             self.path = cache.processes / self.name
 
@@ -1607,6 +1678,10 @@ class Pool:
         with self.cache.lock:
             if not os.path.lexists(dest):
                 os.symlink(src, dest)
+
+            if self.is_process_pool:
+                self.cache.queue.put([uuid, '+'])
+                # print(f'PUT: {[uuid, "+"]}')
 
     def load(self, ref):
         """Loads a reference to an element in the pool.

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -265,7 +265,8 @@ def monitor_thread(cache_dir, is_done):
         time.sleep(60 * 60 * 6)
 
 
-def gc_thread(process_pool_path, queue, is_done, lock):
+def gc_thread(process_pool_path, is_done, lock):
+    global queue
     references = {}
 
     while not is_done.is_set():
@@ -296,6 +297,7 @@ def gc_thread(process_pool_path, queue, is_done, lock):
 
                 except Empty:
                     break
+
 
 
 # This is very important to our trademark
@@ -547,14 +549,18 @@ class Cache:
 
         # Start thread for gc reference counting
         global queue
+
+        if not mp.get_start_method() == 'fork':
+            mp.set_start_method('fork')
+
         queue = mp.Queue()
         self._gc_thread_is_done = threading.Event()
         self._gc_thread_destructor = \
             weakref.finalize(self, self._gc_thread_is_done.set)
         self._gc_thread = threading.Thread(
             target=gc_thread, args=(
-                self.process_pool.path, queue, self._gc_thread_is_done,
-                self.lock), daemon=True)
+                self.process_pool.path, self._gc_thread_is_done, self.lock),
+                daemon=True)
         self._gc_thread.start()
 
     def __enter__(self):

--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -147,8 +147,7 @@ class TestCache(unittest.TestCase):
     def tearDown(self):
         """Remove our cache and all that from last test
         """
-        del self.cache
-        gc.collect()
+        self.cache._gc_thread_is_done.set()
         self.test_dir.cleanup()
 
     def test_is_cache(self):
@@ -552,7 +551,7 @@ class TestCache(unittest.TestCase):
 
         atexit.unregister(_exit_cleanup)
         atexit.register(_on_exit_validate, cache, expected)
-        atexit.register(_exit_cleanup)
+        # atexit.register(_exit_cleanup)
 
     @pytest.mark.skipif(os.geteuid() == 0, reason="super user always wins")
     def test_surreptitiously_write_artifact(self):

--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -147,6 +147,8 @@ class TestCache(unittest.TestCase):
     def tearDown(self):
         """Remove our cache and all that from last test
         """
+        del self.cache
+        gc.collect()
         self.test_dir.cleanup()
 
     def test_is_cache(self):

--- a/qiime2/core/util.py
+++ b/qiime2/core/util.py
@@ -427,9 +427,12 @@ def touch_under_path(path):
                 pass
 
 
-def load_action_yaml(path):
+def load_action_yaml(path, nested=None):
     """Takes a path to an unzipped Artifact and loads its action.yaml with
     yaml.safe_load
+
+    If nested!=None we are loading the provenance of an artifact with
+    uuid=nested that is in the artifact path points to's "artifacts" directory
     """
     # TODO: Make these actually do something useful at least for the tags
     # that are relevant to what we need out of provenance (this is partially
@@ -456,7 +459,12 @@ def load_action_yaml(path):
     yaml.constructor.SafeConstructor.add_constructor('!metadata',
                                                      metadata_constructor)
 
-    prov_path = path / 'provenance' / 'action'
+    if nested is not None:
+        path = path / 'provenance' / 'artifacts' / str(nested)
+        prov_path = path / 'action'
+    else:
+        prov_path = path / 'provenance' / 'action'
+
     action_path = prov_path / 'action.yaml'
 
     with open(action_path) as fh:

--- a/qiime2/sdk/context/asynchronous.py
+++ b/qiime2/sdk/context/asynchronous.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import concurrent.futures
+from multiprocessing import set_start_method
 
 from .base import Context
 
@@ -37,6 +38,10 @@ class AsynchronousContext(Context):
         # function's signature.
         args = args[1:]
 
+        try:
+            set_start_method('fork')
+        except:
+            pass
         pool = concurrent.futures.ProcessPoolExecutor(max_workers=1)
         future = pool.submit(_subprocess_apply, self, args, kwargs)
         # TODO: pool.shutdown(wait=False) caused the child process to

--- a/qiime2/sdk/context/asynchronous.py
+++ b/qiime2/sdk/context/asynchronous.py
@@ -7,7 +7,6 @@
 # ----------------------------------------------------------------------------
 
 import concurrent.futures
-from multiprocessing import set_start_method
 
 from .base import Context
 
@@ -38,10 +37,6 @@ class AsynchronousContext(Context):
         # function's signature.
         args = args[1:]
 
-        try:
-            set_start_method('fork')
-        except:
-            pass
         pool = concurrent.futures.ProcessPoolExecutor(max_workers=1)
         future = pool.submit(_subprocess_apply, self, args, kwargs)
         # TODO: pool.shutdown(wait=False) caused the child process to


### PR DESCRIPTION
We should no longer be required to create many aliases of the same artifact in process pools now that we no longer enter Contexts as Scopes.

Supercedes #855 with a slightly reworked and better approach.
