### PR TITLE
DOC: missing warning-note on interface-only API

### DIFF
--- a/src/rachis/sdk/usage.py
+++ b/src/rachis/sdk/usage.py
@@ -410,6 +410,7 @@ class UsageOutputNames:
         """
         Validates that all names for output vars are strings and follow our
         usual naming rules of Python identifier + -
+
         Warning
         -------
         For use by interface drivers only. Do not use in a written usage

--- a/src/rachis/sdk/usage.py
+++ b/src/rachis/sdk/usage.py
@@ -410,6 +410,11 @@ class UsageOutputNames:
         """
         Validates that all names for output vars are strings and follow our
         usual naming rules of Python identifier + -
+        
+        Warning
+        -------
+        For use by interface drivers only. Do not use in a written usage
+        example.
 
         kwargs : str
             The name of the resulting variables to be returned by

--- a/src/rachis/sdk/usage.py
+++ b/src/rachis/sdk/usage.py
@@ -410,7 +410,6 @@ class UsageOutputNames:
         """
         Validates that all names for output vars are strings and follow our
         usual naming rules of Python identifier + -
-        
         Warning
         -------
         For use by interface drivers only. Do not use in a written usage


### PR DESCRIPTION
Just noticed this was missing.