### PR TITLE
update readme to delineate rachis vs Q2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ![](https://github.com/qiime2/qiime2/workflows/ci-dev/badge.svg)
 
-Source code repository for the QIIME 2™ Framework.
+Source code repository for the rachis Framework (the framework formerly known as the QIIME 2™ Framework).
 
 Are you looking for:
-- the QIIME 2 homepage? That's [https://qiime2.org](https://qiime2.org).
+- the project homepage? That's [https://qiime2.org](https://qiime2.org).
+- an explanation of why we now call this framework `rachis`, and how it is different from QIIME 2? See [this announcement](https://news.rachis.org/en/latest/2025-10-23-q2f-transition.html). (and don't worry, the QIIME 2 that you know and love is still alive and well!)
 - learning resources for microbiome marker gene (i.e., amplicon) analysis? See the [QIIME 2 *amplicon distribution* documentation](https://amplicon-docs.readthedocs.io).
 - learning resources for microbiome metagenome analysis? See the [MOSHPIT documentation](https://moshpit.readthedocs.io).
 - installation instructions, plugins, books, videos, workshops, or resources? See the [QIIME 2 Library](https://library.qiime2.org).
@@ -13,6 +14,6 @@ Are you looking for:
 - information about contributing? See the [Contributing Guide](https://github.com/qiime2/.github/blob/main/CONTRIBUTING.md).
 - information about the developers? See the [Caporaso Lab website](https://caplab.bio).
 
-## Citing QIIME 2
+## Citing rachis
 
-If you use QIIME 2 for any published research, please cite [Bolyen, Rideout, Dillon, Bokulich, et al. (2019)](https://doi.org/10.1038/s41587-019-0209-9).
+If you use rachis, QIIME 2, or any rachis distributions for any published research, please cite [Bolyen, Rideout, Dillon, Bokulich, et al. (2019)](https://doi.org/10.1038/s41587-019-0209-9).


### PR DESCRIPTION
I notice that the readme is largely unchanged and still refers to this repo as the source code for QIIME 2, etc.

This PR updates the readme to differentiate rachis and QIIME 2 and point to @gregcaporaso 's announcement for now until the migration is fully complete (at which point some of the documentation links and language might need to change in a later PR)