### PR TITLE
DEP: remove decorator

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,6 @@ requirements:
   run:
   - python {{ python }}
   - pyyaml
-  - decorator {{ decorator }}
   - pandas {{ pandas }}
   - tzlocal {{ tzlocal }}
   - python-dateutil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python=">=3.10"
 dependencies = [
     "appdirs>=1.4.4,<2.0.0",
     "bibtexparser>=1.4.3,<2.0.0",
-    "decorator~=4.4.2",
     "dill>=0.4.0,<0.5.0",
     "flufl-lock>=9.0.0,<10.0.0",
     "networkx>=3.1,<4.0.0",

--- a/src/rachis/core/type/signature.py
+++ b/src/rachis/core/type/signature.py
@@ -244,6 +244,21 @@ class PipelineSignature:
         collated_inputs.update(kwargs)
         return collated_inputs
 
+    def to_inspect_signature(self):
+        parameters = []
+        kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
+        for name, spec in self.signature_order.items():
+            default = inspect.Parameter.empty
+            if spec.has_default():
+                default = spec.default
+            parameters.append(inspect.Parameter(
+                name, kind, default=default, annotation=spec.qiime_type))
+
+        output_types = tuple(spec.qiime_type for spec in self.outputs.values())
+        return_annotation = tuple[output_types]
+        return inspect.Signature(
+            parameters=parameters, return_annotation=return_annotation)
+
     def _assert_valid_inputs(self, inputs):
         for input_name, spec in inputs.items():
             if not is_semantic_type(spec.qiime_type):

--- a/src/rachis/core/util.py
+++ b/src/rachis/core/util.py
@@ -23,8 +23,6 @@ import shutil
 import subprocess
 import typing
 
-import decorator
-
 READ_ONLY_FILE = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
 READ_ONLY_DIR = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH | stat.S_IRUSR \
     | stat.S_IRGRP | stat.S_IROTH
@@ -323,22 +321,6 @@ class LateBindingAttribute:
         for attr in attrs:
             curr_attr = getattr(curr_attr, attr)
         return staticmethod(curr_attr).__get__(obj, cls)
-
-
-# Removes the first parameter from a callable's signature.
-class DropFirstParameter(decorator.FunctionMaker):
-    @classmethod
-    def from_function(cls, function):
-        return cls.create(function, "return None", {})
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.signature = self._remove_first_arg(self.signature)
-        self.shortsignature = self._remove_first_arg(self.shortsignature)
-
-    def _remove_first_arg(self, string):
-        return ",".join(string.split(',')[1:])[1:]
-
 
 def _immutable_error(obj, *args):
     raise TypeError('%s is immutable.' % obj.__class__.__name__)

--- a/src/rachis/plugin/tests/test_plugin.py
+++ b/src/rachis/plugin/tests/test_plugin.py
@@ -473,6 +473,5 @@ class TestPlugin(unittest.TestCase):
                             ' bad.'
             )
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/src/rachis/plugin/tests/test_plugin.py
+++ b/src/rachis/plugin/tests/test_plugin.py
@@ -473,5 +473,6 @@ class TestPlugin(unittest.TestCase):
                             ' bad.'
             )
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/rachis/sdk/action.py
+++ b/src/rachis/sdk/action.py
@@ -12,7 +12,6 @@ import tempfile
 import textwrap
 from types import FunctionType
 
-import decorator
 import dill
 
 from typing import Mapping, TypedDict, Union
@@ -22,8 +21,8 @@ import rachis.sdk
 from rachis.sdk.result import Artifact, ResultCollection, ChecksumCache
 import rachis.core.type as qtype
 import rachis.core.archive as archive
-from rachis.core.util import (LateBindingAttribute, DropFirstParameter,
-                              tuplize, create_collection_name)
+from rachis.core.util import (LateBindingAttribute, tuplize,
+                              create_collection_name)
 from rachis.core.cite import CitationRecord
 
 
@@ -96,14 +95,6 @@ class Action(metaclass=abc.ABCMeta):
     asynchronous = LateBindingAttribute('_dynamic_async')
     parallel = LateBindingAttribute('_dynamic_parsl')
 
-    # Converts a callable's signature into its wrapper's signature (i.e.
-    # converts the "view API" signature into the "artifact API" signature).
-    # Accepts a callable as input and returns a callable as output with
-    # converted signature.
-    @abc.abstractmethod
-    def _callable_sig_converter_(self, callable):
-        raise NotImplementedError
-
     # Executes a callable on the provided `view_args`, wrapping and returning
     # the callable's outputs. In other words, executes the "view API", wrapping
     # and returning the outputs as the "artifact API". `view_args` is a dict
@@ -167,6 +158,7 @@ class Action(metaclass=abc.ABCMeta):
         self.examples = examples
 
         self.id = callable.__name__
+        self._wrapper_signature = self.signature.to_inspect_signature()
         self._dynamic_call = self._callable_action_wrapper()
         self._dynamic_async = self._get_async_wrapper()
         # This a temp thing to play with parsl before integrating more deeply
@@ -269,11 +261,6 @@ class Action(metaclass=abc.ABCMeta):
 
         """
         def bound_callable(*args, **kwargs):
-            # This function's signature is rewritten below using
-            # `decorator.decorator`. When the signature is rewritten,
-            # args[0] is the function whose signature was used to rewrite
-            # this function's signature.
-            args = args[1:]
             ctx = context_factory()
             provenance = self._ProvCaptureCls(
                 self.type, self.plugin_id, self.id, execution_ctx)
@@ -377,10 +364,12 @@ class Action(metaclass=abc.ABCMeta):
         return parsl_wrapper
 
     def _rewrite_wrapper_signature(self, wrapper):
-        # Convert the callable's signature into the wrapper's signature and set
-        # it on the wrapper.
-        return decorator.decorator(
-            wrapper, self._callable_sig_converter_(self._callable))
+        def signature_wrapper(*args, **kwargs):
+            bound = self._wrapper_signature.bind(*args, **kwargs)
+            bound.apply_defaults()
+            return wrapper(*bound.args, **bound.kwargs)
+
+        return signature_wrapper
 
     def _set_wrapper_name(self, wrapper, name):
         wrapper.__name__ = wrapper.__qualname__ = name
@@ -389,23 +378,13 @@ class Action(metaclass=abc.ABCMeta):
         wrapper.__module__ = self.get_import_path(include_self=False)
         wrapper.__doc__ = self._build_numpydoc()
         wrapper.__annotations__ = self._build_annotations()
-        # This is necessary so that `inspect` doesn't display the wrapped
-        # function's annotations (the annotations apply to the "view API" and
-        # not the "artifact API").
-        del wrapper.__wrapped__
+        wrapper.__signature__ = self._wrapper_signature
 
     def _build_annotations(self):
-        annotations = {}
-        for name, spec in self.signature.signature_order.items():
-            annotations[name] = spec.qiime_type
-
-        output = []
-        for spec in self.signature.outputs.values():
-            output.append(spec.qiime_type)
-        output = tuple(output)
-
-        annotations["return"] = output
-
+        annotations = {
+            name: param.annotation
+            for name, param in self._wrapper_signature.parameters.items()}
+        annotations['return'] = self._wrapper_signature.return_annotation
         return annotations
 
     def _build_numpydoc(self):
@@ -488,10 +467,6 @@ class Method(Action):
 
     # Abstract method implementations:
 
-    def _callable_sig_converter_(self, callable):
-        # No conversion necessary.
-        return callable
-
     def _callable_executor_(self, ctx, view_args, output_types, provenance):
         output_views = self._callable(**view_args)
         output_views = tuplize(output_views)
@@ -548,9 +523,6 @@ class Visualizer(Action):
 
     # Abstract method implementations:
 
-    def _callable_sig_converter_(self, callable):
-        return DropFirstParameter.from_function(callable)
-
     def _callable_executor_(self, ctx, view_args, output_types, provenance):
         with tempfile.TemporaryDirectory(prefix='rachis-temp-') as temp_dir:
             ret_val = self._callable(output_dir=temp_dir, **view_args)
@@ -580,9 +552,6 @@ class Pipeline(Action):
     """Rachis Pipeline"""
     type = 'pipeline'
     _ProvCaptureCls = archive.PipelineProvenanceCapture
-
-    def _callable_sig_converter_(self, callable):
-        return DropFirstParameter.from_function(callable)
 
     def _callable_executor_(self, ctx, view_args, output_types, provenance):
         outputs = self._callable(ctx, **view_args)

--- a/src/rachis/sdk/action.py
+++ b/src/rachis/sdk/action.py
@@ -366,6 +366,7 @@ class Action(metaclass=abc.ABCMeta):
     def _rewrite_wrapper_signature(self, wrapper):
         def signature_wrapper(*args, **kwargs):
             bound = self._wrapper_signature.bind(*args, **kwargs)
+            # ensures that provenance has all default arguments.
             bound.apply_defaults()
             return wrapper(*bound.args, **bound.kwargs)
 

--- a/src/rachis/sdk/context/asynchronous.py
+++ b/src/rachis/sdk/context/asynchronous.py
@@ -32,12 +32,6 @@ class AsynchronousContext(Context):
         except ImportError:
             pass
 
-        # This function's signature is rewritten below using
-        # `decorator.decorator`. When the signature is rewritten, args[0]
-        # is the function whose signature was used to rewrite this
-        # function's signature.
-        args = args[1:]
-
         pool = concurrent.futures.ProcessPoolExecutor(max_workers=1)
         future = pool.submit(_subprocess_apply, self, args, kwargs)
         # TODO: pool.shutdown(wait=False) caused the child process to

--- a/src/rachis/sdk/context/base.py
+++ b/src/rachis/sdk/context/base.py
@@ -83,9 +83,6 @@ class Context:
         return callable_action
 
     def _callable_action_(self, *args, **kwargs):
-        # The function is the first arg, we ditch that
-        args = args[1:]
-
         # If we have a named_pool, we need to check for cached results that
         # we can reuse.
         if self.cache.named_pool is not None and \

--- a/src/rachis/sdk/context/parallel.py
+++ b/src/rachis/sdk/context/parallel.py
@@ -82,9 +82,6 @@ class ParallelContext(Context):
                       for v in PARALLEL_CONFIG.parallel_config.executors}
 
     def _callable_action_(self, *args, **kwargs):
-        # The function is the first arg, we ditch that
-        args = args[1:]
-
         # If we have a named_pool, we need to check for cached results that
         # we can reuse.
         #
@@ -109,12 +106,6 @@ class ParallelContext(Context):
         futures = []
         mapped_args = []
         mapped_kwargs = {}
-
-        # If this is the first time we called _bind_parsl on a pipeline, the
-        # first argument will be the callable for the pipeline which we do not
-        # want to pass on in this manner, so we skip it.
-        if len(args) >= 1 and callable(args[0]):
-            args = args[1:]
 
         # Parsl will queue up apps with futures as their arguments then not
         # execute the apps until the futures are resolved. This is an extremely

--- a/src/rachis/sdk/tests/test_method.py
+++ b/src/rachis/sdk/tests/test_method.py
@@ -164,11 +164,11 @@ class TestMethod(unittest.TestCase):
         merge_mappings = self.plugin.methods['merge_mappings']
 
         concatenate_exp = {
-            'int2': Int, 'ints2': IntSequence1, 'return': (IntSequence1,),
+            'int2': Int, 'ints2': IntSequence1, 'return': tuple[IntSequence1],
             'int1': Int, 'ints3': IntSequence2,
             'ints1': IntSequence1 | IntSequence2}
         merge_exp = {
-            'mapping2': Mapping, 'mapping1': Mapping, 'return': (Mapping,)}
+            'mapping2': Mapping, 'mapping1': Mapping, 'return': tuple[Mapping]}
 
         mapper = {
             concatenate_ints: concatenate_exp,
@@ -184,11 +184,11 @@ class TestMethod(unittest.TestCase):
         merge_mappings = self.plugin.methods['merge_mappings']
 
         concatenate_exp = {
-            'int2': Int, 'ints2': IntSequence1, 'return': (IntSequence1,),
+            'int2': Int, 'ints2': IntSequence1, 'return': tuple[IntSequence1],
             'int1': Int, 'ints3': IntSequence2,
             'ints1': IntSequence1 | IntSequence2}
         merge_exp = {
-            'mapping2': Mapping, 'mapping1': Mapping, 'return': (Mapping,)}
+            'mapping2': Mapping, 'mapping1': Mapping, 'return': tuple[Mapping]}
 
         mapper = {
             concatenate_ints: concatenate_exp,

--- a/src/rachis/sdk/tests/test_visualizer.py
+++ b/src/rachis/sdk/tests/test_visualizer.py
@@ -135,11 +135,11 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         most_common_viz = self.plugin.visualizers['most_common_viz']
 
         mapping_exp = {
-            'mapping1': Mapping, 'return': (VisualizationType,),
+            'mapping1': Mapping, 'return': tuple[VisualizationType],
             'key_label': Str, 'mapping2': Mapping, 'value_label': Str}
         most_common_exp = {
             'ints': IntSequence1 | IntSequence2,
-            'return': (VisualizationType,)}
+            'return': tuple[VisualizationType]}
 
         mapper = {
             mapping_viz: mapping_exp,
@@ -155,11 +155,11 @@ class TestVisualizer(unittest.TestCase, ArchiveTestingMixin):
         most_common_viz = self.plugin.visualizers['most_common_viz']
 
         mapping_exp = {
-            'mapping1': Mapping, 'return': (VisualizationType,),
+            'mapping1': Mapping, 'return': tuple[VisualizationType],
             'key_label': Str, 'mapping2': Mapping, 'value_label': Str}
         most_common_exp = {
             'ints': IntSequence1 | IntSequence2,
-            'return': (VisualizationType,)}
+            'return': tuple[VisualizationType]}
 
         mapper = {
             mapping_viz: mapping_exp,


### PR DESCRIPTION
Took a _lot_ of back-and-forth with `codex`, but modern Python versions basically obviate the need for `decorator` entirely, which is nice.

I'm also pretty pleased that our own `Signature` can take over the job here (I had to prod codex to see that change).