### PR TITLE
MAINT: No error on failing to load cached collection

### DIFF
--- a/qiime2/core/testing/pipeline.py
+++ b/qiime2/core/testing/pipeline.py
@@ -98,7 +98,7 @@ def resumable_pipeline(ctx, int_list, int_dict, fail=False):
         list_uuids = [str(result.uuid) for result in list_return.values()]
         dict_uuids = [str(result.uuid) for result in dict_return.values()]
 
-        raise ValueError(f'{list_uuids}_{dict_uuids}')
+        raise PipelineError([list_uuids, dict_uuids])
 
     return list_return, dict_return
 

--- a/qiime2/sdk/context/base.py
+++ b/qiime2/sdk/context/base.py
@@ -16,9 +16,13 @@ def _validate_collection(collection_order):
     """Validate that all indexed items in the collection agree on how
     large the collection should be and that we have that many elements.
     """
-    assert all([elem.total == collection_order[0].total
-                for elem in collection_order])
-    assert len(collection_order) == collection_order[0].total
+    if not all([
+        elem.total == collection_order[0].total
+        for elem in collection_order]) \
+            or len(collection_order) != collection_order[0].total:
+        return False
+
+    return True
 
 
 class Context:
@@ -129,7 +133,8 @@ class Context:
 
                 # Get the order we should load collection items in
                 collection_order = list(cached_collection.keys())
-                _validate_collection(collection_order)
+                if not _validate_collection(collection_order):
+                    return None
                 collection_order.sort(key=lambda x: x.idx)
 
                 for elem_info in collection_order:

--- a/qiime2/sdk/context/base.py
+++ b/qiime2/sdk/context/base.py
@@ -5,6 +5,7 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import warnings
 
 from qiime2.core.type.util import is_collection_type
 from qiime2.core.type import HashableInvocation
@@ -20,6 +21,8 @@ def _validate_collection(collection_order):
         elem.total == collection_order[0].total
         for elem in collection_order]) \
             or len(collection_order) != collection_order[0].total:
+        warnings.warn("Incomplete collection found when recycling, "
+                      "collection will be remade")
         return False
 
     return True


### PR DESCRIPTION
Currently, if we attempt to load a cached collection for pipeline resumption and it is malformed, we get an assertion error. This should instead just rerun the action to create the collection.