### PR TITLE
Cast get_np_random_seed return to int

### DIFF
--- a/src/rachis/plugin/util.py
+++ b/src/rachis/plugin/util.py
@@ -81,4 +81,4 @@ def get_np_random_seed():
     int
         A random int with 128 bits of entropy
     """
-    return secrets.randbits(NP_RNG_SIZE)
+    return int(secrets.randbits(NP_RNG_SIZE))


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
Cast the return value from `get_np_random_seed` to int.

I don't love that this slipped through. The return value from `secrets.randbits` was being written to prov as some vector encoding a state machine for the state of the RNG... or something. Not just the integer the RNG was producing.  That thing wasn't able to be parsed by our YAML parser, which was causing errors when trying to parse the action.yaml. Since I just want the int itself written to the YAML, I cast the return value to an int.

It is strange to me that no tests in boots failed because of this. It's also obnoxious that this got past the type checking we do before writing the value to prov.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.
