### PR TITLE
MAINT: remove validate calls

### DIFF
--- a/qiime2/sdk/action.py
+++ b/qiime2/sdk/action.py
@@ -296,10 +296,8 @@ class Action(metaclass=abc.ABCMeta):
             checksum_cache = ChecksumCache()
             for input in collated_inputs.values():
                 if isinstance(input, Artifact):
-                    input.validate_checksums()
                     checksum_cache.cache_artifact(input)
                 elif isinstance(input, ResultCollection):
-                    input.validate_checksums()
                     checksum_cache.cache_result_collection(input)
 
             callable_args, captures = \


### PR DESCRIPTION
No longer performs checksum validation of inputs during actions, due to performance concerns with large input artifacts, e.g. those encountered in MOSPHIT.