### PR TITLE
handle ruff update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,4 +85,4 @@ line-length = 79
 
 [tool.ruff.lint]
 # equivalent for flake8
-extend-select = ["E", "F", "W"]
+select = ["E", "F", "W"]


### PR DESCRIPTION
# Description
Ruff [changed](https://astral.sh/blog/ruff-v0.16.0) its default rule set. Restores the previous effective rule set.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.

