### PR TITLE
NEW: pipelines can now narrow their output types with properties

### DIFF
--- a/src/rachis/core/testing/pipeline.py
+++ b/src/rachis/core/testing/pipeline.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from .type import SingleInt, Mapping
+from .type import SingleInt, Mapping, Foo, Bar
 from rachis.sdk.result import ResultCollection
 from rachis.core.testing.util import PipelineError
 
@@ -285,6 +285,21 @@ def de_facto_collection_pipeline(ctx):
     art2, = method()
 
     return [art1, art2]
+
+
+def property_refinement_pipeline(ctx):
+    return ctx.make_artifact(Foo, 'foo', view_type=str)
+
+
+def property_refinement_collection_pipeline(ctx):
+    return [
+        ctx.make_artifact(Foo, 'foo', view_type=str),
+        ctx.make_artifact(Foo, 'bar', view_type=str)
+    ]
+
+
+def property_refinement_mismatch_pipeline(ctx):
+    return ctx.make_artifact(Bar, 'bar', view_type=str)
 
 
 def pointless_pipeline(ctx):

--- a/src/rachis/core/testing/plugin.py
+++ b/src/rachis/core/testing/plugin.py
@@ -10,7 +10,7 @@ from importlib import import_module
 
 from rachis.plugin import (Plugin, Bool, Int, Str, Choices, Range, List, Set,
                            Collection, Visualization, Metadata, MetadataColumn,
-                           Categorical, Numeric, TypeMatch)
+                           Categorical, Numeric, TypeMatch, Properties)
 
 from .format import (
     IntSequenceFormat,
@@ -70,7 +70,10 @@ from .pipeline import (parameter_only_pipeline, typical_pipeline,
                        internal_fail_pipeline, de_facto_list_pipeline,
                        mix_arts_and_proxies, de_facto_dict_pipeline,
                        de_facto_collection_pipeline, list_pipeline,
-                       collection_pipeline, pointless_pipeline,
+                       collection_pipeline, property_refinement_pipeline,
+                       property_refinement_collection_pipeline,
+                       property_refinement_mismatch_pipeline,
+                       pointless_pipeline,
                        failing_pipeline, viz_collection_pipeline)
 from ..cite import Citations
 
@@ -1067,6 +1070,33 @@ dummy_plugin.pipelines.register_function(
     outputs=[('output', Collection[Mapping])],
     name='Returns de facto ResultCollection',
     description='Takes nothing and returns de facto ResultCollection'
+)
+
+dummy_plugin.pipelines.register_function(
+    function=property_refinement_pipeline,
+    inputs={},
+    parameters={},
+    outputs=[('output', Foo % Properties('A'))],
+    name='Refine pipeline output property',
+    description='Returns a broader artifact than its output annotation'
+)
+
+dummy_plugin.pipelines.register_function(
+    function=property_refinement_collection_pipeline,
+    inputs={},
+    parameters={},
+    outputs=[('output', Collection[Foo % Properties('A')])],
+    name='Refine pipeline collection output property',
+    description='Returns broader artifacts than its collection annotation'
+)
+
+dummy_plugin.pipelines.register_function(
+    function=property_refinement_mismatch_pipeline,
+    inputs={},
+    parameters={},
+    outputs=[('output', Foo % Properties('A'))],
+    name='Mismatch pipeline output property',
+    description='Returns an artifact with an empty output intersection'
 )
 
 dummy_plugin.pipelines.register_function(

--- a/src/rachis/plugin/tests/test_plugin.py
+++ b/src/rachis/plugin/tests/test_plugin.py
@@ -105,7 +105,11 @@ class TestPlugin(unittest.TestCase):
                           'internal_fail_pipeline', 'de_facto_list_pipeline',
                           'mix_arts_and_proxies', 'de_facto_dict_pipeline',
                           'de_facto_collection_pipeline', 'list_pipeline',
-                          'collection_pipeline', 'failing_pipeline',
+                          'collection_pipeline',
+                          'property_refinement_pipeline',
+                          'property_refinement_collection_pipeline',
+                          'property_refinement_mismatch_pipeline',
+                          'failing_pipeline',
                           'viz_collection_pipeline',
                           'docstring_order_method',
                           'constrained_input_visualization',
@@ -207,7 +211,11 @@ class TestPlugin(unittest.TestCase):
                           'internal_fail_pipeline', 'de_facto_list_pipeline',
                           'mix_arts_and_proxies', 'de_facto_dict_pipeline',
                           'de_facto_collection_pipeline', 'list_pipeline',
-                          'collection_pipeline', 'failing_pipeline',
+                          'collection_pipeline',
+                          'property_refinement_pipeline',
+                          'property_refinement_collection_pipeline',
+                          'property_refinement_mismatch_pipeline',
+                          'failing_pipeline',
                           'viz_collection_pipeline'})
         for pipeline in pipelines.values():
             self.assertIsInstance(pipeline, rachis.sdk.Pipeline)

--- a/src/rachis/sdk/action.py
+++ b/src/rachis/sdk/action.py
@@ -51,23 +51,15 @@ def _coerce_pipeline_outputs(ctx, outputs):
     return tuple(coerced_outputs)
 
 
-def _raise_incompatible_output_type(expected, output, context=''):
-    observed = output.type if hasattr(output, 'type') else type(output)
+def _intersect_pipeline_output_type(expected, output_type, output_name):
+    refined_type = output_type & expected
+
+    if (not refined_type.is_bottom()) and refined_type.is_concrete():
+        return refined_type
+
     raise TypeError(
-        "Expected output%s to be of type %r, received %r"
-        % (context, expected, observed))
-
-
-def _intersect_pipeline_output_type(expected, output, context=''):
-    try:
-        refined_type = output.type & expected
-    except TypeError:
-        _raise_incompatible_output_type(expected, output, context)
-
-    if refined_type.is_bottom() or not refined_type.is_concrete():
-        _raise_incompatible_output_type(expected, output, context)
-
-    return refined_type
+        "Expected output %s to be of type %r, received %r"
+        % (output_name, expected, output_type))
 
 
 # TODO: validation on these params via data.yaml in distributions
@@ -609,10 +601,6 @@ class Pipeline(Action):
         # happened
         for output, (name, spec) in zip(outputs, output_types.items()):
             if spec.qiime_type.name == 'Collection':
-                if not isinstance(output, rachis.sdk.ResultCollection):
-                    _raise_incompatible_output_type(
-                        spec.qiime_type, output, " %r" % name)
-
                 size = len(output)
                 aliased_output = rachis.sdk.ResultCollection()
                 element_type = spec.qiime_type.fields[0]
@@ -621,7 +609,7 @@ class Pipeline(Action):
                     collection_name = create_collection_name(
                         name=name, key=key, idx=idx, size=size)
                     refined_type = _intersect_pipeline_output_type(
-                        element_type, value, " %r member %r" % (name, key))
+                        element_type, value.type, "%r member %r" % (name, key))
                     aliased_result = \
                         value._alias(collection_name, provenance, ctx,
                                      refined_type)
@@ -630,7 +618,7 @@ class Pipeline(Action):
                 results.append(aliased_output)
             else:
                 refined_type = _intersect_pipeline_output_type(
-                    spec.qiime_type, output, " %r" % name)
+                    spec.qiime_type, output.type, repr(name))
                 aliased_result = output._alias(
                     name, provenance, ctx, refined_type)
 

--- a/src/rachis/sdk/action.py
+++ b/src/rachis/sdk/action.py
@@ -51,6 +51,25 @@ def _coerce_pipeline_outputs(ctx, outputs):
     return tuple(coerced_outputs)
 
 
+def _raise_incompatible_output_type(expected, output, context=''):
+    observed = output.type if hasattr(output, 'type') else type(output)
+    raise TypeError(
+        "Expected output%s to be of type %r, received %r"
+        % (context, expected, observed))
+
+
+def _intersect_pipeline_output_type(expected, output, context=''):
+    try:
+        refined_type = output.type & expected
+    except TypeError:
+        _raise_incompatible_output_type(expected, output, context)
+
+    if refined_type.is_bottom() or not refined_type.is_concrete():
+        _raise_incompatible_output_type(expected, output, context)
+
+    return refined_type
+
+
 # TODO: validation on these params via data.yaml in distributions
 class MigrationInfo(TypedDict):
     to_plugin: str
@@ -586,32 +605,36 @@ class Pipeline(Action):
         results = []
 
         # If we don't have a Collection, we should have a Result, if we
-        # have neither, or our types just don't match up, something bad
+        # have neither, or our types can't be reconciled, something bad
         # happened
         for output, (name, spec) in zip(outputs, output_types.items()):
-            if spec.qiime_type.name == 'Collection' and \
-                    output.collection in spec.qiime_type:
+            if spec.qiime_type.name == 'Collection':
+                if not isinstance(output, rachis.sdk.ResultCollection):
+                    _raise_incompatible_output_type(
+                        spec.qiime_type, output, " %r" % name)
+
                 size = len(output)
                 aliased_output = rachis.sdk.ResultCollection()
+                element_type = spec.qiime_type.fields[0]
 
                 for idx, (key, value) in enumerate(output.items()):
                     collection_name = create_collection_name(
                         name=name, key=key, idx=idx, size=size)
+                    refined_type = _intersect_pipeline_output_type(
+                        element_type, value, " %r member %r" % (name, key))
                     aliased_result = \
-                        value._alias(collection_name, provenance, ctx)
+                        value._alias(collection_name, provenance, ctx,
+                                     refined_type)
 
                     aliased_output[str(key)] = aliased_result
                 results.append(aliased_output)
-            elif output.type <= spec.qiime_type:
-                aliased_result = output._alias(name, provenance, ctx)
+            else:
+                refined_type = _intersect_pipeline_output_type(
+                    spec.qiime_type, output, " %r" % name)
+                aliased_result = output._alias(
+                    name, provenance, ctx, refined_type)
 
                 results.append(aliased_result)
-            else:
-                _type = output.type if hasattr(output, 'type') \
-                    else type(output)
-                raise TypeError(
-                    "Expected output type %r, received %r" %
-                    (spec.qiime_type, _type))
 
         if len(results) != len(self.signature.outputs):
             raise ValueError(

--- a/src/rachis/sdk/iresult.py
+++ b/src/rachis/sdk/iresult.py
@@ -10,9 +10,15 @@ import abc
 
 
 class IResult(metaclass=abc.ABCMeta):
+    @staticmethod
+    def _assert_alias_type_refines_realized_type(qiime_type, realized_type):
+        if qiime_type is not None and not qiime_type <= realized_type:
+            raise TypeError(
+                "Alias type %r must be a subtype of realized result type %r."
+                % (qiime_type, realized_type))
 
     @abc.abstractmethod
-    def _alias(self, name, provenance, ctx):
+    def _alias(self, name, provenance, ctx, qiime_type=None):
         """
         Create a pipeline alias for this result
         """

--- a/src/rachis/sdk/proxy.py
+++ b/src/rachis/sdk/proxy.py
@@ -43,16 +43,24 @@ class ProxyResult(Proxy, IResult):
     def __hash__(self):
         return hash(self.uuid)
 
-    def _alias(self, name, provenance, ctx):
+    def _alias(self, name, provenance, ctx, qiime_type=None):
         """We don't want to alias immediately because aliasing is a blocking
         operation. Calling alias on a Proxy adds a hook that will create the
         alias when the result on the Proxy is requested
         """
+        if self._qiime_type_ is not None:
+            self._assert_alias_type_refines_realized_type(
+                qiime_type, self._qiime_type_)
+
+        alias_type = (
+            qiime_type if qiime_type is not None else self._qiime_type_
+        )
+
         def _alias_hook():
             result = new._get_element_(new._future_.result())
-            return result._alias(name, provenance, ctx)
+            return result._alias(name, provenance, ctx, qiime_type)
 
-        new = self.__class__(self._future_, self._selector_, self._qiime_type_)
+        new = self.__class__(self._future_, self._selector_, alias_type)
         new._alias_hook = _alias_hook
         return new
 

--- a/src/rachis/sdk/result.py
+++ b/src/rachis/sdk/result.py
@@ -271,7 +271,12 @@ class Result(IResult):
         self._archiver.save(filepath)
         return filepath
 
-    def _alias(self, name, provenance, ctx):
+    def _alias(self, name, provenance, ctx, qiime_type=None):
+        self._assert_alias_type_refines_realized_type(qiime_type, self.type)
+
+        if qiime_type is None:
+            qiime_type = self.type
+
         provenance_capture = provenance.fork(name, self)
 
         def clone_original(into):
@@ -289,7 +294,7 @@ class Result(IResult):
         cls = type(self)
         alias = cls.__new__(cls)
         alias._archiver = archive.Archiver.from_data(
-            self.type, self.format, clone_original, provenance_capture)
+            qiime_type, self.format, clone_original, provenance_capture)
 
         return ctx.add_reference(alias)
 

--- a/src/rachis/sdk/tests/test_pipeline.py
+++ b/src/rachis/sdk/tests/test_pipeline.py
@@ -14,8 +14,8 @@ import pandas as pd
 import rachis
 import rachis.sdk
 from rachis.core.testing.util import get_dummy_plugin
-from rachis.core.testing.type import IntSequence1, SingleInt, Mapping
-from rachis.plugin import Visualization, Int, Bool
+from rachis.core.testing.type import IntSequence1, SingleInt, Mapping, Foo
+from rachis.plugin import Visualization, Int, Bool, Properties
 import rachis.sdk.parallel_config
 from rachis.plugin import List, Collection, IContext
 
@@ -179,6 +179,34 @@ class TestPipeline(unittest.TestCase):
             observed[k] = v.view(dict)
 
         self.assertEqual(observed, expected)
+
+    def test_pipeline_output_property_refinement(self):
+        pipeline = self.plugin.pipelines['property_refinement_pipeline']
+
+        result = pipeline()
+
+        self.assertEqual(result.output.type, Foo % Properties('A'))
+
+    def test_pipeline_collection_output_property_refinement(self):
+        pipeline = self.plugin.pipelines[
+            'property_refinement_collection_pipeline']
+
+        result = pipeline()
+
+        expected_type = Foo % Properties('A')
+        self.assertEqual(result.output.type, Collection[expected_type])
+        for artifact in result.output.values():
+            self.assertEqual(artifact.type, expected_type)
+
+    def test_pipeline_output_property_refinement_mismatch(self):
+        pipeline = self.plugin.pipelines[
+            'property_refinement_mismatch_pipeline']
+
+        with self.assertRaisesRegex(
+                TypeError,
+                "Expected output 'output' to be of type "
+                ".*Foo.*Properties.*Bar"):
+            pipeline()
 
     def iter_callables(self, name):
         pipeline = self.plugin.pipelines[name]

--- a/src/rachis/sdk/tests/test_result.py
+++ b/src/rachis/sdk/tests/test_result.py
@@ -16,13 +16,14 @@ import subprocess
 import rachis.core.type
 from rachis.sdk import Result, Artifact, Visualization, ResultCollection
 from rachis.sdk.result import ResultMetadata
+from rachis.sdk.proxy import ProxyResult
 from rachis.core.annotate import Signature
 import rachis.core.archive as archive
 import rachis.core.exceptions as exceptions
 
 from rachis.core.testing.format import IntSequenceDirectoryFormat
 from rachis.core.testing.type import (FourInts, SingleInt, IntSequence1,
-                                      IntSequence2)
+                                      IntSequence2, Foo, Bar)
 from rachis.core.testing.util import get_dummy_plugin, ArchiveTestingMixin
 from rachis.core.testing.visualizer import mapping_viz
 from rachis.core.util import set_permissions, OTHER_NO_WRITE
@@ -57,6 +58,28 @@ class TestResult(unittest.TestCase, ArchiveTestingMixin):
                 NotImplementedError,
                 'Result constructor.*private.*Result.load'):
             Result()
+
+    def test_alias_type_must_refine_realized_type(self):
+        artifact = Artifact.import_data(Foo, 'foo', view_type=str)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                "Alias type Bar must be a subtype of realized result type "
+                "Foo"):
+            artifact._alias('output', None, None, Bar)
+
+    def test_proxy_alias_type_must_refine_known_type(self):
+        class Future:
+            def result(self):
+                raise AssertionError("Proxy alias type check blocked.")
+
+        proxy = ProxyResult(Future(), 'output', Foo)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                "Alias type Bar must be a subtype of realized result type "
+                "Foo"):
+            proxy._alias('output', None, None, Bar)
 
     def test_load_artifact(self):
         saved_artifact = Artifact.import_data(FourInts, [-1, 42, 0, 43])


### PR DESCRIPTION
Code generated by Codex GPT 5.5 under my direction and detailed review.

This should solve the underlying issue in https://github.com/qiime2/q2-boots/pull/60 which was discovered in #929


This works by allowing `Result._alias()` to optionally take a narrower type which will be used in the archiver instead of the original type. This means that pipelines can solve their outputs and then we can intersect those outputs with the underlying result to define what the new type ought to be. The guard in `Result._alias()` is because I wanted to make sure if it was called for some other reason, we don't get a completely nonsense type attached, but otherwise we should think of the intersection as being totally sufficient here.