### PR TITLE
Validate usage output names (and just standardize the method we use to do that to a util)

### DIFF
--- a/src/rachis/core/annotate.py
+++ b/src/rachis/core/annotate.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from rachis.core.util import (find_root_fp, sha512_file_hex,
                               gpg_find_key, format_algorithm,
                               unix_gpg_terminal_helper)
+from rachis.util import is_valid_python_identifier
 
 
 class Annotation():
@@ -151,7 +152,7 @@ class Annotation():
             If the Annotation base class is instantiated.
 
         """
-        self.validate_name(name)
+        is_valid_python_identifier(name, 'name')
 
         if type(self) is Annotation:
             raise TypeError('Annotation is an abstract class'
@@ -159,29 +160,6 @@ class Annotation():
         self.name = name
         self.id = _uuid.uuid4()
         self.created_at = datetime.now()
-
-    def validate_name(self, name):
-        """Validates that the given name is a valid Python idenitifier with the
-        exception that `-` is allowed.
-
-        Parameters
-        ----------
-        name : str
-            The name to validate.
-
-        Raises
-        ------
-        ValueError
-            If the name passed in is not a valid Python identifier.
-        """
-        validate_name = name.replace('-', '_')
-        if not validate_name.isidentifier():
-            raise ValueError(f'Name "{name}" is not a valid Python identifier.'
-                             ' Keys may contain `-` characters but must'
-                             ' otherwise be valid Python identifiers. Python'
-                             ' identifier rules may be found here'
-                             ' https://www.askpython.com/python/'
-                             'python-identifiers-rules-best-practices')
 
     def _write_meta_yaml(self, annotations_dir,
                          root_result_uuid, referenced_result_uuid,

--- a/src/rachis/core/annotate.py
+++ b/src/rachis/core/annotate.py
@@ -152,7 +152,7 @@ class Annotation():
             If the Annotation base class is instantiated.
 
         """
-        is_valid_python_identifier(name, 'name')
+        self.validate_name(name)
 
         if type(self) is Annotation:
             raise TypeError('Annotation is an abstract class'
@@ -160,6 +160,22 @@ class Annotation():
         self.name = name
         self.id = _uuid.uuid4()
         self.created_at = datetime.now()
+
+    def validate_name(self, name):
+        """Validates that the given name is a valid Python idenitifier with the
+        exception that `-` is allowed.
+
+        Parameters
+        ----------
+        name : str
+            The name to validate.
+
+        Raises
+        ------
+        ValueError
+            If the name passed in is not a valid Python identifier.
+        """
+        is_valid_python_identifier(name, 'name')
 
     def _write_meta_yaml(self, annotations_dir,
                          root_result_uuid, referenced_result_uuid,

--- a/src/rachis/core/cache.py
+++ b/src/rachis/core/cache.py
@@ -690,32 +690,6 @@ class Cache:
                          " can only handle version "
                          f"`{cls.CURRENT_FORMAT_VERSION}` and earlier")
 
-    @classmethod
-    def validate_key(cls, key):
-        """Validates that the given key is a valid Python idenitifier with the
-        exception that - is allowed.
-
-        Parameters
-        ----------
-        key : str
-            The name of the key to validate.
-
-        Raises
-        ------
-        ValueError
-            If the key passed in is not a valid Python identifier. We enforce
-            this to ensure no one creates keys that cause issues when we try to
-            load them.
-        """
-        validation_key = key.replace('-', '_')
-        if not validation_key.isidentifier():
-            raise ValueError(f"Key '{key}' is not a valid Python identifier. "
-                             "Keys may contain '-' characters but must "
-                             "otherwise be valid Python identifiers. Python "
-                             "identifier rules may be found here "
-                             "https://www.askpython.com/python/"
-                             "python-identifiers-rules-best-practices")
-
     def _create_cache_contents(self):
         """Create the cache directory, all sub directories, and the version
         file.
@@ -1033,7 +1007,7 @@ class Cache:
         pool : bool
             Whether we are keying a pool or not.
         """
-        self.validate_key(key)
+        rachis.util.is_valid_python_identifier(key, 'key')
         key_fp = self.keys / key
 
         key_dict = {}

--- a/src/rachis/core/cache.py
+++ b/src/rachis/core/cache.py
@@ -690,6 +690,25 @@ class Cache:
                          " can only handle version "
                          f"`{cls.CURRENT_FORMAT_VERSION}` and earlier")
 
+    @classmethod
+    def validate_key(cls, key):
+        """Validates that the given key is a valid Python idenitifier with the
+        exception that - is allowed.
+
+        Parameters
+        ----------
+        key : str
+            The name of the key to validate.
+
+        Raises
+        ------
+        ValueError
+            If the key passed in is not a valid Python identifier. We enforce
+            this to ensure no one creates keys that cause issues when we try to
+            load them.
+        """
+        rachis.util.is_valid_python_identifier(key, 'key')
+
     def _create_cache_contents(self):
         """Create the cache directory, all sub directories, and the version
         file.
@@ -1007,7 +1026,7 @@ class Cache:
         pool : bool
             Whether we are keying a pool or not.
         """
-        rachis.util.is_valid_python_identifier(key, 'key')
+        self.validate_key(key)
         key_fp = self.keys / key
 
         key_dict = {}

--- a/src/rachis/sdk/usage.py
+++ b/src/rachis/sdk/usage.py
@@ -380,13 +380,7 @@ class UsageOutputNames:
         UsageInputs
         Usage.action
         """
-        for key, val in kwargs.items():
-            if not isinstance(val, str):
-                raise TypeError(
-                    'Name provided for key %r must be a string, not a %r.' %
-                    (key, type(val)))
-            rachis.util.is_valid_python_identifier(val, 'name')
-
+        self.validate_names(kwargs)
         self.values = kwargs
 
     def __repr__(self):
@@ -411,6 +405,29 @@ class UsageOutputNames:
         example.
         """
         return key in self.values
+
+    def validate_names(self, kwargs):
+        """
+        Validates that all names for output vars are strings and follow our
+        usual naming rules of Python identifier + -
+
+        kwargs : str
+            The name of the resulting variables to be returned by
+            :meth:`Usage.action`.
+
+        Raises
+        ------
+        ValueError
+            If the value passed in is not a string or not a valid Python
+            identifier.
+        """
+        for key, val in kwargs.items():
+            if not isinstance(val, str):
+                raise TypeError(
+                    'Name provided for key %r must be a string, not a %r.' %
+                    (key, type(val)))
+            rachis.util.is_valid_python_identifier(val, 'name')
+
 
     def items(self):
         """Same as a dictionary.

--- a/src/rachis/sdk/usage.py
+++ b/src/rachis/sdk/usage.py
@@ -381,11 +381,11 @@ class UsageOutputNames:
         Usage.action
         """
         for key, val in kwargs.items():
-            rachis.util.is_valid_python_identifier(val, 'name')
             if not isinstance(val, str):
                 raise TypeError(
                     'Name provided for key %r must be a string, not a %r.' %
                     (key, type(val)))
+            rachis.util.is_valid_python_identifier(val, 'name')
 
         self.values = kwargs
 

--- a/src/rachis/sdk/usage.py
+++ b/src/rachis/sdk/usage.py
@@ -381,6 +381,7 @@ class UsageOutputNames:
         Usage.action
         """
         for key, val in kwargs.items():
+            rachis.util.is_valid_python_identifier(val, 'name')
             if not isinstance(val, str):
                 raise TypeError(
                     'Name provided for key %r must be a string, not a %r.' %

--- a/src/rachis/util.py
+++ b/src/rachis/util.py
@@ -161,7 +161,7 @@ def is_valid_python_identifier(given_string, var_name):
     ------
     ValueError
         If the string passed in is not a valid Python identifier.
-        """
+    """
     replaced_string = given_string.replace('-', '_')
     if not replaced_string.isidentifier():
         raise ValueError(f'{var_name.capitalize()} "{given_string}" is not a'

--- a/src/rachis/util.py
+++ b/src/rachis/util.py
@@ -147,7 +147,7 @@ def get_filepath_from_package(package, relative_filepath):
 
 
 def is_valid_python_identifier(given_string, var_name):
-    """Validates that the given strng is a valid Python idenitifier with the
+    """Validates that the given string is a valid Python idenitifier with the
     exception that `-` is allowed.
 
     Parameters

--- a/src/rachis/util.py
+++ b/src/rachis/util.py
@@ -144,3 +144,29 @@ def get_filepath_from_package(package, relative_filepath):
             f'The requested data asset {fp} does not exist.')
     else:
         return fp
+
+
+def is_valid_python_identifier(given_string, var_name):
+    """Validates that the given strng is a valid Python idenitifier with the
+    exception that `-` is allowed.
+
+    Parameters
+    ----------
+    given_string : str
+        The string to validate.
+    var_name : str
+        The name of the variable. This is templated into the error message
+
+    Raises
+    ------
+    ValueError
+        If the string passed in is not a valid Python identifier.
+        """
+    replaced_string = given_string.replace('-', '_')
+    if not replaced_string.isidentifier():
+        raise ValueError(f'{var_name.capitalize()} "{given_string}" is not a'
+                         f' valid Python identifier. {var_name.capitalize()}s'
+                         ' may contain `-` characters but must otherwise be'
+                         ' valid Python identifiers. Python identifier rules'
+                         ' may be found here https://www.askpython.com/python/'
+                         'python-identifiers-rules-best-practices')


### PR DESCRIPTION
Validate that usage output names follow the same rules as every other name we use, valid Python id + '-', this prevents real weird stuff like qiime2/q2-feature-table#353. This ought to get things close enough to correct for any given interface that `to_interface_name` can handle the rest.