### PR TITLE
MAINT: Only remove set permissions none o that fancy thread

### DIFF
--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -837,6 +837,12 @@ class Cache:
                     # We may not have permissions because old versions of
                     # QIIME 2 set entries in data to read-only. If we encounter
                     # that then set write permissions here and try again.
+                    #
+                    # This try-except will induce a slight performance overhead
+                    # in Python versions pre 3.11, but much less than running
+                    # set_permissions every time. In Python 3.11 and on,
+                    # try-except introduces no performance penalty if an
+                    # exception is not raised.
                     except PermissionError as e:
                         if e.errno == 13:
                             set_permissions(target, None, USER_GROUP_RWX)

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -832,7 +832,16 @@ class Cache:
 
                 if data not in referenced_data:
                     target = self.data / data
-                    shutil.rmtree(target)
+                    try:
+                        shutil.rmtree(target)
+                    # We may not have permissions because old versions of
+                    # QIIME 2 set entries in data to read-only. If we encounter
+                    # that then set write permissions here and try again.
+                    except PermissionError as e:
+                        if e.errno == 13:
+                            set_permissions(target, None, USER_GROUP_RWX)
+                            shutil.rmtree(target)
+                        raise e
 
     def _check_dangling_reference(self, data_path, key_path):
         """ If the data specified does not exist then we have a dangling

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -841,7 +841,8 @@ class Cache:
                         if e.errno == 13:
                             set_permissions(target, None, USER_GROUP_RWX)
                             shutil.rmtree(target)
-                        raise e
+                        else:
+                            raise e
 
     def _check_dangling_reference(self, data_path, key_path):
         """ If the data specified does not exist then we have a dangling

--- a/qiime2/core/cache.py
+++ b/qiime2/core/cache.py
@@ -52,8 +52,7 @@ import qiime2
 from .path import ArchivePath
 from qiime2.sdk.result import Result
 from qiime2.core.util import (is_uuid4, set_permissions, touch_under_path,
-                              load_action_yaml, READ_ONLY_FILE, READ_ONLY_DIR,
-                              USER_GROUP_RWX)
+                              load_action_yaml, USER_GROUP_RWX)
 from qiime2.core.archive.archiver import Archiver
 from qiime2.core.type import HashableInvocation, IndexedCollectionElement
 
@@ -833,8 +832,6 @@ class Cache:
 
                 if data not in referenced_data:
                     target = self.data / data
-
-                    set_permissions(target, None, USER_GROUP_RWX)
                     shutil.rmtree(target)
 
     def _check_dangling_reference(self, data_path, key_path):
@@ -1171,8 +1168,6 @@ class Cache:
                     shutil.copytree(
                         ref._archiver.path, self.data, dirs_exist_ok=True)
 
-                set_permissions(destination, READ_ONLY_FILE, READ_ONLY_DIR)
-
     def _rename_to_data(self, uuid, src):
         """Takes some data in src and renames it into the cache's data dir. It
         then ensures there are symlinks for this data in the process pool and
@@ -1202,7 +1197,6 @@ class Cache:
             # Rename errors if the destination already exists
             if not os.path.exists(dest):
                 os.rename(src, dest)
-                set_permissions(dest, READ_ONLY_FILE, READ_ONLY_DIR)
 
             # Create a new alias whether we renamed or not because this is
             # still loading a new reference to the data even if the data is


### PR DESCRIPTION
Only the removal of set permissions in #849 not the thread that is causing issues on MacOS.

The only potential issue with this is if someone has a very old cache that still has read-only permissions set on something. The cache has not set those permissions for some time because `set_permissions` has been no-oped on anything but `USER_GROUP_RWX` for some time. The only one of these calls that actually did anything was the one setting those permissions in GC to make sure it could be garbage collected.