### PR TITLE
PATCH: fix ArchiveFormat & UnknownAnnotation type bugs

### DIFF
--- a/qiime2/core/annotate.py
+++ b/qiime2/core/annotate.py
@@ -249,6 +249,8 @@ class UnknownAnnotation(Annotation):
     """Utility sub-class that handles loading newer Annotation types on an
     older version of QIIME 2 that supports Annotations.
     """
+    annotation_type = 'Unknown'
+
     def __init__(*args):
         raise NotImplementedError('`UnknownAnnotation` is an abstract class'
                                   ' used for handling Annotations associated'

--- a/qiime2/core/archive/archiver.py
+++ b/qiime2/core/archive/archiver.py
@@ -270,7 +270,7 @@ class ArchiveCheck(_Archive):
 
 
 class Archiver:
-    CURRENT_FORMAT_VERSION = '7.0'
+    CURRENT_FORMAT_VERSION = '7.1'
     _FORMAT_REGISTRY = {
         # NOTE: add more archive formats as things change
         '0': 'qiime2.core.archive.format.v0:ArchiveFormat',
@@ -280,7 +280,8 @@ class Archiver:
         '4': 'qiime2.core.archive.format.v4:ArchiveFormat',
         '5': 'qiime2.core.archive.format.v5:ArchiveFormat',
         '6': 'qiime2.core.archive.format.v6:ArchiveFormat',
-        '7.0': 'qiime2.core.archive.format.v7_0:ArchiveFormat'
+        '7.0': 'qiime2.core.archive.format.v7_0:ArchiveFormat',
+        '7.1': 'qiime2.core.archive.format.v7_1:ArchiveFormat'
     }
 
     @classmethod

--- a/qiime2/core/archive/provenance_lib/archive_parser.py
+++ b/qiime2/core/archive/provenance_lib/archive_parser.py
@@ -1137,5 +1137,6 @@ FORMAT_REGISTRY = {
     '4': ParserV4,
     '5': ParserV5,
     '6': ParserV6,
-    '7.0': ParserV7
+    '7.0': ParserV7,
+    '7.1': ParserV7
 }

--- a/qiime2/core/archive/tests/test_archiver.py
+++ b/qiime2/core/archive/tests/test_archiver.py
@@ -12,6 +12,7 @@ import unittest
 import uuid
 import zipfile
 import pathlib
+import importlib
 
 from qiime2.sdk.result import Result
 from qiime2.core.annotate import Note
@@ -393,6 +394,41 @@ class TestArchiver(unittest.TestCase, ArchiveTestingMixin):
         self.assertEqual(diff.added, {})
         self.assertEqual(diff.removed, {})
         self.assertEqual(diff.changed, {})
+
+    def test_archive_versions_match_current_format_version(self):
+        """
+        Another deadman switch to assert that we haven't created a new
+        Archive Format without updating the _FORMAT_REGISTRY and the
+        CURRENT_FORMAT_VERSION
+
+        If this test fails, it's because a new Archive Format was added
+        without being included in the Archiver's format registry
+        """
+        # pull the listed current archive version from the Archiver
+        # syntax for this will look like:
+        # qiime2.core.archive.format.vwhatever:ArchiveFormat
+        current_archive_ver, class_name = \
+            Archiver._FORMAT_REGISTRY[
+                Archiver.CURRENT_FORMAT_VERSION].split(':')
+
+        # grap all archive format paths
+        from qiime2.core.archive import format
+        paths = os.listdir(format.__path__[0])
+
+        # rip apart each path to grab the format names and import them
+        for path in paths:
+            if path.endswith('py') and not path.startswith('__init__'):
+                importlib.import_module(
+                    f'qiime2.core.archive.format.{path.split(".py")[0]}'
+                    )
+
+        # construct the latest ArchiveFormat based on the format registry
+        ArchiveFormat = \
+            getattr(importlib.import_module(current_archive_ver), class_name)
+
+        # ensure there are no subclasses (ie new archive versions that
+        # havent been added to the format registry)
+        self.assertEqual(ArchiveFormat.__subclasses__(), [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes two bugs:
1. when attempting to view a result with a signature on it (using either QIIME 2 2025.4 or 2025.7), an error is raised bc there's no associated annotation_type for an UnknownAnnotation. This was an oversight based on the @property decorator used for annotation_type - but has been fixed by setting the annotation_type to `Unknown`.
2. the new archive format 7.1 wasn't added to the format registry. this wasn't caught because there wasn't a test to assert that the newest existing archive format also existed in the format registry & was set to the current format version. this has been both fixed and a deadman switch test has been added (although ugly) to ensure a failure if this is forgotten in future versions.