### PR TITLE
IMP: cache save hardlink

### DIFF
--- a/src/rachis/core/cache.py
+++ b/src/rachis/core/cache.py
@@ -56,6 +56,7 @@ from rachis.core.util import (is_uuid4, set_permissions, touch_under_path,
                               load_action_yaml, USER_GROUP_RWX)
 from rachis.core.archive.archiver import Archiver
 from rachis.core.type import HashableInvocation, IndexedCollectionElement
+from rachis.util import duplicate
 
 _VERSION_TEMPLATE = """\
 QIIME 2
@@ -1258,12 +1259,14 @@ class Cache:
                 if not isinstance(ref._archiver.path, ArchivePath):
                     os.mkdir(destination)
                     shutil.copytree(
-                        ref._archiver.path, destination, dirs_exist_ok=True)
+                        ref._archiver.path, destination, dirs_exist_ok=True,
+                        copy_function=duplicate)
                 # Otherwise, the path we are copying should already contain the
                 # uuid, so we don't need to manually create the uuid directory
                 else:
                     shutil.copytree(
-                        ref._archiver.path, self.data, dirs_exist_ok=True)
+                        ref._archiver.path, self.data, dirs_exist_ok=True,
+                        copy_function=duplicate)
             else:
                 existing = \
                     Result._from_archiver(Archiver.load_raw(destination, self))


### PR DESCRIPTION
@Oddant1, I landed on this change while doing some benchmarking of `moshpit annotation classify-kraken2`. It doesn't seem to help much in my benchmarks, but seems like this is how we'd want this to work. Can you review and make sure I'm not missing some reason why we don't want to use `duplicate` here? 