### PR TITLE
Fix issue replaying Results of Import

### DIFF
--- a/src/rachis/core/archive/provenance_lib/archive_parser.py
+++ b/src/rachis/core/archive/provenance_lib/archive_parser.py
@@ -857,7 +857,8 @@ class ParserV2(ParserV1):
                 framework_version=framework_version)
         }
 
-        # If this is the Result of an import, it won't have this dir.
+        # If this is the Result of an import, or an Action with no inputs,
+        # it won't have this dir.
         if os.path.exists(archiver.provenance_dir / 'artifacts'):
             for fp in os.listdir(archiver.provenance_dir / 'artifacts'):
                 fp = pathlib.Path(fp)

--- a/src/rachis/core/archive/provenance_lib/archive_parser.py
+++ b/src/rachis/core/archive/provenance_lib/archive_parser.py
@@ -857,18 +857,20 @@ class ParserV2(ParserV1):
                 framework_version=framework_version)
         }
 
-        for fp in os.listdir(archiver.provenance_dir / 'artifacts'):
-            fp = pathlib.Path(fp)
-            node_uuid = os.path.basename(fp)
+        # If this is the Result of an import, it won't have this dir.
+        if os.path.exists(archiver.provenance_dir / 'artifacts'):
+            for fp in os.listdir(archiver.provenance_dir / 'artifacts'):
+                fp = pathlib.Path(fp)
+                node_uuid = os.path.basename(fp)
 
-            if node_uuid in archive_contents:
-                continue
+                if node_uuid in archive_contents:
+                    continue
 
-            archive_version, _ = parse_version(archiver, node_uuid)
-            archive_contents[node_uuid] = ProvNode(
-                cfg, archiver, archive_version=archive_version,
-                framework_version=framework_version, uuid=node_uuid
-            )
+                archive_version, _ = parse_version(archiver, node_uuid)
+                archive_contents[node_uuid] = ProvNode(
+                    cfg, archiver, archive_version=archive_version,
+                    framework_version=framework_version, uuid=node_uuid
+                )
 
         graph = self._digraph_from_archive_contents(archive_contents)
 

--- a/src/rachis/core/archive/provenance_lib/tests/test_replay.py
+++ b/src/rachis/core/archive/provenance_lib/tests/test_replay.py
@@ -263,6 +263,26 @@ class ReplayProvenanceTests(unittest.TestCase):
             self.assertNotIn('optional1=', rendered)
             self.assertNotIn('num2=', rendered)
 
+    def test_replay_imported_artifact(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_fp = pathlib.Path(tmpdir) / 'rendered.txt'
+            in_fp = self.das.single_int.filepath
+
+            replay_provenance(
+                ReplayPythonUsage, in_fp, out_fp, md_out_dir=tmpdir
+            )
+            self.assertTrue(out_fp.is_file())
+
+            with open(out_fp, 'r') as fp:
+                rendered = fp.read()
+
+            self.assertIn('from rachis import Artifact', rendered)
+            self.assertIn('single_int_0 = Artifact.import_data(', rendered)
+            self.assertIn("'SingleInt',", rendered)
+            self.assertIn('<your data here>,', rendered)
+            self.assertIn(')', rendered)
+            self.assertIn("single_int_0.save('single_int_0')", rendered)
+
 
 class MultiplePluginTests(unittest.TestCase):
     @classmethod

--- a/src/rachis/core/archive/provenance_lib/tests/testing_utilities.py
+++ b/src/rachis/core/archive/provenance_lib/tests/testing_utilities.py
@@ -73,6 +73,10 @@ class DummyArtifacts:
                 name, artifact, artifact._archiver, str(artifact.uuid), fp,
                 ProvDAG(fp)
             )
+            # This dir is empty on imported artifacts and won't actually be
+            # here for real .qzas of imported artifacts. Caused us a bit of a
+            # headache https://github.com/rachis-org/rachis/pull/943
+            os.rmdir(artifact._archiver.provenance_dir / 'artifacts')
             setattr(self, name, test_artifact)
 
     def init_action_artifacts(self):


### PR DESCRIPTION
# Description
When an `Artifact` is imported, the "Artifacts" directory in its prov is empty. When we write this to a .qza, that empty directory is not included. This was causing an error when attempting to parse that directory in the post-refactor provlib.

This slipped by testing because when we import Artifacts in Python their archivers do have empty "Artifacts" directories. It isn't until we zip them that the directory goes away.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.
