### PR TITLE
MAINT: Use archiver.validate_checksums

### DIFF
--- a/qiime2/core/archive/provenance_lib/_checksum_validator.py
+++ b/qiime2/core/archive/provenance_lib/_checksum_validator.py
@@ -6,13 +6,12 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 from enum import IntEnum
-import pathlib
 import warnings
 from typing import Optional, Tuple
 from zipfile import ZipFile
 
-from qiime2.core.util import checksum_directory_zip, from_checksum_format
 from qiime2.core.archive.archiver import ChecksumDiff
+from qiime2.sdk.result import Result
 
 from .util import get_root_uuid, parse_version
 
@@ -56,6 +55,7 @@ class ValidationCode(IntEnum):
 
 
 def validate_checksums(
+    archive: str,
     zf: ZipFile
 ) -> Tuple[ValidationCode, Optional[ChecksumDiff]]:
     '''
@@ -65,6 +65,8 @@ def validate_checksums(
 
     Parameters
     ----------
+    archive : str
+        A path to the artifact to be parsed.
     zf : ZipFile
         The zipfile object of the archive.
 
@@ -75,6 +77,7 @@ def validate_checksums(
         set ChecksumDiff to None and ValidationCode to INVALID and return.
 
     '''
+    result: Result = Result.load(archive)
     checksum_diff: Optional[ChecksumDiff]
     provenance_is_valid = ValidationCode.VALID
     checksum_ext = _parse_checksum_ext(zf)
@@ -90,7 +93,7 @@ def validate_checksums(
         )
         return ValidationCode.INVALID, None
 
-    checksum_diff = diff_checksums(zf)
+    checksum_diff = result._archiver.validate_checksums()
     if checksum_diff != ChecksumDiff({}, {}, {}):
         root_uuid = get_root_uuid(zf)
         warnings.warn(
@@ -106,57 +109,6 @@ def validate_checksums(
         provenance_is_valid = ValidationCode.INVALID
 
     return provenance_is_valid, checksum_diff
-
-
-def diff_checksums(zf: ZipFile) -> ChecksumDiff:
-    '''
-    Calculates checksums for all files in an archive
-    (except checksums.md5 or checksums.sha512,
-    depending on the archive version).
-    Compares these against the checksums stored in
-    checksums.md5/checksums.sha512, returning a summary ChecksumDiff.
-
-    Parameters
-    ----------
-    zf : ZipFile
-        The zipfile object of the archive.
-
-    Returns
-    -------
-    ChecksumDiff
-        A tuple of three dicts, one each for added, removed, and changed
-        files. Keys are filepaths. For the added and removed dicts
-        values are the checksum of the added or removed file. For the changed
-        dict values are a tuple of (expected checksum, observed checksum).
-
-    '''
-    archive_version, _ = parse_version(zf)
-    # TODO: don't think this is ever called
-    if float(archive_version) < 5.0:
-        return ChecksumDiff({}, {}, {})
-
-    checksum_ext = _parse_checksum_ext(zf)
-
-    root_dir = pathlib.Path(get_root_uuid(zf))
-    checksum_fp = str(root_dir / f'checksums.{checksum_ext}')
-    obs = checksum_directory_zip(zf, checksum_type=checksum_ext)
-
-    exp = {}
-    for line in zf.open(checksum_fp):
-        fp, checksum = from_checksum_format(str(line, 'utf-8'))
-        exp[fp] = checksum
-
-    obs_fps = set(obs)
-    exp_fps = set(exp)
-
-    added = {fp: obs[fp] for fp in obs_fps - exp_fps}
-    removed = {fp: exp[fp] for fp in exp_fps - obs_fps}
-    changed = {
-        fp: (exp[fp], obs[fp]) for fp in exp_fps & obs_fps
-        if exp[fp] != obs[fp]
-    }
-
-    return ChecksumDiff(added=added, removed=removed, changed=changed)
 
 
 def _parse_checksum_ext(zf):

--- a/qiime2/core/archive/provenance_lib/archive_parser.py
+++ b/qiime2/core/archive/provenance_lib/archive_parser.py
@@ -702,7 +702,7 @@ class ParserV0(ArchiveParser):
         with ZipFile(archive) as zf:
             if cfg.perform_checksum_validation:
                 provenance_is_valid, checksum_diff = \
-                    self._validate_checksums(zf)
+                    self._validate_checksums(archive, zf)
             else:
                 provenance_is_valid = ValidationCode.VALIDATION_OPTOUT
                 checksum_diff = None
@@ -764,7 +764,9 @@ class ParserV0(ArchiveParser):
         return _ResultMetadata(zf, root_md_fp)
 
     def _validate_checksums(
-            self, zf: ZipFile
+            self,
+            archive: str,
+            zf: ZipFile
     ) -> Tuple[ValidationCode, Optional[ChecksumDiff]]:
         '''
         Return the ValidationCode and ChecksumDiff for an archive. Because
@@ -774,6 +776,8 @@ class ParserV0(ArchiveParser):
 
         Parameters
         ----------
+        archive : str
+            A path to the artifact to be parsed.
         zf : ZipFile
             The zipfile object representing the archive. Ignored here but
             needed in signature for inheritance.
@@ -947,7 +951,7 @@ class ParserV2(ParserV1):
         with ZipFile(archive) as zf:
             if cfg.perform_checksum_validation:
                 provenance_is_valid, checksum_diff = \
-                    self._validate_checksums(zf)
+                    self._validate_checksums(archive, zf)
             else:
                 provenance_is_valid = ValidationCode.VALIDATION_OPTOUT
                 checksum_diff = None
@@ -1053,13 +1057,17 @@ class ParserV5(ParserV4):
     expected_files_all_nodes = ParserV4.expected_files_all_nodes
 
     def _validate_checksums(
-            self, zf: ZipFile
+            self,
+            archive: str,
+            zf: ZipFile
     ) -> Tuple[ValidationCode, Optional[ChecksumDiff]]:
         '''
         Checksum support added for v5, so perform checksum validation.
 
         Parameters
         ----------
+        archive : str
+            A path to the artifact to be parsed.
         zf : ZipFile
             The zipfile object representation of the parsed archive.
 
@@ -1079,7 +1087,7 @@ class ParserV5(ParserV4):
         than in pre-V5 archive parsers, the ChecksumDiff should only be
         intepreted in conjuction with the ValidationCode.
         '''
-        return validate_checksums(zf)
+        return validate_checksums(archive, zf)
 
 
 class ParserV6(ParserV5):

--- a/qiime2/core/archive/provenance_lib/tests/test_archive_parser.py
+++ b/qiime2/core/archive/provenance_lib/tests/test_archive_parser.py
@@ -117,7 +117,8 @@ class ParserVxTests(unittest.TestCase):
         for artifact in self.das.all_artifact_versions:
             parser = ArchiveParser.get_parser(artifact.filepath)
             with zipfile.ZipFile(artifact.filepath) as zf:
-                is_valid, diff = parser._validate_checksums(zf)
+                is_valid, diff = parser._validate_checksums(
+                    artifact.filepath, zf)
                 if artifact.archive_version < 5:
                     self.assertEqual(is_valid,
                                      ValidationCode.PREDATES_CHECKSUMS)

--- a/qiime2/core/archive/provenance_lib/tests/test_checksum_validator.py
+++ b/qiime2/core/archive/provenance_lib/tests/test_checksum_validator.py
@@ -38,7 +38,7 @@ class ValidateChecksumTests(unittest.TestCase):
         int_seq.save(fp)
 
         with zipfile.ZipFile(fp) as zf:
-            is_valid, diff = validate_checksums(zf)
+            is_valid, diff = validate_checksums(fp, zf)
         self.assertEqual(is_valid, ValidationCode.VALID)
         self.assertEqual(diff, ChecksumDiff({}, {}, {}))
 
@@ -73,7 +73,7 @@ class ValidateChecksumTests(unittest.TestCase):
             write_zip_archive(fp, tempdir)
 
         with zipfile.ZipFile(fp) as zf:
-            is_valid, diff = validate_checksums(zf)
+            is_valid, diff = validate_checksums(fp, zf)
 
         self.assertEqual(is_valid, ValidationCode.INVALID)
         self.assertEqual(list(diff.added.keys()), ['tamper.txt'])
@@ -97,7 +97,7 @@ class ValidateChecksumTests(unittest.TestCase):
             write_zip_archive(fp, tempdir)
 
         with zipfile.ZipFile(fp) as zf:
-            is_valid, diff = validate_checksums(zf)
+            is_valid, diff = validate_checksums(fp, zf)
 
         self.assertEqual(is_valid, ValidationCode.INVALID)
         self.assertEqual(diff, None)


### PR DESCRIPTION
Closes #857 

But I don't think we actually want to close that second checkbox, and I think this PR kinda shows why.

Provenance lib never loads the thing it's looking at as an actual Result. If I recall correctly, this decision was made so that when it was initially not a part of the QIIME 2 framework, it could be divorced from QIIME 2 basically entirely, right? I wasn't involved in any of that planning back in ye olden days, so I'm not sure.

That being said, it is very cludgy at this point to load a Result and call methods on it in provenance lib because it is passing things around as raw filepaths and zipfiles, and whatnot. In this instance, provenance lib also has some additional data it relies on that isn't provided by `Archiver.validate_checksums`

I think if we want to get rid of provenance lib's redundant checksum validation, we will probably want to do a mass refactor of provenance lib to load the file as a Result from the beginning and assume we will actually have a Result for all of the things it does. This would help with other things as well, such as qiime2/q2cli#310.
