### PR TITLE
BUG: handle old artifact formats in checksum cache

### DIFF
--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -1178,6 +1178,9 @@ class ChecksumCache:
             True if the artifact uses the same checksum type as the current
             one, False otherwise.
         '''
+        if not artifact._archiver.has_checksums():
+            return False
+
         artifact_checksum_type = artifact._archiver._fmt.CHECKSUM_TYPE
         current_checksum_type = archive.Archiver.get_format_class(
             archive.Archiver.CURRENT_FORMAT_VERSION

--- a/qiime2/sdk/tests/test_checksum_cache.py
+++ b/qiime2/sdk/tests/test_checksum_cache.py
@@ -6,15 +6,21 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from pathlib import Path
+import tempfile
 import unittest
 import uuid
 
+import qiime2
 from qiime2 import Artifact
 from qiime2.sdk.result import ChecksumCache
 from qiime2.core.testing.type import IntSequence1, Mapping
 from qiime2.core.testing.util import get_dummy_plugin
 from qiime2.core.util import checksum_native, checksum_python
 from qiime2.core.archive.format.util import artifact_version
+from qiime2.core.archive.provenance_lib.tests.testing_utilities import (
+    write_zip_file
+)
 
 
 class TestChecksumCache(unittest.TestCase):
@@ -119,3 +125,22 @@ class TestChecksumCache(unittest.TestCase):
         for output in outputs:
             if isinstance(output, Artifact):
                 output.validate_checksums()
+
+    def test_checksum_cache_handles_artifacts_with_no_checksums(self):
+        '''
+        Tests that artifacts with a format that does not contain checksums are
+        handled by the checksum cache.
+        '''
+        v3_artifact_dir = (
+            Path(qiime2.__file__).parent / 'core' / 'archive' /
+            'provenance_lib' / 'tests' / 'data' / 'concated-ints-v3'
+        )
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_zf_path = Path(tempdir) / 'v3-artifact.zip'
+            write_zip_file(temp_zf_path, v3_artifact_dir)
+            v3_artifact = Artifact.load(temp_zf_path)
+
+        ints1, ints2 = self.plugin.actions['split_ints'](v3_artifact)
+        ints1.validate_checksums()
+        ints2.validate_checksums()


### PR DESCRIPTION
Fixes a bug where artifacts of version < 5 caused the checksum cache to crash due to a missing `CHECKSUM_TYPE`. The test added in this PR is apparently the only test that runs an action on a pre-v5 artifact, which is concerning. I only noticed the bug when running feature table tests which download old artifacts in the examples. 