### PR TITLE
MAINT: update tuplize

### DIFF
--- a/src/rachis/core/archive/provenance_lib/tests/test_usage_drivers.py
+++ b/src/rachis/core/archive/provenance_lib/tests/test_usage_drivers.py
@@ -25,7 +25,7 @@ class ReplayPythonUsageTests(unittest.TestCase):
             prefix='rachis-test-usage-drivers-temp-'
         )
 
-        def return_many_ints() -> (list, list, list, list, list, list):
+        def return_many_ints() -> tuple[list, list, list, list, list, list]:
             return ([1, 2, 3], [4, 5, 6], [7], [4, 4], [0], [9, 8])
 
         self.dp.methods.register_function(
@@ -52,7 +52,7 @@ class ReplayPythonUsageTests(unittest.TestCase):
             description=''
         )
 
-        def return_four_ints() -> (list, list, list, list):
+        def return_four_ints() -> tuple[list, list, list, list]:
             return ([1, 2, 3], [4, 5, 6], [7, 8, 9], [4, 4])
 
         self.dp.methods.register_function(

--- a/src/rachis/core/testing/mapped.py
+++ b/src/rachis/core/testing/mapped.py
@@ -42,7 +42,7 @@ del T, U, V
 
 
 def combinatorically_mapped_method(a: EchoFormat, b: EchoFormat
-                                   ) -> (EchoFormat, EchoFormat):
+                                   ) -> tuple[EchoFormat, EchoFormat]:
     return a, b
 
 

--- a/src/rachis/core/testing/method.py
+++ b/src/rachis/core/testing/method.py
@@ -10,6 +10,7 @@ import random
 import sys
 from typing import Union
 import warnings
+import typing
 
 import rachis
 import rachis.core.type as qtype
@@ -23,12 +24,18 @@ def concatenate_ints(ints1: list, ints2: list, ints3: list, int1: int,
 
 
 # Multiple output artifacts.
-def split_ints(ints: list) -> (list, list):
+def split_ints(ints: list) -> tuple[list, list]:
     middle = int(len(ints) / 2)
     left = ints[:middle]
     right = ints[middle:]
     return left, right
 
+@typing.no_type_check  # use the pre-PEP version of this annotation
+def split_ints_compat(ints: list) -> (list, list):
+    middle = int(len(ints) / 2)
+    left = ints[:middle]
+    right = ints[middle:]
+    return left, right
 
 # No parameters, only artifacts.
 def merge_mappings(mapping1: dict, mapping2: dict) -> dict:
@@ -231,7 +238,7 @@ def list_params(ints: list) -> int:
 
 
 def varied_method(ints1: int, ints2: list, int1: int = None,
-                  string: str = "NO") -> (int, list, int):
+                  string: str = "NO") -> tuple[int, list, int]:
     if int1 is None:
         int1 = 1
     assert isinstance(ints1, list)

--- a/src/rachis/core/testing/plugin.py
+++ b/src/rachis/core/testing/plugin.py
@@ -59,7 +59,7 @@ from .method import (concatenate_ints, split_ints, merge_mappings,
                      migrated_method_from_distro_to_distro,
                      migrated_method_from_distro_epoch,
                      migrated_method_to_distro_epoch,
-                     raises_rachis_warning)
+                     raises_rachis_warning, split_ints_compat)
 from .visualizer import (most_common_viz, mapping_viz, params_only_viz,
                          no_input_viz)
 from .pipeline import (parameter_only_pipeline, typical_pipeline,
@@ -256,6 +256,25 @@ dummy_plugin.methods.register_function(
         'right': T
     },
     name='Split sequence of integers in half',
+    description='This method splits a sequence of integers in half, returning '
+                'the two halves (left and right). If the input sequence\'s '
+                'length is not evenly divisible by 2, the right half will '
+                'have one more element than the left.',
+    citations=[
+        citations['witcombe2006sword'], citations['reimers2012response']]
+)
+
+dummy_plugin.methods.register_function(
+    function=split_ints_compat,
+    inputs={
+        'ints': T
+    },
+    parameters={},
+    outputs={
+        'left': T,
+        'right': T
+    },
+    name='Split sequence of integers in half (compat)',
     description='This method splits a sequence of integers in half, returning '
                 'the two halves (left and right). If the input sequence\'s '
                 'length is not evenly divisible by 2, the right half will '

--- a/src/rachis/core/util.py
+++ b/src/rachis/core/util.py
@@ -21,6 +21,7 @@ import zipfile
 import pathlib
 import shutil
 import subprocess
+import typing
 
 import decorator
 
@@ -56,6 +57,10 @@ def get_view_name(view):
 
 
 def tuplize(x):
+    # get_origin returns None if not a GenericAlias
+    if typing.get_origin(x) is tuple:
+        # tuple[X, Y] -> (X, Y)
+        return typing.get_args(x)
     if type(x) is not tuple:
         return (x,)
     return x

--- a/src/rachis/plugin/tests/test_plugin.py
+++ b/src/rachis/plugin/tests/test_plugin.py
@@ -85,6 +85,7 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(actions.keys(),
                          {'merge_mappings', 'concatenate_ints', 'split_ints',
                           'most_common_viz', 'mapping_viz',
+                          'split_ints_compat',
                           'identity_with_metadata',
                           'identity_with_metadata_column',
                           'identity_with_categorical_metadata_column',
@@ -146,6 +147,7 @@ class TestPlugin(unittest.TestCase):
 
         self.assertEqual(methods.keys(),
                          {'merge_mappings', 'concatenate_ints', 'split_ints',
+                          'split_ints_compat',
                           'identity_with_metadata',
                           'identity_with_metadata_column',
                           'identity_with_categorical_metadata_column',

--- a/src/rachis/sdk/tests/test_util.py
+++ b/src/rachis/sdk/tests/test_util.py
@@ -46,6 +46,7 @@ class TestUtil(unittest.TestCase):
             'Do a great many things', 'Identity', 'Identity', 'Identity',
             'Visualize most common integers', 'Inputs with typing.Union',
             'Split sequence of integers in half',
+            'Split sequence of integers in half (compat)',
             'Test different ways of failing', 'Optional artifacts method',
             'Do stuff normally, but override this one step sometimes',
             'TypeMatch with list and set params',


### PR DESCRIPTION
Bringing `tuplize` into the modern age.

(We can now annotate multiple return types correctly without breaking backwards compatibility.)