### PR TITLE
Add support for transforming from unions 

### DIFF
--- a/src/rachis/sdk/result.py
+++ b/src/rachis/sdk/result.py
@@ -705,7 +705,10 @@ class Artifact(Result):
 
         if cls._is_union_type(view_type):
             transformation, _ = cls._transform_to_or_from_union(
-                from_type=view_type, to_type=to_type, recorder=recorder
+                from_type=view_type,
+                to_type=to_type,
+                recorder=recorder,
+                view=view
             )
         else:
             from_type = transform.ModelType.from_view_type(view_type)
@@ -759,7 +762,9 @@ class Artifact(Result):
         return result
 
     @classmethod
-    def _transform_to_or_from_union(cls, from_type, to_type, recorder):
+    def _transform_to_or_from_union(
+        cls, from_type, to_type, recorder, view=None
+    ):
         '''
         Attempts to find a transformation to/from a union type that lives in
         either `from_type` or `to_type`.
@@ -769,6 +774,7 @@ class Artifact(Result):
         from_type : ModelType | Union
         to_type : ModelType | Union
         recorder : Callable
+        view : Any
 
         Returns
         -------
@@ -797,6 +803,10 @@ class Artifact(Result):
             arg_type = transform.ModelType.from_view_type(arg)
             try:
                 if cls._is_union_type(from_type):
+                    # don't grab the wrong transformer
+                    if not isinstance(view, arg):
+                        continue
+
                     transformation = arg_type.make_transformation(
                         to_type, recorder=recorder
                     )

--- a/src/rachis/sdk/result.py
+++ b/src/rachis/sdk/result.py
@@ -700,12 +700,19 @@ class Artifact(Result):
             # lookup default format for the type
             view_type = output_dir_fmt
 
-        from_type = transform.ModelType.from_view_type(view_type)
         to_type = transform.ModelType.from_view_type(output_dir_fmt)
-
         recorder = provenance_capture.transformation_recorder('return')
-        transformation = from_type.make_transformation(to_type,
-                                                       recorder=recorder)
+
+        if cls._is_union_type(view_type):
+            transformation, _ = cls._transform_to_or_from_union(
+                from_type=view_type, to_type=to_type, recorder=recorder
+            )
+        else:
+            from_type = transform.ModelType.from_view_type(view_type)
+            transformation = from_type.make_transformation(
+                to_type, recorder=recorder
+            )
+
         result = transformation(view, validate_level)
 
         if type_raw in pm.validators:
@@ -720,6 +727,10 @@ class Artifact(Result):
 
         return artifact
 
+    @classmethod
+    def _is_union_type(cls, view_type):
+        return isinstance(get_origin(view_type), type(Union))
+
     def view(self, view_type):
         return self._view(view_type)
 
@@ -730,29 +741,15 @@ class Artifact(Result):
 
         from_type = transform.ModelType.from_view_type(self.format)
 
-        if isinstance(get_origin(view_type), type(Union)):
-            transformation = None
-            for arg in get_args(view_type):
-                to_type = transform.ModelType.from_view_type(arg)
-                try:
-                    transformation = from_type.make_transformation(
-                        to_type, recorder=recorder)
-                    if transformation:
-                        break
-                except Exception as e:
-                    if str(e).startswith("No transformation from"):
-                        continue
-                    else:
-                        raise e
-            if not transformation:
-                raise Exception(
-                    "No transformation into either of %s was found" %
-                    ", ".join([str(x) for x in view_type.__args__])
-                )
+        if self._is_union_type(view_type):
+            transformation, to_type = self._transform_to_or_from_union(
+                from_type=from_type, to_type=view_type, recorder=recorder
+            )
         else:
             to_type = transform.ModelType.from_view_type(view_type)
             transformation = from_type.make_transformation(to_type,
                                                            recorder=recorder)
+
         result = transformation(self._archiver.data_dir)
 
         if view_type is rachis.Metadata:
@@ -760,6 +757,70 @@ class Artifact(Result):
 
         to_type.set_user_owned(result, True)
         return result
+
+    @classmethod
+    def _transform_to_or_from_union(cls, from_type, to_type, recorder):
+        '''
+        Attempts to find a transformation to/from a union type that lives in
+        either `from_type` or `to_type`.
+
+        Parameters
+        ----------
+        from_type : ModelType | Union
+        to_type : ModelType | Union
+        recorder : Callable
+
+        Returns
+        -------
+        Callable, ModelType
+            The transformer and the union member as a ModelType for which the
+            transformer was found.
+
+        Raises
+        ------
+        Exception
+            If no transformation to/from any of the union members is found.
+        TypeError
+            If the union type expression has no arguments.
+        '''
+        if cls._is_union_type(from_type):
+            union_type = from_type
+        else:
+            union_type = to_type
+
+        args = get_args(union_type)
+        if len(args) == 0:
+            raise TypeError("Non-parameterized (empty) Union provided.")
+
+        transformation = None
+        for arg in args:
+            arg_type = transform.ModelType.from_view_type(arg)
+            try:
+                if cls._is_union_type(from_type):
+                    transformation = arg_type.make_transformation(
+                        to_type, recorder=recorder
+                    )
+                else:
+                    transformation = from_type.make_transformation(
+                        arg_type, recorder=recorder
+                    )
+            except Exception as e:
+                if str(e).startswith("No transformation from"):
+                    continue
+                else:
+                    raise e
+
+        if transformation is None:
+            if cls._is_union_type(from_type):
+                types = ", ".join([str(t) for t in from_type.__args__])
+                msg = f"No transformation from any of {types} to {to_type}."
+            else:
+                types = ", ".join([str(t) for t in to_type.__args__])
+                msg = f"No transformation from {from_type} to any of {types}."
+
+            raise Exception(msg)
+
+        return transformation, arg_type
 
     def has_metadata(self):
         """ Checks for metadata within an artifact

--- a/src/rachis/sdk/tests/test_artifact.py
+++ b/src/rachis/sdk/tests/test_artifact.py
@@ -110,7 +110,7 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
         self.assertIsInstance(artifact.uuid, uuid.UUID)
         with self.assertRaisesRegex(
                 Exception,
-                'No transformation into either of'):
+                'No transformation from'):
             self.assertEqual(artifact.view(Union[str, dict]), [-1, 42, 0, 43])
 
     def test_from_view_different_type_with_multiple_view_types(self):

--- a/src/rachis/sdk/tests/test_artifact.py
+++ b/src/rachis/sdk/tests/test_artifact.py
@@ -113,6 +113,15 @@ class TestArtifact(unittest.TestCase, ArchiveTestingMixin):
                 'No transformation from'):
             self.assertEqual(artifact.view(Union[str, dict]), [-1, 42, 0, 43])
 
+    def test_from_view_with_union_view_type(self):
+        artifact = Artifact._from_view(
+            IntSequence1, [1, 2, 3, 4], Union[IntSequenceFormat, list],
+            self.provenance_capture)
+
+        self.assertEqual(artifact.type, IntSequence1)
+        self.assertIsInstance(artifact.uuid, uuid.UUID)
+        self.assertEqual(artifact.view(list), [1, 2, 3, 4])
+
     def test_from_view_different_type_with_multiple_view_types(self):
         artifact = Artifact._from_view(IntSequence1, [42, 42, 43, -999, 42],
                                        list, self.provenance_capture)


### PR DESCRIPTION
Adds support for transforming from unions. Useful when a `TypeMatch` requires an action to return one of distinct view types. 

This mirrors what Michal added a few years ago to support transforming *into* a member of union, and factors the logic for both into a class method. 

Would be helpful for an addition @miiixi1in is making to `q2_feature_table.rename_ids` to allow us to rename feature IDs in any of `FeatureTable[*]`, `FeatureData[Taxonomy]`, `FeatureData[Sequence]`.