### PR TITLE
MAINT: Merge annotations in the cache

### DIFF
--- a/qiime2/core/annotate.py
+++ b/qiime2/core/annotate.py
@@ -101,6 +101,7 @@ class Annotation():
                 annotation.annotation_type = meta_yaml['type']
                 annotation.created_at = meta_yaml['created_at']
 
+        annotation._filepath = filepath
         return annotation
 
     # We never expect this to be hit as the base class for Annotations
@@ -332,11 +333,11 @@ class Note(Annotation):
 
         note_path = os.path.join(annotation_uuid_dirname, 'note.txt')
 
-        if self._filepath:
+        if self.contents:
+            contents = self.contents.encode('utf-8')
+        else:
             with open(self._filepath, 'rb') as fh:
                 contents = fh.read()
-        else:
-            contents = self.contents.encode('utf-8')
 
         # validation for max size and parsability
         max_size = 10 * 1024 * 1024

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1182,9 +1182,6 @@ class Cache:
                     Result._from_archiver(Archiver.load_raw(destination, self))
                 existing.merge_annotations(ref)
 
-    # TODO: If multiple instances of the same artifact are put into the cache
-    # with different annotations, we merge the annotations. If there are
-    # namespace collisions, throw a warning and append UUID to end of name?
     def _rename_to_data(self, uuid, src):
         """Takes some data in src and renames it into the cache's data dir. It
         then ensures there are symlinks for this data in the process pool and

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -1179,7 +1179,6 @@ class Cache:
 
                 set_permissions(destination, READ_ONLY_FILE, READ_ONLY_DIR)
             else:
-                # Check for annotation whatever
                 existing = Result._from_archiver(Archiver.load_raw(destination, self))
                 existing.merge_annotations(ref)
 
@@ -1217,7 +1216,6 @@ class Cache:
                 os.rename(src, dest)
                 set_permissions(dest, READ_ONLY_FILE, READ_ONLY_DIR)
             else:
-                # Check for annotation whatever
                 existing = Result._from_archiver(Archiver.load_raw(dest, self))
                 new = Result._from_archiver(Archiver.load_raw(src, self))
                 existing.merge_annotations(new)

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -984,7 +984,6 @@ class Cache:
                 with open(self.keys / key) as fh:
                     return yaml.safe_load(fh)
             except FileNotFoundError as e:
-                print("READING")
                 raise KeyError(f"The cache '{self.path}' does not contain the "
                                f"key '{key}'") from e
 

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -907,8 +907,8 @@ class Cache:
                 if key in self.get_keys():
                     self.remove(key)
                 raise
-            else:
-                return self.load(key)
+
+            return self.load(key)
 
     def save_collection(self, ref_collection, key):
         """Saves a Collection to a pool in the cache with the given key. This

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -903,7 +903,7 @@ class Cache:
             try:
                 self._register_key(key, str(ref.uuid))
                 self._copy_to_data(ref)
-            except:
+            except:  # noqa: E722
                 if key in self.get_keys():
                     self.remove(key)
                 raise
@@ -1178,7 +1178,8 @@ class Cache:
 
                 set_permissions(destination, READ_ONLY_FILE, READ_ONLY_DIR)
             else:
-                existing = Result._from_archiver(Archiver.load_raw(destination, self))
+                existing = \
+                    Result._from_archiver(Archiver.load_raw(destination, self))
                 existing.merge_annotations(ref)
 
     # TODO: If multiple instances of the same artifact are put into the cache

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -900,10 +900,15 @@ class Cache:
         # process is running garbage collection it doesn't see our un-keyed
         # data and remove it leaving us with a dangling reference and no data
         with self.lock:
-            self._register_key(key, str(ref.uuid))
-            self._copy_to_data(ref)
-
-        return self.load(key)
+            try:
+                self._register_key(key, str(ref.uuid))
+                self._copy_to_data(ref)
+            except:
+                if key in self.get_keys():
+                    self.remove(key)
+                raise
+            else:
+                return self.load(key)
 
     def save_collection(self, ref_collection, key):
         """Saves a Collection to a pool in the cache with the given key. This
@@ -979,6 +984,7 @@ class Cache:
                 with open(self.keys / key) as fh:
                     return yaml.safe_load(fh)
             except FileNotFoundError as e:
+                print("READING")
                 raise KeyError(f"The cache '{self.path}' does not contain the "
                                f"key '{key}'") from e
 
@@ -1172,7 +1178,14 @@ class Cache:
                         ref._archiver.path, self.data, dirs_exist_ok=True)
 
                 set_permissions(destination, READ_ONLY_FILE, READ_ONLY_DIR)
+            else:
+                # Check for annotation whatever
+                existing = Result._from_archiver(Archiver.load_raw(destination, self))
+                existing.merge_annotations(ref)
 
+    # TODO: If multiple instances of the same artifact are put into the cache
+    # with different annotations, we merge the annotations. If there are
+    # namespace collisions, throw a warning and append UUID to end of name?
     def _rename_to_data(self, uuid, src):
         """Takes some data in src and renames it into the cache's data dir. It
         then ensures there are symlinks for this data in the process pool and
@@ -1203,6 +1216,11 @@ class Cache:
             if not os.path.exists(dest):
                 os.rename(src, dest)
                 set_permissions(dest, READ_ONLY_FILE, READ_ONLY_DIR)
+            else:
+                # Check for annotation whatever
+                existing = Result._from_archiver(Archiver.load_raw(dest, self))
+                new = Result._from_archiver(Archiver.load_raw(src, self))
+                existing.merge_annotations(new)
 
             # Create a new alias whether we renamed or not because this is
             # still loading a new reference to the data even if the data is

--- a/qiime2/core/tests/test_cache.py
+++ b/qiime2/core/tests/test_cache.py
@@ -676,3 +676,73 @@ class TestCache(unittest.TestCase):
             ValueError, f"The cache at `{self.cache.path}`.*`{future_version}`"
                         f".*`{Cache.CURRENT_FORMAT_VERSION}`"):
             Cache.is_cache(self.cache.path)
+
+    def test_annotation_merge(self):
+        art1_path = os.path.join(self.test_dir.name, 'art1.qza')
+        art1_copy_path = os.path.join(self.test_dir.name, 'art1_copy.qza')
+
+        self.art1.save(art1_path)
+        self.art1.save(art1_copy_path)
+
+        # Use different caches to force creation of two different on disk
+        # representations of the artifact
+        cache2 = Cache(os.path.join(self.test_dir.name, 'new_cache2'))
+        cache3 = Cache(os.path.join(self.test_dir.name, 'new_cache3'))
+
+        with cache2:
+            art1 = qiime2.sdk.Result.load(art1_path)
+            self.assertEqual(art1._annotations, {})
+            Note1 = qiime2.core.annotate.Note(name='annotation-1', text='1')
+            art1.add_annotation(Note1)
+            self.cache.save(art1, 'annotation-1')
+            art1_annotation1 = self.cache.load('annotation-1')
+
+        self.assertEqual(
+            set(art1_annotation1._annotations.keys()), set(['annotation-1']))
+
+        with cache3:
+            art1_copy = qiime2.sdk.Result.load(art1_copy_path)
+            self.assertEqual(art1_copy._annotations, {})
+            Note2 = qiime2.core.annotate.Note(name='annotation-2', text='2')
+            art1_copy.add_annotation(Note2)
+            self.cache.save(art1_copy, 'annotation-2')
+            art1_both_annotations = self.cache.load('annotation-2')
+
+        self.assertEqual(
+            set(art1_both_annotations._annotations.keys()),
+            set(['annotation-1', 'annotation-2']))
+
+    def test_annotation_merge_collisions(self):
+        art1_path = os.path.join(self.test_dir.name, 'art1.qza')
+        art1_copy_path = os.path.join(self.test_dir.name, 'art1_copy.qza')
+
+        self.art1.save(art1_path)
+        self.art1.save(art1_copy_path)
+
+        # Use different caches to force creation of two different on disk
+        # representations of the artifact
+        cache2 = Cache(os.path.join(self.test_dir.name, 'new_cache2'))
+        cache3 = Cache(os.path.join(self.test_dir.name, 'new_cache3'))
+
+        with cache2:
+            art1 = qiime2.sdk.Result.load(art1_path)
+            Note1 = qiime2.core.annotate.Note(name='annotation-1', text='1')
+            art1.add_annotation(Note1)
+            self.cache.save(art1, 'annotation-1')
+            art1_annotation1 = self.cache.load('annotation-1')
+
+        self.assertEqual(
+            set(art1_annotation1._annotations.keys()), set(['annotation-1']))
+
+        with cache3:
+            art1_copy = qiime2.sdk.Result.load(art1_copy_path)
+            Note2 = qiime2.core.annotate.Note(
+                name='annotation-1', text='1 again')
+            art1_copy.add_annotation(Note2)
+            with self.assertWarnsRegex(Warning, 'Duplicate name annotation-1'):
+                self.cache.save(art1_copy, 'annotation-1')
+            art1_both_annotations = self.cache.load('annotation-1')
+
+        self.assertEqual(
+            set(art1_both_annotations._annotations.keys()),
+            set(['annotation-1', f'annotation-1-{Note2.id}']))

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -457,10 +457,10 @@ class Result(IResult):
 
     def merge_annotations(self, other):
         annotation_uuids = \
-            [annotation.id for annotation in self._annotations.values()]
+            [str(annotation.id) for annotation in self._annotations.values()]
 
         for other_annotation in other._annotations.values():
-            if other_annotation.id not in annotation_uuids:
+            if str(other_annotation.id) not in annotation_uuids:
                 try:
                     self.add_annotation(other_annotation)
                 except ValueError as e:

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -362,6 +362,7 @@ class Result(IResult):
                 'they are attached to.'
             )
 
+        print(annotation.contents)
         annotation._write(annotations_dir=self._archiver.annotations_dir,
                           root_result_uuid=str(self.uuid),
                           referenced_result_uuid=str(self.uuid))
@@ -454,6 +455,27 @@ class Result(IResult):
 
         shutil.rmtree(annotation_disk_dir)
         del annotations[name]
+
+    def merge_annotations(self, other):
+        print(self._archiver.path)
+        print(other._archiver.path)
+        annotation_uuids = [annotation.id for annotation in self._annotations.values()]
+
+        for other_annotation in other._annotations.values():
+            if other_annotation.id not in annotation_uuids:
+                try:
+                    self.add_annotation(other_annotation)
+                except ValueError as e:
+                    if 'Duplicate name' in str(e):
+                        warnings.warn(f'Duplicate name {other_annotation.name}'
+                                      ' found. The annotation UUID will be'
+                                      ' prepended to the name of the new'
+                                      ' annotation.')
+                        other_annotation.name = \
+                            f'{other_annotation.name}-{other_annotation.id}'
+                        self.add_annotation(other_annotation)
+                    else:
+                        raise e
 
 
 class Artifact(Result):

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -456,7 +456,8 @@ class Result(IResult):
         del annotations[name]
 
     def merge_annotations(self, other):
-        annotation_uuids = [annotation.id for annotation in self._annotations.values()]
+        annotation_uuids = \
+            [annotation.id for annotation in self._annotations.values()]
 
         for other_annotation in other._annotations.values():
             if other_annotation.id not in annotation_uuids:

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -362,7 +362,6 @@ class Result(IResult):
                 'they are attached to.'
             )
 
-        print(annotation.contents)
         annotation._write(annotations_dir=self._archiver.annotations_dir,
                           root_result_uuid=str(self.uuid),
                           referenced_result_uuid=str(self.uuid))
@@ -457,8 +456,6 @@ class Result(IResult):
         del annotations[name]
 
     def merge_annotations(self, other):
-        print(self._archiver.path)
-        print(other._archiver.path)
         annotation_uuids = [annotation.id for annotation in self._annotations.values()]
 
         for other_annotation in other._annotations.values():

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -469,6 +469,9 @@ class Result(IResult):
                                       ' found. The annotation UUID will be'
                                       ' prepended to the name of the new'
                                       ' annotation.')
+                        # It should not be possible for this to collide because
+                        # we only get here if this annotation.id isn't present
+                        # on the artifact.
                         other_annotation.name = \
                             f'{other_annotation.name}-{other_annotation.id}'
                         self.add_annotation(other_annotation)


### PR DESCRIPTION
Merge annotations in cache if an artifact is added to a cache twice with two different sets of annotations.

Prior behavior would be to just ignore the second addition of the artifact.

Closes #869 