### PR TITLE
Just let em put view types on Pipelines

### DIFF
--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -326,8 +326,25 @@ class PipelineSignature:
                                     " with an input type: %r")
 
     def _assert_valid_views(self, inputs, parameters, outputs):
-        # Just let em use views on Pipelines if they feel like it... what's the
-        # worst that could happen right?
+        """
+        Assert that the view type annotations on a Pipeline, if they are
+        present, are valid. Inputs and outputs must be some form of Result.
+        Parameters don't follow any special rules.
+
+        Parameters
+        ----------
+        inputs : Dict[string : ParameterSpec]
+            The inputs to the Pipeline
+        parameters : Dict[string : ParameterSpec]
+            The parameters to the Pipeline
+        outputs : Dict[string : ParameterSpec]
+            The outputs of the Pipeline
+
+        Raises
+        ------
+        TypeError
+            If a view type annotation on an input or an output is invalid.
+        """
         annotated = self._assert_all_annotated_or_unannotated(
             inputs, parameters, outputs
         )

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -326,13 +326,9 @@ class PipelineSignature:
                                     " with an input type: %r")
 
     def _assert_valid_views(self, inputs, parameters, outputs):
-        for name, spec in itertools.chain(inputs.items(),
-                                          parameters.items(),
-                                          outputs.items()):
-            if spec.has_view_type():
-                raise TypeError(
-                    " Pipelines do not support function annotations (found one"
-                    " for parameter: %r)." % name)
+        # Just let em use views on Pipelines if they feel like it... what's the
+        # worst that could happen right?
+        pass
 
     def coerce_user_input(self, **user_input):
         """ Coerce user inputs to be appropriate for callable

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -345,10 +345,7 @@ class PipelineSignature:
         # TODO: Cleanup the formatting of these error messages
         if annotated:
             for name, spec in inputs.items():
-                if spec.view_type not in [
-                            rachis.sdk.Artifact, list[rachis.sdk.Artifact],
-                            dict[rachis.sdk.Artifact]
-                        ]:
+                if spec.view_type not in VALID_INPUTS:
                     raise ValueError(
                         f'The input {name} has the view type {spec.view_type}.'
                         f' Valid view types for Pipeline inputs are'
@@ -356,13 +353,7 @@ class PipelineSignature:
                     )
 
             for name, spec in outputs.items():
-                if spec.view_type not in [
-                            rachis.sdk.Artifact, list[rachis.sdk.Artifact],
-                            dict[rachis.sdk.Artifact],
-                            rachis.sdk.Visualization,
-                            list[rachis.sdk.Visualization],
-                            dict[rachis.sdk.Visualization]
-                        ]:
+                if spec.view_type not in VALID_OUTPUTS:
                     raise ValueError(
                         f'The output {name} has the view type'
                         f' {spec.view_type}. Valid view types for Pipeline'

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -359,7 +359,6 @@ class PipelineSignature:
             list[rachis.sdk.Visualization], dict[rachis.sdk.Visualization]
         ]
 
-        # TODO: Cleanup the formatting of these error messages
         if annotated:
             for name, spec in inputs.items():
                 if spec.view_type not in VALID_INPUTS:

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -332,13 +332,27 @@ class PipelineSignature:
             inputs, parameters, outputs
         )
 
+        VALID_INPUTS = [
+            rachis.sdk.Artifact, list[rachis.sdk.Artifact],
+            dict[rachis.sdk.Artifact]
+        ]
+        VALID_OUTPUTS = [
+            rachis.sdk.Artifact, list[rachis.sdk.Artifact],
+            dict[rachis.sdk.Artifact], rachis.sdk.Visualization,
+            list[rachis.sdk.Visualization], dict[rachis.sdk.Visualization]
+        ]
+
         if annotated:
             for name, spec in inputs.items():
                 if spec.view_type not in [
                             rachis.sdk.Artifact, list[rachis.sdk.Artifact],
                             dict[rachis.sdk.Artifact]
                         ]:
-                    raise ValueError(f'{name} {spec.view_type}')
+                    raise ValueError(
+                        f'The input {name} has the view type {spec.view_type}.'
+                        f' Valid view types for Pipeline inputs are'
+                        f' {VALID_INPUTS}'
+                    )
 
             for name, spec in outputs.items():
                 if spec.view_type not in [
@@ -348,7 +362,11 @@ class PipelineSignature:
                             list[rachis.sdk.Visualization],
                             dict[rachis.sdk.Visualization]
                         ]:
-                    raise ValueError(f'{name} {spec.view_type}')
+                    raise ValueError(
+                        f'The output {name} has the view type'
+                        f' {spec.view_type}. Valid view types for Pipeline'
+                        f' outputs are {VALID_OUTPUTS}'
+                    )
 
     def _assert_all_annotated_or_unannotated(
                 self, inputs, parameters, outputs

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -342,6 +342,7 @@ class PipelineSignature:
             list[rachis.sdk.Visualization], dict[rachis.sdk.Visualization]
         ]
 
+        # TODO: Cleanup the formatting of these error messages
         if annotated:
             for name, spec in inputs.items():
                 if spec.view_type not in [

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -328,7 +328,68 @@ class PipelineSignature:
     def _assert_valid_views(self, inputs, parameters, outputs):
         # Just let em use views on Pipelines if they feel like it... what's the
         # worst that could happen right?
-        pass
+        annotated = self._assert_all_annotated_or_unannotated(
+            inputs, parameters, outputs
+        )
+
+        if annotated:
+            print(f"Inputs: {inputs}\nOutputs: {outputs}")
+            for name, spec in inputs.items():
+                if spec.view_type not in [
+                            rachis.sdk.Artifact, list[rachis.sdk.Artifact],
+                            dict[rachis.sdk.Artifact]
+                        ]:
+                    raise ValueError(f'{name} {spec.view_type}')
+
+            for name, spec in outputs.items():
+                if spec.view_type not in [
+                            rachis.sdk.Artifact, list[rachis.sdk.Artifact],
+                            dict[rachis.sdk.Artifact],
+                            rachis.sdk.Visualization,
+                            list[rachis.sdk.Visualization],
+                            dict[rachis.sdk.Visualization]
+                        ]:
+                    raise ValueError(f'{name} {spec.view_type}')
+
+    def _assert_all_annotated_or_unannotated(
+                self, inputs, parameters, outputs
+            ):
+        """
+        Asserts that we don't have a mix of annotated and unannotated inputs,
+        parameters, and outputs. All must be annotated or none.
+
+        Parameters
+        ----------
+        inputs : Dict[string : ParameterSpec]
+            The inputs to the Pipeline
+        parameters : Dict[string : ParameterSpec]
+            The parameters to the Pipeline
+        outputs : Dict[string : ParameterSpec]
+            The outputs of the Pipeline
+
+        Returns
+        -------
+        Boolean
+            True if we have annotations False if we don't
+
+        Raises
+        ------
+        TypeError
+            If there is a mix of annotated and unannotated
+        """
+        annotated = False
+
+        all_specs = itertools.chain(
+            inputs.values(), parameters.values(), outputs.values()
+        )
+        if any(spec.has_view_type() for spec in all_specs) and not \
+                (annotated := all(spec.has_view_type() for spec in all_specs)):
+            raise TypeError(
+                "Pipelines must have annotations for all inputs, parameters,"
+                " and outputs or no annotations."
+            )
+
+        return annotated
 
     def coerce_user_input(self, **user_input):
         """ Coerce user inputs to be appropriate for callable

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -346,7 +346,7 @@ class PipelineSignature:
         if annotated:
             for name, spec in inputs.items():
                 if spec.view_type not in VALID_INPUTS:
-                    raise ValueError(
+                    raise TypeError(
                         f'The input {name} has the view type {spec.view_type}.'
                         f' Valid view types for Pipeline inputs are'
                         f' {VALID_INPUTS}'
@@ -354,7 +354,7 @@ class PipelineSignature:
 
             for name, spec in outputs.items():
                 if spec.view_type not in VALID_OUTPUTS:
-                    raise ValueError(
+                    raise TypeError(
                         f'The output {name} has the view type'
                         f' {spec.view_type}. Valid view types for Pipeline'
                         f' outputs are {VALID_OUTPUTS}'

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -349,36 +349,40 @@ class PipelineSignature:
             inputs, parameters, outputs
         )
 
-        VALID_INPUTS = [
-            rachis.sdk.Artifact, list[rachis.sdk.Artifact],
+        VALID_INPUT_ANNOTATIONS = (
+            rachis.sdk.Artifact,
+            list[rachis.sdk.Artifact],
             dict[rachis.sdk.Artifact]
-        ]
-        VALID_OUTPUTS = [
-            rachis.sdk.Artifact, list[rachis.sdk.Artifact],
-            dict[rachis.sdk.Artifact], rachis.sdk.Visualization,
-            list[rachis.sdk.Visualization], dict[rachis.sdk.Visualization]
-        ]
+        )
+        VALID_OUTPUT_ANNOTATIONS = (
+            rachis.sdk.Artifact,
+            list[rachis.sdk.Artifact],
+            dict[rachis.sdk.Artifact],
+            rachis.sdk.Visualization,
+            list[rachis.sdk.Visualization],
+            dict[rachis.sdk.Visualization]
+        )
 
         if annotated:
             for name, spec in inputs.items():
-                if spec.view_type not in VALID_INPUTS:
+                if spec.view_type not in VALID_INPUT_ANNOTATIONS:
                     raise TypeError(
                         f'The input {name} has the view type {spec.view_type}.'
                         f' Valid view types for Pipeline inputs are'
-                        f' {VALID_INPUTS}'
+                        f' {VALID_INPUT_ANNOTATIONS}.'
                     )
 
             for name, spec in outputs.items():
-                if spec.view_type not in VALID_OUTPUTS:
+                if spec.view_type not in VALID_OUTPUT_ANNOTATIONS:
                     raise TypeError(
                         f'The output {name} has the view type'
                         f' {spec.view_type}. Valid view types for Pipeline'
-                        f' outputs are {VALID_OUTPUTS}'
+                        f' outputs are {VALID_OUTPUT_ANNOTATIONS}.'
                     )
 
     def _assert_all_annotated_or_unannotated(
-                self, inputs, parameters, outputs
-            ):
+            self, inputs, parameters, outputs
+        ):
         """
         Asserts that we don't have a mix of annotated and unannotated inputs,
         parameters, and outputs. All must be annotated or none.

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -333,7 +333,6 @@ class PipelineSignature:
         )
 
         if annotated:
-            print(f"Inputs: {inputs}\nOutputs: {outputs}")
             for name, spec in inputs.items():
                 if spec.view_type not in [
                             rachis.sdk.Artifact, list[rachis.sdk.Artifact],

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -484,6 +484,12 @@ class PipelineSignature:
         provenance.add_input(name, _input)
         qiime_type, _ = self._get_qiime_type_and_name(spec)
 
+        if type(self) is PipelineSignature:
+            # We do not transform Artifacts to view type for Pipeline inputs.
+            # view type annotations are purely informational for
+            # whoever/whatever is looking at the pipeline signature
+            return _input
+
         # Transform artifacts to view types as necessary
         if _input is None:
             transformed_input = None

--- a/src/rachis/plugin/__init__.py
+++ b/src/rachis/plugin/__init__.py
@@ -9,8 +9,7 @@
 from .model import (TextFileFormat, BinaryFileFormat, DirectoryFormat,
                     ValidationError, SingleFileDirectoryFormat)
 from .plugin import Plugin
-from .util import (get_available_cores, NP_RNG_MAX_SIZE,
-                   set_np_random_seed)
+from .util import get_available_cores, NP_RNG_SIZE, set_np_random_seed
 from rachis.core.cite import Citations, CitationRecord
 from rachis.core.type import (SemanticType, Int, Str, Float, Metadata,
                               MetadataColumn, Categorical, Numeric, Properties,
@@ -25,8 +24,8 @@ __all__ = ['TextFileFormat', 'BinaryFileFormat', 'DirectoryFormat', 'Plugin',
            'Properties', 'Range', 'Start', 'End', 'Choices', 'Visualization',
            'Jobs', 'Threads', 'TypeMap', 'TypeMatch', 'ValidationError',
            'Citations', 'CitationRecord', 'get_available_cores',
-           'NP_RNG_MAX_SIZE', 'set_np_random_seed',
-           'SingleFileDirectoryFormat', 'CaptureHolder']
+           'NP_RNG_SIZE', 'set_np_random_seed', 'SingleFileDirectoryFormat',
+           'CaptureHolder']
 
 # IMPORTANT:
 # Autodoc cannot find a docstring unless it is defined in the same module that

--- a/src/rachis/plugin/__init__.py
+++ b/src/rachis/plugin/__init__.py
@@ -9,7 +9,8 @@
 from .model import (TextFileFormat, BinaryFileFormat, DirectoryFormat,
                     ValidationError, SingleFileDirectoryFormat)
 from .plugin import Plugin
-from .util import get_available_cores
+from .util import (get_available_cores, NP_RNG_MAX_SIZE,
+                   set_np_random_seed_if_needed)
 from rachis.core.cite import Citations, CitationRecord
 from rachis.core.type import (SemanticType, Int, Str, Float, Metadata,
                               MetadataColumn, Categorical, Numeric, Properties,
@@ -24,6 +25,7 @@ __all__ = ['TextFileFormat', 'BinaryFileFormat', 'DirectoryFormat', 'Plugin',
            'Properties', 'Range', 'Start', 'End', 'Choices', 'Visualization',
            'Jobs', 'Threads', 'TypeMap', 'TypeMatch', 'ValidationError',
            'Citations', 'CitationRecord', 'get_available_cores',
+           'NP_RNG_MAX_SIZE', 'set_np_random_seed_if_needed'.
            'SingleFileDirectoryFormat', 'CaptureHolder']
 
 # IMPORTANT:

--- a/src/rachis/plugin/__init__.py
+++ b/src/rachis/plugin/__init__.py
@@ -10,7 +10,7 @@ from .model import (TextFileFormat, BinaryFileFormat, DirectoryFormat,
                     ValidationError, SingleFileDirectoryFormat)
 from .plugin import Plugin
 from .util import (get_available_cores, NP_RNG_MAX_SIZE,
-                   set_np_random_seed_if_needed)
+                   set_np_random_seed)
 from rachis.core.cite import Citations, CitationRecord
 from rachis.core.type import (SemanticType, Int, Str, Float, Metadata,
                               MetadataColumn, Categorical, Numeric, Properties,
@@ -25,7 +25,7 @@ __all__ = ['TextFileFormat', 'BinaryFileFormat', 'DirectoryFormat', 'Plugin',
            'Properties', 'Range', 'Start', 'End', 'Choices', 'Visualization',
            'Jobs', 'Threads', 'TypeMap', 'TypeMatch', 'ValidationError',
            'Citations', 'CitationRecord', 'get_available_cores',
-           'NP_RNG_MAX_SIZE', 'set_np_random_seed_if_needed'.
+           'NP_RNG_MAX_SIZE', 'set_np_random_seed',
            'SingleFileDirectoryFormat', 'CaptureHolder']
 
 # IMPORTANT:

--- a/src/rachis/plugin/util.py
+++ b/src/rachis/plugin/util.py
@@ -7,8 +7,10 @@
 # ----------------------------------------------------------------------------
 
 import psutil
+import random
 import subprocess
 
+from rachis.core.type import CaptureHolder
 from rachis.core.transform import ModelType
 
 
@@ -63,3 +65,25 @@ def run_commands(cmds, verbose=True):
             print("\nCommand:", end=' ')
             print(" ".join(cmd), end='\n\n')
         subprocess.run(cmd, check=True)
+
+
+# Numpy recommends using at least 128 bits of entropy as a seed, and we are
+# indirectly seeding numpy in this plugin.
+NP_RNG_MAX_SIZE = 2**128
+
+
+def set_np_random_seed_if_needed(random_seed: CaptureHolder):
+    """
+    Sets the value on a CaptureHolder to a random value for numpy seeding if
+    there is not value set on the CaptureHolder. Does nothing if a value is
+    already set
+
+    Parameters
+    ----------
+    random_seed : CaptureHolder<Int>
+        A CaptureHolder object intended to store an integer value for seeing
+        numpy rng
+    """
+    if not random_seed.is_set:
+        random_int = random.randrange(NP_RNG_MAX_SIZE)
+        random_seed.set_value(random_int)

--- a/src/rachis/plugin/util.py
+++ b/src/rachis/plugin/util.py
@@ -72,7 +72,7 @@ def run_commands(cmds, verbose=True):
 NP_RNG_MAX_SIZE = 2**128
 
 
-def set_np_random_seed_if_needed(random_seed: CaptureHolder):
+def set_np_random_seed(random_seed: CaptureHolder):
     """
     Sets the value on a CaptureHolder to a random value for numpy seeding if
     there is not value set on the CaptureHolder. Does nothing if a value is

--- a/src/rachis/plugin/util.py
+++ b/src/rachis/plugin/util.py
@@ -69,7 +69,7 @@ def run_commands(cmds, verbose=True):
 
 # Numpy recommends using at least 128 bits of entropy as a seed, and we are
 # indirectly seeding numpy in this plugin.
-NP_RNG_MAX_SIZE = 2**128
+NP_RNG_SIZE = 2**128
 
 
 def set_np_random_seed(random_seed: CaptureHolder):
@@ -85,5 +85,5 @@ def set_np_random_seed(random_seed: CaptureHolder):
         numpy rng
     """
     if not random_seed.is_set:
-        random_int = random.randrange(NP_RNG_MAX_SIZE)
+        random_int = random.randrange(NP_RNG_SIZE)
         random_seed.set_value(random_int)

--- a/src/rachis/plugin/util.py
+++ b/src/rachis/plugin/util.py
@@ -81,7 +81,7 @@ def set_np_random_seed(random_seed: CaptureHolder):
     Parameters
     ----------
     random_seed : CaptureHolder<Int>
-        A CaptureHolder object intended to store an integer value for seeing
+        A CaptureHolder object intended to store an integer value for seeding
         numpy rng
     """
     if not random_seed.is_set:

--- a/src/rachis/sdk/tests/test_method.py
+++ b/src/rachis/sdk/tests/test_method.py
@@ -814,7 +814,7 @@ class TestMethod(unittest.TestCase):
                     'random_seed': Int
                 },
                 outputs=[('seed', SingleInt)],
-                name='Sets a ',
+                name='Sets a bad default CaptureHolder value',
                 description='Sets a bad value for the default. '
                             'This will always raise an error on registration'
             )

--- a/src/rachis/sdk/tests/test_pipeline.py
+++ b/src/rachis/sdk/tests/test_pipeline.py
@@ -357,8 +357,8 @@ class TestPipeline(unittest.TestCase):
 
     def test_annotations_mixed(self):
         def mixed_annotations(
-                    ctx, annotated: int, unannotated
-                ) -> tuple[rachis.Artifact]:
+                ctx, annotated: int, unannotated
+            ) -> tuple[rachis.Artifact]:
             raise ValueError(
                 "I should never run. I should never even pass registration"
             )
@@ -403,7 +403,7 @@ class TestPipeline(unittest.TestCase):
             )
 
     def test_annotations_bad_output(self):
-        def bad_input_annotation(
+        def bad_output_annotation(
                     ctx, is_artifact: rachis.Artifact, is_int: rachis.Artifact
                 ) -> tuple[int]:
             raise ValueError(
@@ -412,7 +412,7 @@ class TestPipeline(unittest.TestCase):
 
         with self.assertRaisesRegex(TypeError, ".*out1.*int.*"):
             self.plugin.pipelines.register_function(
-                function=bad_input_annotation,
+                function=bad_output_annotation,
                 inputs={
                     'is_artifact': SingleInt,
                 },

--- a/src/rachis/sdk/tests/test_pipeline.py
+++ b/src/rachis/sdk/tests/test_pipeline.py
@@ -355,6 +355,44 @@ class TestPipeline(unittest.TestCase):
 
         self.assertTrue(True)
 
+    def test_annotations_mixed(self):
+        def mixed_annotations(ctx, annotated: int, unannotated) -> tuple[rachis.Artifact]:
+            pass
+
+        # with self.assertRaisesRegex(
+        #         ValueError,
+        #         "Default value of CaptureHolder.*random_seed.*1.*None"):
+        self.plugin.pipelines.register_function(
+            function=mixed_annotations,
+            inputs={},
+            parameters={
+                'annotated': Int,
+                'unannotated': Int
+            },
+            outputs=[('out1', SingleInt)],
+            name='Sets a ',
+            description='Sets a bad value for the default. '
+                        'This will always raise an error on registration'
+        )
+
+    def test_annotations_bad(self):
+        def bad_annotations(ctx, is_artifact: int, is_int: rachis.Artifact) -> tuple[int]:
+            pass
+
+        self.plugin.pipelines.register_function(
+            function=bad_annotations,
+            inputs={
+                'is_artifact': SingleInt,
+            },
+            parameters={
+                'is_int': Int,
+            },
+            outputs=[('out1', SingleInt)],
+            name='Sets a ',
+            description='Sets a bad value for the default. '
+                        'This will always raise an error on registration'
+        )
+
     def test_failing_from_arity(self):
         for call in self.iter_callables('failing_pipeline'):
             with self.assertRaisesRegex(TypeError, 'match number.*3.*1'):

--- a/src/rachis/sdk/tests/test_pipeline.py
+++ b/src/rachis/sdk/tests/test_pipeline.py
@@ -356,42 +356,73 @@ class TestPipeline(unittest.TestCase):
         self.assertTrue(True)
 
     def test_annotations_mixed(self):
-        def mixed_annotations(ctx, annotated: int, unannotated) -> tuple[rachis.Artifact]:
-            pass
+        def mixed_annotations(
+                    ctx, annotated: int, unannotated
+                ) -> tuple[rachis.Artifact]:
+            raise ValueError(
+                "I should never run. I should never even pass registration"
+            )
 
-        # with self.assertRaisesRegex(
-        #         ValueError,
-        #         "Default value of CaptureHolder.*random_seed.*1.*None"):
-        self.plugin.pipelines.register_function(
-            function=mixed_annotations,
-            inputs={},
-            parameters={
-                'annotated': Int,
-                'unannotated': Int
-            },
-            outputs=[('out1', SingleInt)],
-            name='Sets a ',
-            description='Sets a bad value for the default. '
-                        'This will always raise an error on registration'
-        )
+        with self.assertRaisesRegex(
+                    TypeError,
+                    "Pipelines must have annotations for all inputs,"
+                    " parameters, and outputs or no annotations."
+                ):
+            self.plugin.pipelines.register_function(
+                function=mixed_annotations,
+                inputs={},
+                parameters={
+                    'annotated': Int,
+                    'unannotated': Int
+                },
+                outputs=[('out1', SingleInt)],
+                name='Mixes annotated and unannotated.',
+                description=''
+            )
 
-    def test_annotations_bad(self):
-        def bad_annotations(ctx, is_artifact: int, is_int: rachis.Artifact) -> tuple[int]:
-            pass
+    def test_annotations_bad_input(self):
+        def bad_input_annotation(
+                    ctx, is_artifact: int, is_int: rachis.Artifact
+                ) -> tuple[rachis.Artifact]:
+            raise ValueError(
+                "I should never run. I should never even pass registration"
+            )
 
-        self.plugin.pipelines.register_function(
-            function=bad_annotations,
-            inputs={
-                'is_artifact': SingleInt,
-            },
-            parameters={
-                'is_int': Int,
-            },
-            outputs=[('out1', SingleInt)],
-            name='Sets a ',
-            description='Sets a bad value for the default. '
-                        'This will always raise an error on registration'
-        )
+        with self.assertRaisesRegex(TypeError, ".*is_artifact.*int.*"):
+            self.plugin.pipelines.register_function(
+                function=bad_input_annotation,
+                inputs={
+                    'is_artifact': SingleInt,
+                },
+                parameters={
+                    'is_int': Int,
+                },
+                outputs=[('out1', SingleInt)],
+                name='Sets a bad view type on the input.',
+                description='Sets a bad view type on the input.'
+            )
+
+    def test_annotations_bad_output(self):
+        def bad_input_annotation(
+                    ctx, is_artifact: rachis.Artifact, is_int: rachis.Artifact
+                ) -> tuple[int]:
+            raise ValueError(
+                "I should never run. I should never even pass registration"
+            )
+
+        with self.assertRaisesRegex(TypeError, ".*out1.*int.*"):
+            self.plugin.pipelines.register_function(
+                function=bad_input_annotation,
+                inputs={
+                    'is_artifact': SingleInt,
+                },
+                parameters={
+                    'is_int': Int,
+                },
+                outputs=[('out1', SingleInt)],
+                name='Sets a bad view type on the output.',
+                description='Sets a bad view type on the output.'
+            )
 
     def test_failing_from_arity(self):
         for call in self.iter_callables('failing_pipeline'):


### PR DESCRIPTION
Allow users to, optionally, put view types on Pipelines.

Blocking qiime2/q2-boots#62
Blocking qiime2/q2-feature-table#352
Blocking qiime2/q2-diversity#390