### PR TITLE
Test how CapureHolder behaves with resumption

### DIFF
--- a/src/rachis/core/testing/pipeline.py
+++ b/src/rachis/core/testing/pipeline.py
@@ -5,10 +5,13 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import sys
+import random
 
 from .type import SingleInt, Mapping, Foo, Bar
-from rachis.sdk.result import ResultCollection
+from rachis.sdk.result import ResultCollection, Artifact
 from rachis.core.testing.util import PipelineError
+from rachis.plugin import IContext, CaptureHolder
 
 
 def parameter_only_pipeline(ctx, int1, int2=2, metadata=None, other=False):
@@ -345,3 +348,22 @@ def viz_collection_pipeline(ctx, ints):
     viz2, = most_common_viz(ints)
 
     return [viz1, viz2]
+
+
+def resumable_random_seed_pipeline(
+            ctx: IContext,
+            fail: bool = False,
+            random_seed: CaptureHolder[int] = None
+        ) -> Artifact:
+    random_int = CaptureHolder.get_or_set(
+        random_seed, lambda: random.randrange(sys.maxsize)
+    )
+
+    random_seed_method = ctx.get_action('dummy_plugin', 'random_seed_method')
+    random_int_art, = random_seed_method(random_int)
+
+    if fail:
+        uuids = [str(random_int_art.uuid)]
+        raise PipelineError(uuids)
+
+    return random_int_art

--- a/src/rachis/core/testing/plugin.py
+++ b/src/rachis/core/testing/plugin.py
@@ -75,7 +75,8 @@ from .pipeline import (parameter_only_pipeline, typical_pipeline,
                        property_refinement_collection_pipeline,
                        property_refinement_mismatch_pipeline,
                        pointless_pipeline,
-                       failing_pipeline, viz_collection_pipeline)
+                       failing_pipeline, viz_collection_pipeline,
+                       resumable_random_seed_pipeline)
 from ..cite import Citations
 
 from .examples import (concatenate_ints_simple, concatenate_ints_complex,
@@ -1137,6 +1138,21 @@ dummy_plugin.pipelines.register_function(
     name='Return a collection of Visualizations',
     description='Just returns a collection of Visualizations',
     examples={'collection_of_visualizations': collection_of_visualizations}
+)
+
+dummy_plugin.pipelines.register_function(
+    function=resumable_random_seed_pipeline,
+    inputs={},
+    parameters={
+        'fail': Bool,
+        'random_seed': Int,
+    },
+    outputs=[
+        ('random_seed', SingleInt)
+    ],
+    name=('Takes a random seed and returns it but this time as a pipeline that'
+          ' can be resumed.'),
+    description='Just returns a random int',
 )
 
 dummy_plugin.methods.register_function(

--- a/src/rachis/core/tests/test_pipeline_resumption.py
+++ b/src/rachis/core/tests/test_pipeline_resumption.py
@@ -737,3 +737,49 @@ class TestPipelineResumption(unittest.TestCase):
             self.assertNotEqual(int_list_uuids, complete_int_list_uuids)
             # The dict should have been recycled
             self.assertEqual(int_dict_uuids, complete_int_dict_uuids)
+
+    def test_capture_holder_value_passed(self):
+        '''
+        Assert that when passing the a value into a CaptureHolder we do recycle
+        the cached Result due to the value of the seed matching.
+        '''
+        pipeline = self.plugin.pipelines['resumable_random_seed_pipeline']
+
+        with self.pool:
+            with self.assertRaises(PipelineError) as e:
+                pipeline(fail=True, random_seed=42)
+
+            random_int_uuid_failed, = e.exception.uuids
+
+            random_int, = pipeline(random_seed=42)
+            random_int_uuid_succeeded = _load_alias_uuid(random_int)
+
+            self.assertEqual(
+                random_int_uuid_failed, random_int_uuid_succeeded
+            )
+
+    def test_capture_holder_no_value_passed(self):
+        '''
+        Assert that when passing the auto value into a CaptureHolder we do not
+        recycle the cached Result due to the value of the seed not matching.
+
+        Note
+        ----
+        This test has a 1/sys.maxsize chance of failing due to the
+        CaptureHolder in resumable_random_seed_pipeline getting the same random
+        value in both calls.
+        '''
+        pipeline = self.plugin.pipelines['resumable_random_seed_pipeline']
+
+        with self.pool:
+            with self.assertRaises(PipelineError) as e:
+                pipeline(fail=True)
+
+            random_int_uuid_failed, = e.exception.uuids
+
+            random_int, = pipeline()
+            random_int_uuid_succeeded = _load_alias_uuid(random_int)
+
+            self.assertNotEqual(
+                random_int_uuid_failed, random_int_uuid_succeeded
+            )

--- a/src/rachis/plugin/tests/test_plugin.py
+++ b/src/rachis/plugin/tests/test_plugin.py
@@ -111,6 +111,7 @@ class TestPlugin(unittest.TestCase):
                           'property_refinement_mismatch_pipeline',
                           'failing_pipeline',
                           'viz_collection_pipeline',
+                          'resumable_random_seed_pipeline',
                           'docstring_order_method',
                           'constrained_input_visualization',
                           'combinatorically_mapped_method',
@@ -219,7 +220,8 @@ class TestPlugin(unittest.TestCase):
                           'property_refinement_collection_pipeline',
                           'property_refinement_mismatch_pipeline',
                           'failing_pipeline',
-                          'viz_collection_pipeline'})
+                          'viz_collection_pipeline',
+                          'resumable_random_seed_pipeline'})
         for pipeline in pipelines.values():
             self.assertIsInstance(pipeline, rachis.sdk.Pipeline)
 


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
Test that CaptureHolders behave as expected with resumption.

If an explicit value is passed, recycle the Artifact.
If an explicit value is not passed, don't.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.
